### PR TITLE
Speed up the first render/Give a chance to cache thumbnail

### DIFF
--- a/lib/src/widgets/pdf_viewer.dart
+++ b/lib/src/widgets/pdf_viewer.dart
@@ -976,7 +976,7 @@ class _PdfViewerState extends State<PdfViewer>
                 widget.params.onViewerReady?.call(
                   _document!,
                   _controller!,
-                  newImage
+                  newImage.image
                 );
               }
             }

--- a/lib/src/widgets/pdf_viewer.dart
+++ b/lib/src/widgets/pdf_viewer.dart
@@ -381,7 +381,6 @@ class _PdfViewerState extends State<PdfViewer>
       }
 
       if (!_initialized && _layout != null) {
-        _initialized = true;
         Future.microtask(() async {
           if (mounted) {
             final initialPageNumber = widget.params.calculateInitialPageNumber
@@ -394,6 +393,7 @@ class _PdfViewerState extends State<PdfViewer>
               widget.params.onViewerReady?.call(_document!, _controller!);
             }
           }
+          _initialized = true;
         });
       }
 
@@ -428,11 +428,13 @@ class _PdfViewerState extends State<PdfViewer>
                           ? _onWheelDelta
                           : null,
                       // PDF pages
-                      child: CustomPaint(
-                        foregroundPainter:
-                            _CustomPainter.fromFunction(_customPaint),
-                        size: _layout!.documentSize,
-                      ),
+                      child: _initialized
+                          ? CustomPaint(
+                              foregroundPainter:
+                                  _CustomPainter.fromFunction(_customPaint),
+                              size: _layout!.documentSize,
+                            )
+                          : Container(),
                     ),
                     ..._buildPageOverlayWidgets(),
                     if (widget.params.viewerOverlayBuilder != null)

--- a/lib/src/widgets/pdf_viewer.dart
+++ b/lib/src/widgets/pdf_viewer.dart
@@ -968,17 +968,14 @@ class _PdfViewerState extends State<PdfViewer>
         _pageImages[page.pageNumber] = newImage;
         img.dispose();
 
+        final imagePngBytes = await newImage.image.toByteData(format: ui.ImageByteFormat.png);
+
         if (!_firstPageRendered) {
           _firstPageRendered = true;
           Future.microtask(() async {
-            if (mounted) {
-              if (mounted && _document != null && _controller != null) {
-                widget.params.onViewerReady?.call(
-                  _document!,
-                  _controller!,
-                  newImage.image
-                );
-              }
+            if (mounted && _document != null && _controller != null && imagePngBytes != null) {
+              widget.params.onViewerReady
+                  ?.call(_document!, _controller!, imagePngBytes!.buffer.asUint8List());
             }
           });
         }

--- a/lib/src/widgets/pdf_viewer_params.dart
+++ b/lib/src/widgets/pdf_viewer_params.dart
@@ -1,3 +1,4 @@
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
@@ -460,7 +461,7 @@ typedef PdfViewerCalculateInitialPageNumberFunction = int? Function(
 typedef PdfViewerReadyCallback = void Function(
   PdfDocument document,
   PdfViewerController controller,
-  ui.Image firstPage,
+  Uint8List firstPagePngBytes,
 );
 
 /// Function called when the current page is changed.

--- a/lib/src/widgets/pdf_viewer_params.dart
+++ b/lib/src/widgets/pdf_viewer_params.dart
@@ -460,7 +460,7 @@ typedef PdfViewerCalculateInitialPageNumberFunction = int? Function(
 typedef PdfViewerReadyCallback = void Function(
   PdfDocument document,
   PdfViewerController controller,
-  Image firstPage,
+  ui.Image firstPage,
 );
 
 /// Function called when the current page is changed.

--- a/lib/src/widgets/pdf_viewer_params.dart
+++ b/lib/src/widgets/pdf_viewer_params.dart
@@ -460,6 +460,7 @@ typedef PdfViewerCalculateInitialPageNumberFunction = int? Function(
 typedef PdfViewerReadyCallback = void Function(
   PdfDocument document,
   PdfViewerController controller,
+  Image firstPage,
 );
 
 /// Function called when the current page is changed.

--- a/lib/src/widgets/pdf_widgets.dart
+++ b/lib/src/widgets/pdf_widgets.dart
@@ -230,7 +230,6 @@ class PdfPageView extends StatefulWidget {
 class _PdfPageViewState extends State<PdfPageView> {
   ui.Image? _image;
 
-  ByteData? _imagePngBytes;
   Size? _pageSize;
   PdfPageRenderCancellationToken? _cancellationToken;
 
@@ -345,7 +344,7 @@ class _PdfPageViewState extends State<PdfPageView> {
     Future.microtask(() async {
       if (mounted && document != null && imagePngBytes != null) {
         widget.onViewerReady
-            ?.call(document!, _imagePngBytes!.buffer.asUint8List());
+            ?.call(document!, imagePngBytes!.buffer.asUint8List());
       }
     });
 


### PR DESCRIPTION
- [Skip rendering the first page if an initialPageNumber specified](https://github.com/espresso3389/pdfrx/commit/8048a50787ac6bae68abec984f3a7993065cdc0a)
- [Call onViewerReady only when the first page rendered; Speed up the first render by only rendering the necessary pages](https://github.com/espresso3389/pdfrx/commit/c34e71b304c3c7174a1f278ab39573e7d7e8ac16) 

The changes on ```onViewerReady``` gives a chance to show a loading widget and to save the first page image as a cached thumbnail(no need to load the doc if need a thumbnail later).
I thought adding a new ```onFirstPageRendered```, but  it might just makes more sense to postpone ```onViewerReady``` a bit waiting for the first render to make the 'ready' more ready.