### PR TITLE
Check for non-existent zoom element in PdfDest.params in some PDFs

### DIFF
--- a/lib/src/widgets/pdf_viewer.dart
+++ b/lib/src/widgets/pdf_viewer.dart
@@ -1407,8 +1407,9 @@ class _PdfViewerState extends State<PdfViewer>
     switch (dest.command) {
       case PdfDestCommand.xyz:
         if (params != null && params.length >= 2) {
-          final zoom =
-              params[2] != null && params[2] != 0.0 ? params[2]! : _currentZoom;
+          final zoom = params.length >= 3
+              ? params[2] != null && params[2] != 0.0 ? params[2]!
+              : _currentZoom : 1.0;
           final hw = _viewSize!.width / 2 / zoom;
           final hh = _viewSize!.height / 2 / zoom;
           return _calcMatrixFor(


### PR DESCRIPTION
Bookmarks in some PDFs (example attached) don't contain z (zoom) value, so the PdfDest.params.length = 2 ([x, y]), but _PdfViewerState._calcMatrixForDest tries to access PdfDest.params[2], so the error occurs when trying PdfViewerController.goToDest(PdfDest).
![image](https://github.com/user-attachments/assets/3ec3319d-b025-402c-8943-3ea006a4e47b)
Requesting small fix for that

[pdf-example-bookmarks.pdf](https://github.com/user-attachments/files/17990854/pdf-example-bookmarks.pdf)