### PR TITLE
Allow tests to use existing PDFium

### DIFF
--- a/test/setup.dart
+++ b/test/setup.dart
@@ -1,3 +1,5 @@
+// Tests can skip PDFium download by setting the `PDFIUM_PATH` environment
+// variable to an existing module file.
 import 'dart:io';
 
 import 'package:archive/archive_io.dart';
@@ -12,7 +14,12 @@ final cacheRoot = Directory('${tmpRoot.path}/cache');
 
 /// Sets up the test environment.
 Future<void> setup() async {
-  Pdfrx.pdfiumModulePath = await downloadAndGetPdfiumModulePath();
+  final envPath = Platform.environment['PDFIUM_PATH'];
+  if (envPath != null && await File(envPath).exists()) {
+    Pdfrx.pdfiumModulePath = envPath;
+  } else {
+    Pdfrx.pdfiumModulePath = await downloadAndGetPdfiumModulePath();
+  }
 
   TestWidgetsFlutterBinding.ensureInitialized();
 


### PR DESCRIPTION
## Summary
- check `PDFIUM_PATH` in `setup()` to use an existing pdfium module when running tests
- document the environment variable at the top of `test/setup.dart`

## Testing
- `dart format test/setup.dart --line-length 120` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bb3a1b68832e9a524a8fa3aa2e8c