### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,10 @@ android {
         namespace 'jp.espresso3389.pdfrx'
     }
 
+    packagingOptions {
+        pickFirst '**/libpdfium.so'
+    }
+
     // Bumping the plugin compileSdkVersion requires all clients of this plugin
     // to bump the version in their app.
     compileSdkVersion 33


### PR DESCRIPTION
During the build of the apk file of my app, I always get this issue from pdfrx. Specifying this packaging option on the main project level does not solve the issue.

Execution failed for task ':pdfrx:mergeReleaseNativeLibs'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.MergeNativeLibsTask$MergeNativeLibsTaskWorkAction
   > 2 files found with path 'lib/arm64-v8a/libpdfium.so' from inputs:
      - /jenkins/workspace/head_amos_mobile_exec/amos_mobile_exec/build/pdfrx/intermediates/merged_jni_libs/release/out/arm64-v8a/libpdfium.so
      - /jenkins/workspace/head_amos_mobile_exec/amos_mobile_exec/build/pdfrx/intermediates/cxx/RelWithDebInfo/6i5b2q3w/obj/arm64-v8a/libpdfium.so If you are using jniLibs and CMake IMPORTED targets, see https://developer.android.com/r/tools/jniLibs-vs-imported-targets