### PR TITLE
Add PDF annotation data loading & annotation widgets for `PdfViewer`

### DIFF
--- a/example/viewer/lib/main.dart
+++ b/example/viewer/lib/main.dart
@@ -176,6 +176,11 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
                           }
                         },
                 ),
+                IconButton(
+                  visualDensity: visualDensity,
+                  icon: const Icon(Icons.comment),
+                  onPressed: documentRef == null ? null : _showAnnotations,
+                ),
               ],
             );
           },
@@ -698,5 +703,43 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
     if (path == null) return null;
     final parts = path.split(RegExp(r'[\\/]'));
     return parts.isEmpty ? path : parts.last;
+  }
+
+  Future<void> _showAnnotations() async {
+    if (!controller.isReady) {
+      return;
+    }
+    final page = controller.pages[controller.pageNumber! - 1];
+    if (page == null) {
+      return;
+    }
+    final annotations = await page.loadAnnotations();
+    if (!mounted) return;
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('Annotations for Page ${page.pageNumber}'),
+        content: SizedBox(
+          width: 400,
+          height: 600,
+          child: ListView.builder(
+            itemCount: annotations.length,
+            itemBuilder: (context, index) {
+              final annot = annotations[index];
+              return ListTile(
+                title: Text('Annotation #${index + 1}: ${annot.subtype.name}'),
+                subtitle: Text('Rect: ${annot.rect}'),
+              );
+            },
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/src/pdf_api.dart
+++ b/lib/src/pdf_api.dart
@@ -457,6 +457,52 @@ abstract class PdfPage {
   /// This is useful if the PDF file contains text that looks like Web links but not defined as links in the PDF.
   /// The default is true.
   Future<List<PdfLink>> loadLinks({bool compact = false, bool enableAutoLinkDetection = true});
+
+  /// Load annotations.
+  ///
+  /// If [compact] is true, it tries to reduce memory usage by compacting the annotation data.
+  Future<List<PdfAnnotation>> loadAnnotations({bool compact = false});
+}
+
+/// Annotation subtype.
+/// See PDF 32000-1:2008, 12.5.2, Table 169.
+enum PdfAnnotationSubtype {
+  unknown,
+  text,
+  link,
+  freeText,
+  line,
+  square,
+  circle,
+  polygon,
+  polyline,
+  highlight,
+  underline,
+  squiggly,
+  strikeOut,
+  stamp,
+  caret,
+  ink,
+  popup,
+  fileAttachment,
+  sound,
+  movie,
+  widget,
+  screen,
+  printerMark,
+  trapNet,
+  watermark,
+  threeD,
+  redact,
+}
+
+/// PDF annotation.
+abstract class PdfAnnotation {
+  /// Annotation subtype.
+  PdfAnnotationSubtype get subtype;
+
+  /// Annotation rectangle in PDF page coordinates.
+  PdfRect get rect;
 }
 
 /// Page rotation.

--- a/lib/src/pdf_api.dart
+++ b/lib/src/pdf_api.dart
@@ -465,7 +465,7 @@ abstract class PdfPage {
 }
 
 /// Annotation subtype.
-/// See PDF 32000-1:2008, 12.5.2, Table 169.
+/// See PDF 32000-1:2008, 12.5.6, Table 169.
 enum PdfAnnotationSubtype {
   unknown,
   text,

--- a/lib/src/pdfium/pdfrx_pdfium.dart
+++ b/lib/src/pdfium/pdfrx_pdfium.dart
@@ -750,6 +750,58 @@ class _PdfPagePdfium extends PdfPage {
     return List.unmodifiable(links);
   }
 
+  @override
+  Future<List<PdfAnnotation>> loadAnnotations({bool compact = false}) async {
+    final annotsData = await _loadAnnotationsData();
+    final annots = annotsData.map((d) {
+      // FIXME: this is a temporary workaround for the issue that FPDFAnnot_GetSubtype() may return a value that is not in PdfAnnotationSubtype.
+      final subtype = d.subtype < PdfAnnotationSubtype.values.length ? PdfAnnotationSubtype.values[d.subtype] : PdfAnnotationSubtype.unknown;
+      return _PdfAnnotationPdfium(
+        subtype: subtype,
+        rect: d.rect,
+      );
+    }).toList();
+    return List.unmodifiable(annots);
+  }
+
+  Future<List<({int subtype, PdfRect rect})>> _loadAnnotationsData() async => document.isDisposed
+      ? []
+      : await (await backgroundWorker).compute(
+          (params) => using((arena) {
+            final document = pdfium_bindings.FPDF_DOCUMENT.fromAddress(params.document);
+            final page = pdfium.FPDF_LoadPage(document, params.pageNumber - 1);
+            try {
+              final count = pdfium.FPDFPage_GetAnnotCount(page);
+              final rectf = arena.allocate<pdfium_bindings.FS_RECTF>(sizeOf<pdfium_bindings.FS_RECTF>());
+              final annots = <({int subtype, PdfRect rect})>[];
+              for (int i = 0; i < count; i++) {
+                final annot = pdfium.FPDFPage_GetAnnot(page, i);
+                try {
+                  pdfium.FPDFAnnot_GetRect(annot, rectf);
+                  final r = rectf.ref;
+                  final rect = PdfRect(
+                    r.left,
+                    r.top > r.bottom ? r.top : r.bottom,
+                    r.right,
+                    r.top > r.bottom ? r.bottom : r.top,
+                  );
+                  final subtype = pdfium.FPDFAnnot_GetSubtype(annot);
+                  annots.add((
+                    subtype: subtype,
+                    rect: rect,
+                  ));
+                } finally {
+                  pdfium.FPDFPage_CloseAnnot(annot);
+                }
+              }
+              return annots;
+            } finally {
+              pdfium.FPDF_ClosePage(page);
+            }
+          }),
+          (document: document.document.address, pageNumber: pageNumber),
+        );
+
   Future<List<PdfLink>> _loadWebLinks() async =>
       document.isDisposed
           ? []
@@ -882,6 +934,19 @@ class _PdfPagePdfium extends PdfPage {
         return null;
     }
   }
+}
+
+class _PdfAnnotationPdfium implements PdfAnnotation {
+  _PdfAnnotationPdfium({
+    required this.subtype,
+    required this.rect,
+  });
+
+  @override
+  final PdfAnnotationSubtype subtype;
+
+  @override
+  final PdfRect rect;
 }
 
 class PdfPageRenderCancellationTokenPdfium extends PdfPageRenderCancellationToken {

--- a/lib/src/widgets/pdf_viewer.dart
+++ b/lib/src/widgets/pdf_viewer.dart
@@ -451,8 +451,6 @@ class _PdfViewerState extends State<PdfViewer> with SingleTickerProviderStateMix
                         ),
                       ),
                       if (_initialized) ..._buildPageOverlayWidgets(context),
-                      if (_initialized && _canvasLinkPainter.isEnabled)
-                        SelectionContainer.disabled(child: _canvasLinkPainter.linkHandlingOverlay(_viewSize!)),
                       if (_initialized && widget.params.viewerOverlayBuilder != null)
                         ...widget.params.viewerOverlayBuilder!(context, _viewSize!, _canvasLinkPainter._handleLinkTap)
                             .map((e) => SelectionContainer.disabled(child: e)),
@@ -880,6 +878,9 @@ class _PdfViewerState extends State<PdfViewer> with SingleTickerProviderStateMix
             child: Stack(children: textWidgets),
           ),
         ),
+      if (_canvasLinkPainter.isEnabled)
+        SelectionContainer.disabled(
+            child: _canvasLinkPainter.linkHandlingOverlay(_viewSize!)),
       ...linkWidgets,
       ...overlayWidgets,
       if (annotationWidgets.isNotEmpty) Stack(children: annotationWidgets),

--- a/lib/src/widgets/pdf_viewer_params.dart
+++ b/lib/src/widgets/pdf_viewer_params.dart
@@ -57,6 +57,7 @@ class PdfViewerParams {
     this.loadingBannerBuilder,
     this.errorBannerBuilder,
     this.linkWidgetBuilder,
+    this.annotationBuilder,
     this.pagePaintCallbacks,
     this.pageBackgroundPaintCallbacks,
     this.onTextSelectionChange,
@@ -468,6 +469,11 @@ class PdfViewerParams {
   /// [linkHandlerParams] is the recommended way to handle links.
   final PdfLinkWidgetBuilder? linkWidgetBuilder;
 
+  /// Build annotation widget.
+  ///
+  /// If null, no annotation widgets are built.
+  final PdfAnnotationWidgetBuilder? annotationBuilder;
+
   /// Callback to paint over the rendered page.
   ///
   /// For the detail usage, see [PdfViewerPagePaintCallback].
@@ -604,6 +610,7 @@ class PdfViewerParams {
         other.loadingBannerBuilder == loadingBannerBuilder &&
         other.errorBannerBuilder == errorBannerBuilder &&
         other.linkWidgetBuilder == linkWidgetBuilder &&
+        other.annotationBuilder == annotationBuilder &&
         other.pagePaintCallbacks == pagePaintCallbacks &&
         other.pageBackgroundPaintCallbacks == pageBackgroundPaintCallbacks &&
         other.onTextSelectionChange == onTextSelectionChange &&
@@ -658,6 +665,7 @@ class PdfViewerParams {
         loadingBannerBuilder.hashCode ^
         errorBannerBuilder.hashCode ^
         linkWidgetBuilder.hashCode ^
+        annotationBuilder.hashCode ^
         pagePaintCallbacks.hashCode ^
         pageBackgroundPaintCallbacks.hashCode ^
         onTextSelectionChange.hashCode ^
@@ -764,6 +772,9 @@ typedef PdfViewerErrorBannerBuilder =
 ///
 /// [size] is the size of the link.
 typedef PdfLinkWidgetBuilder = Widget? Function(BuildContext context, PdfLink link, Size size);
+
+/// Function to build annotation widget.
+typedef PdfAnnotationWidgetBuilder = Widget Function(BuildContext context, PdfAnnotation annotation);
 
 /// Function to inject [SelectionArea] or [SelectableRegion] to customize text selection.
 typedef PdfSelectableRegionInjector = Widget Function(BuildContext context, Widget child);


### PR DESCRIPTION
This PR adds: 
- [`PdfAnnotationSubtype`](https://github.com/espresso3389/pdfrx/compare/master...yunho-c:pdfrx:annotation_viewing_api#diff-6dcd75731400e32378b4fbbe7423db9f78c1ac550903332193c7039711cafb27R472) enum to represent PDF annotation types mentioned in `PDF 32000-1:2008, 12.5.6, Table 169` spec
- [A preliminary implementation](https://github.com/espresso3389/pdfrx/compare/master...yunho-c:pdfrx:annotation_viewing_api#diff-6dcd75731400e32378b4fbbe7423db9f78c1ac550903332193c7039711cafb27R527) of inheritance-based data classes to hold relevant data for each type of annotations, to be able to build respective annotation widgets in the viewer
  - Note: I was not able to review/test them rigorously yet!
  - Pdfium.NET SDK documentation was a good reference to learn about underlying data properties of annotations [PdfAnnotation Class](https://pdfium.patagames.com/help/html/T_Patagames_Pdf_Net_Annotations_PdfAnnotation.htm#!), [Annotations Namespace](https://pdfium.patagames.com/help/html/N_Patagames_Pdf_Net_Annotations.htm)
- [A preliminary implementation](https://github.com/espresso3389/pdfrx/compare/master...yunho-c:pdfrx:annotation_viewing_api#diff-b8c9918c12f7a0f34981fa0225d3a04bdd1e173f7f4a083c51c07502ddf54452R754) of `loadAnnotations()` function that cover a subset of annotation types
- `PdfPageAnnotationWidgets` to `PdfViewer`  and `annotationBuilder` to `PdfViewerParams`
  - An approach similar to `linkHandlingOverlay` that provides a default builder with a concise parameter set to define behavior would be nice, this is just a quick MVP
- An example `annotationBuilder` in the example app

Caveats:
- The annotation data loader for JS/WASM does not handle subtypes properly, and instead only loads the bounding rect. 
  - This wasn't due to a specific limitation, but due to my unfamiliarity with it (i.e., not knowing how to build/test the web builds)
- Not all annotation types are covered. 
  - Here is a simple feature tracker: https://link.yunhocho.com/pdfrx-annotation-type-data-implementation-tracker

This PR achieves the relatively straightforward job of loading data that are needed to build annotation widgets. 

I do not have a sophisticated understanding of Pdfium, pdfrx, or Dart/Flutter, so please feel comfortable in pointing out things to fix and/or reject! 

My ultimate goal is to be able to interactively edit annotations (e.g., add/remove highlights) in the viewer. I plan to make the remaining tasks (file editing, saving, and reloading; dynamically loading edit options the context menu; etc.) as a separate PR in the future! 