### PR TITLE
Don't Animate to initialPage

### DIFF
--- a/lib/src/widgets/pdf_widgets.dart
+++ b/lib/src/widgets/pdf_widgets.dart
@@ -318,8 +318,8 @@ class _PdfViewerState extends State<PdfViewer>
 
       if (!_initialized && _layout != null) {
         _initialized = true;
-        Future.microtask(
-            () => _controller!.goToPage(pageNumber: widget.initialPageNumber));
+        Future.microtask(() => _controller!.goToPage(
+            pageNumber: widget.initialPageNumber, duration: Duration.zero));
       }
 
       return Container(


### PR DESCRIPTION
Currently, the PdfViewer animates to the initialPage, but this causes undesirable flicker when the document is loaded. This change changes the initialPage loading to be instant.