### PR TITLE
Fix ArgumentError param names in PdfRect

### DIFF
--- a/lib/src/pdf_api.dart
+++ b/lib/src/pdf_api.dart
@@ -842,7 +842,7 @@ class PdfRect {
       case 3:
         return PdfRect(height - top, right, height - bottom, left);
       default:
-        throw ArgumentError.value(rotate, 'rotate');
+        throw ArgumentError.value(rotation, 'rotation');
     }
   }
 
@@ -861,7 +861,7 @@ class PdfRect {
       case 3:
         return PdfRect(bottom, height - left, top, height - right);
       default:
-        throw ArgumentError.value(rotate, 'rotate');
+        throw ArgumentError.value(rotation, 'rotation');
     }
   }
 


### PR DESCRIPTION
## Summary
- fix typo in default cases of `PdfRect.rotate` and `PdfRect.rotateReverse`

## Testing
- `dart analyze` *(fails: 1936 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_6841baf21ef4832e86993bcf11cf6de9