### PR TITLE
Remove redundant check that breaks building on some systems

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -67,8 +67,6 @@ endif()
 file(REMOVE ${PDFIUM_LATEST_DIR})
 file(CREATE_LINK ${PDFIUM_LIBS_DIR} ${PDFIUM_LATEST_DIR} SYMBOLIC)
 
-find_library(libc++ libc++_static.a)
-
 set(pdfrx_bundled_libraries
   # Defined in ../src/CMakeLists.txt.
   # This can be changed to accommodate different builds.
@@ -78,4 +76,4 @@ set(pdfrx_bundled_libraries
 )
 
 target_include_directories(pdfrx PRIVATE ${PDFIUM_LATEST_DIR}/include)
-target_link_libraries(pdfrx PRIVATE ${PDFIUM_LASTEST_LIB_FILENAME} ${libc++})
+target_link_libraries(pdfrx PRIVATE ${PDFIUM_LASTEST_LIB_FILENAME})


### PR DESCRIPTION
While trying to build any project that depends on pdfrx, I always get the following error:
```
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
libc++
   linked by target "pdfrx" in directory /Users/tymscar/.pub-cache/hosted/pub.dev/pdfrx-1.0.91/src
```

Now after hours of trying everything, I stumbled upon this article from [developer.android.com](https://developer.android.com/ndk/guides/cpp-support#cmake) stating that:
`The default for CMake is c++_static.`

Because of this, I decided to remove ` ${libc++}` from `target_link_libraries` from pdfrx's `CMakeLists.txt` and it built without an issue after that.

I don't fully know why `find_library(libc++ libc++_static.a)` fails for me, and not for everybody, but considering it's redundant and it works without it for everyone, including me, I suggest this PR that removes the need.