### PR TITLE
Fix null max-age parsing in cache control

### DIFF
--- a/lib/src/pdfium/http_cache_control.dart
+++ b/lib/src/pdfium/http_cache_control.dart
@@ -195,7 +195,7 @@ class HttpCacheControlState {
   int get hashCode => cacheControl.hashCode ^ date.hashCode ^ expires.hashCode ^ etag.hashCode ^ lastModified.hashCode;
 }
 
-int _parseInt(String s) => s == 'null' ? 0 : int.parse(s);
+int? _parseInt(String s) => s == 'null' ? null : int.parse(s);
 
 DateTime? _parseDateTime(String s) => s == 'null' ? null : DateTime.fromMillisecondsSinceEpoch(int.parse(s) * 1000);
 


### PR DESCRIPTION
## Summary
- preserve null values when parsing cache-control fields

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841b2c56d6c832e9144068ed8d1f1b5