### PR TITLE
Lower SDK version to 3.7.0-323.0.dev to avoid "version solving failed" on Flutter 3.29.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.1.3
 homepage: https://github.com/espresso3389/pdfrx
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: '>=3.7.0-323.0.dev <4.0.0'
   flutter: ">=3.29.0"
 
 dependencies:


### PR DESCRIPTION
Fixes https://github.com/espresso3389/pdfrx/issues/314