### PR TITLE
Fix Issue in resetTextSearch Functionality

### DIFF
--- a/lib/src/widgets/pdf_text_searcher.dart
+++ b/lib/src/widgets/pdf_text_searcher.dart
@@ -129,6 +129,7 @@ class PdfTextSearcher extends Listenable {
     _currentIndex = null;
     _currentMatch = null;
     _isSearching = false;
+    _lastSearchPattern = null;
     if (notify) {
       notifyListeners();
     }


### PR DESCRIPTION
We need to set the `_lastSearchPattern` to null again in the `_resetTextSearch` method. Otherwise, if we search for a word again after resetting the search, the method will return in line 84 of the pdf_text_searcher.dart file, and other code will not be executed.