### PR TITLE
Add Document rotation

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,6 +31,7 @@ class _MainPageState extends State<MainPage> {
   final controller = PdfViewerController();
   bool showSearchToolbar = false;
   final outline = ValueNotifier<List<PdfOutlineNode>?>(null);
+  int rotation = 0;
 
   @override
   void dispose() {
@@ -58,6 +59,7 @@ class _MainPageState extends State<MainPage> {
             // Set password provider to show password dialog
             passwordProvider: _passwordDialog,
             controller: controller,
+            rotation: rotation,
             displayParams: PdfViewerParams(
               enableTextSelection: true,
               maxScale: 8,
@@ -224,7 +226,10 @@ class _MainPageState extends State<MainPage> {
           FloatingActionButton(
               child: const Icon(Icons.search),
               onPressed: () =>
-                  setState(() => showSearchToolbar = !showSearchToolbar))
+                  setState(() => showSearchToolbar = !showSearchToolbar)),
+          FloatingActionButton(
+              child: const Icon(Icons.rotate_90_degrees_cw),
+              onPressed: () => setState(() => rotation = (rotation + 90) % 360))
         ],
       ),
       //

--- a/lib/src/pdf_api.dart
+++ b/lib/src/pdf_api.dart
@@ -17,6 +17,7 @@ abstract class PdfDocumentFactory {
     String name, {
     PdfPasswordProvider? passwordProvider,
     bool firstAttemptByEmptyPassword = true,
+    int rotation = 0,
   });
 
   /// See [PdfDocument.openData].
@@ -25,6 +26,7 @@ abstract class PdfDocumentFactory {
     PdfPasswordProvider? passwordProvider,
     bool firstAttemptByEmptyPassword = true,
     String? sourceName,
+    int rotation = 0,
     void Function()? onDispose,
   });
 
@@ -33,6 +35,7 @@ abstract class PdfDocumentFactory {
     String filePath, {
     PdfPasswordProvider? passwordProvider,
     bool firstAttemptByEmptyPassword = true,
+    int rotation = 0,
   });
 
   /// See [PdfDocument.openCustom].
@@ -44,6 +47,7 @@ abstract class PdfDocumentFactory {
     PdfPasswordProvider? passwordProvider,
     bool firstAttemptByEmptyPassword = true,
     int? maxSizeToCacheOnMemory,
+    int rotation = 0,
     void Function()? onDispose,
   });
 
@@ -53,6 +57,7 @@ abstract class PdfDocumentFactory {
     PdfPasswordProvider? passwordProvider,
     bool firstAttemptByEmptyPassword = true,
     PdfDownloadProgressCallback? progressCallback,
+    int rotation = 0,
   });
 
   /// Singleton [PdfDocumentFactory] instance.
@@ -117,11 +122,13 @@ abstract class PdfDocument {
     String filePath, {
     PdfPasswordProvider? passwordProvider,
     bool firstAttemptByEmptyPassword = true,
+    int rotation = 0,
   }) =>
       PdfDocumentFactory.instance.openFile(
         filePath,
         passwordProvider: passwordProvider,
         firstAttemptByEmptyPassword: firstAttemptByEmptyPassword,
+        rotation: rotation,
       );
 
   /// Opening the specified asset.
@@ -133,11 +140,13 @@ abstract class PdfDocument {
     String name, {
     PdfPasswordProvider? passwordProvider,
     bool firstAttemptByEmptyPassword = true,
+    int rotation = 0,
   }) =>
       PdfDocumentFactory.instance.openAsset(
         name,
         passwordProvider: passwordProvider,
         firstAttemptByEmptyPassword: firstAttemptByEmptyPassword,
+        rotation: rotation,
       );
 
   /// Opening the PDF on memory.
@@ -150,6 +159,7 @@ abstract class PdfDocument {
     PdfPasswordProvider? passwordProvider,
     bool firstAttemptByEmptyPassword = true,
     String? sourceName,
+    int rotation = 0,
     void Function()? onDispose,
   }) =>
       PdfDocumentFactory.instance.openData(
@@ -158,6 +168,7 @@ abstract class PdfDocument {
         firstAttemptByEmptyPassword: firstAttemptByEmptyPassword,
         sourceName: sourceName,
         onDispose: onDispose,
+        rotation: rotation,
       );
 
   /// Opening the PDF from custom source.
@@ -177,6 +188,7 @@ abstract class PdfDocument {
     PdfPasswordProvider? passwordProvider,
     bool firstAttemptByEmptyPassword = true,
     int? maxSizeToCacheOnMemory,
+    int rotation = 0,
     void Function()? onDispose,
   }) =>
       PdfDocumentFactory.instance.openCustom(
@@ -187,6 +199,7 @@ abstract class PdfDocument {
         firstAttemptByEmptyPassword: firstAttemptByEmptyPassword,
         maxSizeToCacheOnMemory: maxSizeToCacheOnMemory,
         onDispose: onDispose,
+        rotation: rotation,
       );
 
   /// Opening the PDF from URI.
@@ -205,12 +218,14 @@ abstract class PdfDocument {
     PdfPasswordProvider? passwordProvider,
     bool firstAttemptByEmptyPassword = true,
     PdfDownloadProgressCallback? progressCallback,
+    int rotation = 0,
   }) =>
       PdfDocumentFactory.instance.openUri(
         uri,
         passwordProvider: passwordProvider,
         firstAttemptByEmptyPassword: firstAttemptByEmptyPassword,
         progressCallback: progressCallback,
+        rotation: rotation,
       );
 
   /// Pages.

--- a/lib/src/widgets/pdf_viewer.dart
+++ b/lib/src/widgets/pdf_viewer.dart
@@ -47,15 +47,17 @@ class PdfViewer extends StatefulWidget {
     PdfViewerController? controller,
     PdfViewerParams displayParams = const PdfViewerParams(),
     int initialPageNumber = 1,
+    int rotation = 0,
     PdfDocumentStore? store,
   }) : this(
           key: key,
           documentRef: (store ?? PdfDocumentStore.defaultStore).load(
-            '##PdfViewer:asset:$name',
+            '##PdfViewer:asset:$name:$rotation',
             documentLoader: (_) => PdfDocument.openAsset(
               name,
               passwordProvider: passwordProvider,
               firstAttemptByEmptyPassword: firstAttemptByEmptyPassword,
+              rotation: rotation,
             ),
           ),
           controller: controller,
@@ -71,15 +73,17 @@ class PdfViewer extends StatefulWidget {
     PdfViewerController? controller,
     PdfViewerParams displayParams = const PdfViewerParams(),
     int initialPageNumber = 1,
+    int rotation = 0,
     PdfDocumentStore? store,
   }) : this(
           key: key,
           documentRef: (store ?? PdfDocumentStore.defaultStore).load(
-            '##PdfViewer:file:$path',
+            '##PdfViewer:file:$path:$rotation',
             documentLoader: (_) => PdfDocument.openFile(
               path,
               passwordProvider: passwordProvider,
               firstAttemptByEmptyPassword: firstAttemptByEmptyPassword,
+              rotation: rotation,
             ),
           ),
           controller: controller,
@@ -95,16 +99,18 @@ class PdfViewer extends StatefulWidget {
     PdfViewerController? controller,
     PdfViewerParams displayParams = const PdfViewerParams(),
     int initialPageNumber = 1,
+    int rotation = 0,
     PdfDocumentStore? store,
   }) : this(
           key: key,
           documentRef: (store ?? PdfDocumentStore.defaultStore).load(
-            '##PdfViewer:uri:$uri',
+            '##PdfViewer:uri:$uri:$rotation',
             documentLoader: (progressCallback) => PdfDocument.openUri(
               uri,
               passwordProvider: passwordProvider,
               firstAttemptByEmptyPassword: firstAttemptByEmptyPassword,
               progressCallback: progressCallback,
+              rotation: rotation,
             ),
           ),
           controller: controller,
@@ -121,16 +127,18 @@ class PdfViewer extends StatefulWidget {
     PdfViewerController? controller,
     PdfViewerParams displayParams = const PdfViewerParams(),
     int initialPageNumber = 1,
+    int rotation = 0,
     PdfDocumentStore? store,
   }) : this(
           key: key,
           documentRef: (store ?? PdfDocumentStore.defaultStore).load(
-            '##PdfViewer:data:${sourceName ?? bytes.hashCode}',
+            '##PdfViewer:data:${sourceName ?? bytes.hashCode}:$rotation',
             documentLoader: (_) => PdfDocument.openData(
               bytes,
               passwordProvider: passwordProvider,
               firstAttemptByEmptyPassword: firstAttemptByEmptyPassword,
               sourceName: sourceName,
+              rotation: rotation,
             ),
           ),
           controller: controller,
@@ -149,17 +157,19 @@ class PdfViewer extends StatefulWidget {
     PdfViewerController? controller,
     PdfViewerParams displayParams = const PdfViewerParams(),
     int initialPageNumber = 1,
+    int rotation = 0,
     PdfDocumentStore? store,
   }) : this(
           key: key,
           documentRef: (store ?? PdfDocumentStore.defaultStore).load(
-            '##PdfViewer:custom:$sourceName',
+            '##PdfViewer:custom:$sourceName:$rotation',
             documentLoader: (_) => PdfDocument.openCustom(
               read: read,
               fileSize: fileSize,
               sourceName: sourceName,
               passwordProvider: passwordProvider,
               firstAttemptByEmptyPassword: firstAttemptByEmptyPassword,
+              rotation: rotation,
             ),
           ),
           controller: controller,


### PR DESCRIPTION
I added a rotation parameter to the current code to rotate the page. When the page is rotated, the document is reloaded to draw the screen again. This ensures that the correct document size is displayed after the page is rotated.