### PR TITLE
fix: blank pdf on Windows when restore window from minimize

### DIFF
--- a/lib/src/widgets/pdf_viewer.dart
+++ b/lib/src/widgets/pdf_viewer.dart
@@ -388,7 +388,7 @@ class _PdfViewerState extends State<PdfViewer> with SingleTickerProviderStateMix
                         constrained: false,
                         boundaryMargin: widget.params.boundaryMargin ?? const EdgeInsets.all(double.infinity),
                         maxScale: widget.params.maxScale,
-                        minScale: _alternativeFitScale != null ? _alternativeFitScale! / 2 : minScale,
+                        minScale: minScale,
                         panAxis: widget.params.panAxis,
                         panEnabled: widget.params.panEnabled,
                         scaleEnabled: widget.params.scaleEnabled,
@@ -421,6 +421,7 @@ class _PdfViewerState extends State<PdfViewer> with SingleTickerProviderStateMix
   }
 
   void _updateLayout(Size viewSize) {
+    if (viewSize.height <= 0) return; // For fix blank pdf when restore window from minimize on Windows
     final currentPageNumber = _guessCurrentPageNumber();
     final oldSize = _viewSize;
     final isViewSizeChanged = oldSize != viewSize;


### PR DESCRIPTION
on Windows when minimize window to taskbar, after click to app icon in taskbar to restore window
=> pdf will not display anymore