### PR TITLE
improve memory usage

### DIFF
--- a/lib/src/pdfium/pdfrx_pdfium.dart
+++ b/lib/src/pdfium/pdfrx_pdfium.dart
@@ -872,6 +872,7 @@ class PdfImagePdfium extends PdfImage {
 
   @override
   void dispose() {
+    super.dispose();
     malloc.free(_buffer);
   }
 }

--- a/lib/src/web/pdfrx_web.dart
+++ b/lib/src/web/pdfrx_web.dart
@@ -488,8 +488,6 @@ class PdfImageWeb extends PdfImage {
   final Uint8List pixels;
   @override
   PixelFormat get format => PixelFormat.rgba8888;
-  @override
-  void dispose() {}
 }
 
 class PdfPageTextFragmentWeb implements PdfPageTextFragment {

--- a/lib/src/widgets/pdf_widgets.dart
+++ b/lib/src/widgets/pdf_widgets.dart
@@ -331,10 +331,19 @@ class _PdfPageViewState extends State<PdfPageView> {
       cancellationToken: _cancellationToken,
     );
     if (pageImage == null) return;
-    final newImage = await pageImage.createImage();
-    pageImage.dispose();
+
     final oldImage = _image;
-    _image = newImage;
+
+    if (mounted) {
+      final newImage = await pageImage.createImage();
+      if (mounted) {
+        _image = newImage;
+      } else {
+        newImage.dispose();
+      }
+    }
+    pageImage.dispose();
+
     oldImage?.dispose();
     if (mounted) {
       setState(() {});


### PR DESCRIPTION
Have been seeing some crashes in Flutter web and noticed a lot of extra memory being used by pdfrx than needed. This pull request includes the following changes to help keep memory usage down:

- fix many potential memory leaks when widget is unmounted during rendering
- synchronizes rendering using document reference instead of widget state, so that multiple widgets referencing the same document reference will not run canvaskit renderer out of memory if they are quickly built and disposed before async rendering completes (current behavior can result in out of memory errors in web). 
- Better protection against dispose of images during async creation of image
- Properly enforce max / min scale so that final resolution of image is properly limited by min and max scale.
- Fixes exception thrown by interactive viewer when _alternativeFitScale is less than maxScale.
