### PR TITLE
feat: Add an option to disable web link detection in loadLinks

### DIFF
--- a/assets/pdfium_worker.js
+++ b/assets/pdfium_worker.js
@@ -1087,21 +1087,24 @@ function _getText(textPage, from, length) {
  */
 
 /**
- * @param {{docHandle: number, pageIndex: number}} params
+ * @param {{docHandle: number, pageIndex: number, loadWebLinks: boolean}} params
  * @returns {{links: Array<PdfUrlLink|PdfDestLink>}}
  */
 function loadLinks(params) {
-  const links = [..._loadAnnotLinks(params), ..._loadLinks(params)];
+  const links = [
+    ..._loadAnnotLinks(params), 
+    ...(params.loadWebLinks ? _loadWebLinks(params) : []),
+  ];
   return {
     links: links,
   };
 }
 
 /**
- * @param {{docHandle: number, pageIndex: number}} params
+ * @param {{docHandle: number, pageIndex: number, loadWebLinks: boolean}} params
  * @returns {Array<PdfUrlLink>}
  */
-function _loadLinks(params) {
+function _loadWebLinks(params) {
   const { pageIndex, docHandle } = params;
   const pageHandle = Pdfium.wasmExports.FPDF_LoadPage(docHandle, pageIndex);
   const textPage = Pdfium.wasmExports.FPDFText_LoadPage(pageHandle);

--- a/lib/src/pdf_api.dart
+++ b/lib/src/pdf_api.dart
@@ -436,7 +436,9 @@ abstract class PdfPage {
   ///
   /// if [compact] is true, it tries to reduce memory usage by compacting the link data.
   /// See [PdfLink.compact] for more info.
-  Future<List<PdfLink>> loadLinks({bool compact = false});
+  /// if [loadWebLinks] is false, it does not load web-like links from text content.
+  /// The default is true.
+  Future<List<PdfLink>> loadLinks({bool compact = false, bool loadWebLinks = true});
 }
 
 /// Page rotation.

--- a/lib/src/pdfium/pdfrx_pdfium.dart
+++ b/lib/src/pdfium/pdfrx_pdfium.dart
@@ -728,8 +728,11 @@ class PdfPagePdfium extends PdfPage {
   Future<PdfPageText> loadText() => PdfPageTextPdfium._loadText(this);
 
   @override
-  Future<List<PdfLink>> loadLinks({bool compact = false}) async {
-    final links = await _loadAnnotLinks() + await _loadLinks();
+  Future<List<PdfLink>> loadLinks({bool compact = false, bool loadWebLinks = true}) async {
+    final links = await _loadAnnotLinks();
+    if (loadWebLinks) {
+      links.addAll(await _loadWebLinks());
+    }
     if (compact) {
       for (int i = 0; i < links.length; i++) {
         links[i] = links[i].compact();
@@ -738,7 +741,7 @@ class PdfPagePdfium extends PdfPage {
     return List.unmodifiable(links);
   }
 
-  Future<List<PdfLink>> _loadLinks() async =>
+  Future<List<PdfLink>> _loadWebLinks() async =>
       document.isDisposed
           ? []
           : await (await backgroundWorker).compute((params) {

--- a/lib/src/web/pdfrx_wasm.dart
+++ b/lib/src/web/pdfrx_wasm.dart
@@ -435,10 +435,14 @@ class PdfPageWasm extends PdfPage {
   final PdfDocumentWasm document;
 
   @override
-  Future<List<PdfLink>> loadLinks({bool compact = false}) async {
+  Future<List<PdfLink>> loadLinks({bool compact = false, bool loadWebLinks = true}) async {
     final result = await document.factory.sendCommand(
       'loadLinks',
-      parameters: {'docHandle': document.document['docHandle'], 'pageIndex': pageNumber - 1},
+      parameters: {
+        'docHandle': document.document['docHandle'],
+        'pageIndex': pageNumber - 1,
+        'loadWebLinks': loadWebLinks
+      },
     );
     return (result['links'] as List).map((link) {
       if (link is! Map<Object?, dynamic>) {

--- a/lib/src/widgets/pdf_viewer.dart
+++ b/lib/src/widgets/pdf_viewer.dart
@@ -2078,7 +2078,8 @@ class _CanvasLinkPainter {
     synchronized(() async {
       final links = _links[page.pageNumber];
       if (links != null) return links;
-      _links[page.pageNumber] = await page.loadLinks(compact: true);
+      final loadWebLinks = _state.widget.params.linkHandlerParams?.loadWebLinks ?? true;
+      _links[page.pageNumber] = await page.loadLinks(compact: true, loadWebLinks: loadWebLinks);
       if (onLoaded != null) {
         onLoaded();
       } else {

--- a/lib/src/widgets/pdf_viewer_params.dart
+++ b/lib/src/widgets/pdf_viewer_params.dart
@@ -817,7 +817,12 @@ enum PdfPageAnchor {
 
 /// Parameters to customize link handling/appearance.
 class PdfLinkHandlerParams {
-  const PdfLinkHandlerParams({required this.onLinkTap, this.linkColor, this.customPainter});
+  const PdfLinkHandlerParams({
+    required this.onLinkTap,
+    this.linkColor,
+    this.customPainter,
+    this.loadWebLinks = true,
+  });
 
   /// Function to be called when the link is tapped.
   ///
@@ -847,16 +852,25 @@ class PdfLinkHandlerParams {
   /// ```
   final PdfLinkCustomPagePainter? customPainter;
 
+  /// Whether to load web-like links from text content.
+  final bool loadWebLinks;
+
   @override
   bool operator ==(covariant PdfLinkHandlerParams other) {
     if (identical(this, other)) return true;
 
-    return other.onLinkTap == onLinkTap && other.linkColor == linkColor && other.customPainter == customPainter;
+    return other.onLinkTap == onLinkTap &&
+        other.linkColor == linkColor &&
+        other.customPainter == customPainter &&
+        other.loadWebLinks == loadWebLinks;
   }
 
   @override
   int get hashCode {
-    return onLinkTap.hashCode ^ linkColor.hashCode ^ customPainter.hashCode;
+    return onLinkTap.hashCode ^
+        linkColor.hashCode ^
+        customPainter.hashCode ^
+        loadWebLinks.hashCode;
   }
 }
 


### PR DESCRIPTION
Summary
----
This pull request introduces a new loadWebLinks option to the PdfPage.loadLinks API. This allows developers to disable the automatic detection of web-like links from text content.



Background and Motivation
----
The current loadLinks API detects not only links defined as annotations but also web-like strings from the text content (e.g., "https://example.com/") using FPDFLink_LoadWebLinks.

While this feature is useful in many cases, it can sometimes lead to the creation of unintended or incomplete links, especially when a URL is broken across multiple lines in the PDF content (as seen in the attached [wrapped-url.pdf](https://github.com/user-attachments/files/21014645/wrapped-url.pdf)).



The purpose of this change is to provide a way to avoid this behavior for use cases where such unintended link generation is not desirable. This allows developers to choose between fetching only explicitly defined annotation links or maintaining the existing behavior.

Changes
----
Added a loadWebLinks option (defaulting to true) to PdfPage.loadLinks.

Modified both the native (pdfrx_pdfium.dart) and WASM (pdfrx_wasm.dart, pdfium_worker.js) implementations to skip calling FPDFLink_LoadWebLinks when this option is false.

Added the loadWebLinks option to PdfLinkHandlerParams within PdfViewerParams to allow controlling this feature from the PdfViewer widget.

Demonstration
----
|loadWebLinks: false|loadWebLinks: true(default)|
|-|-|
|![loadWebLinks-false](https://github.com/user-attachments/assets/5ac8a83b-42f7-491d-89d7-6e3de8f2884c)|![loadWebLinks-true](https://github.com/user-attachments/assets/34701a27-b12b-461e-b3f4-eccc35d1b9b4)|

I've attached [url_text_only.pdf](https://github.com/user-attachments/files/21014649/url_text_only.pdf) which was used to create this demonstration.




Usage
----
To disable automatic web link detection in PdfViewer, set loadWebLinks to false in PdfLinkHandlerParams as shown below:

Dart
```
PdfViewer.asset(
  'assets/document.pdf',
  params: PdfViewerParams(
    // A link tap handler is still required.
    linkHandlerParams: PdfLinkHandlerParams(
      onLinkTap: (link) => print('Link tapped: ${link.url ?? link.dest}'),
      // Set this option to false.
      loadWebLinks: false,
    ),
  ),
),
```
I'd appreciate it if you could review this. Thank you.