### PR TITLE
Fix bug with no cache headers.

### DIFF
--- a/lib/src/pdfium/pdf_file_cache.dart
+++ b/lib/src/pdfium/pdf_file_cache.dart
@@ -309,7 +309,9 @@ Future<PdfDocument> pdfDocumentFromUri(
           useRangeAccess: useRangeAccess,
           headers: headers,
         );
-        if (result.isFullDownload) {
+        // cached file has expired
+        // if the file has fully downloaded again or has not been modified
+        if (result.isFullDownload || result.notModified) {
           cache.close(); // close the cache file before opening it.
           httpClientWrapper.reset();
           return await PdfDocument.openFile(


### PR DESCRIPTION
When a pdf has no cache headers...

First download attempt to view saves the pdf into pdf-cache and displays the file.

Future attempts, pdf-cache indicates that the file has expired, then does a http test to see if the file has been modified on the server.  If the file has not been modified http status 304 is returned, and result is returned saying file not downloaded, but also not modified. Meaning ok to use the cached file, even though it has expired.

Prior to this fix, cache would not get updated, nor would the cached file be used, displaying an error.