### PR TITLE
Fix build issue on pdf_page_text_overlay.dart

### DIFF
--- a/lib/src/widgets/pdf_page_text_overlay.dart
+++ b/lib/src/widgets/pdf_page_text_overlay.dart
@@ -192,6 +192,12 @@ class _PdfTextRenderBox extends RenderBox with PdfPageTextSelectable, Selectable
 
   final ValueNotifier<SelectionGeometry> _geometry;
 
+  @override
+  int get contentLength => 0;
+
+  @override
+  SelectedContentRange? getSelection() => null;
+
   Color _selectionColor;
   Color get selectionColor => _selectionColor;
   set selectionColor(Color value) {


### PR DESCRIPTION
Fix for breaking change on flutter  3.32.0+, where 
SelectionHandler interface has added two new abstract members:

-> int get contentLength;

-> SelectedContentRange? getSelection();