### PR TITLE
Fix for #478 - boundary respect for mouse wheel and scroll thumb with ScrollPhysics

### DIFF
--- a/packages/pdfrx/lib/src/widgets/pdf_viewer_scroll_thumb.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer_scroll_thumb.dart
@@ -88,7 +88,7 @@ class _PdfViewerScrollThumbState extends State<PdfViewerScrollThumb> {
           final y = (_panStartOffset + details.localPosition.dy) / vh;
           final m = widget.controller.value.clone();
           m.y = -y * (all.height - view.height);
-          widget.controller.value = m;
+          widget.controller.setMatrixWithBoundaryCheck(m);
         },
       ),
     );
@@ -133,7 +133,7 @@ class _PdfViewerScrollThumbState extends State<PdfViewerScrollThumb> {
           final x = (_panStartOffset + details.localPosition.dx) / vw;
           final m = widget.controller.value.clone();
           m.x = -x * (all.width - view.width);
-          widget.controller.value = m;
+          widget.controller.setMatrixWithBoundaryCheck(m);
         },
       ),
     );


### PR DESCRIPTION
#478
For mouse wheel and scroll thumb actions, when ScrollPhysics was enabled, the boundaries could be exceeded if using BouncingScrollPhysics(), and the ScrollPhysics would not return/snap-back to the boundary. The expected/desired behavior is that boundaries are respected (and not exceeded). 

- Add _setMatrixWithBoundaryCheck method for direct matrix manipulations
- Preserve InteractiveViewer's ScrollPhysics behavior (which for BouncingScrollPhysics() enables boundaries to be exceeded)
- Apply boundary checking only for bypass operations (mouse wheel, scroll thumb)
- Use existing _calcMatrixForClampedToNearestBoundary when scrollPhysics enabled
- Fix missing return type annotation for _adjustBoundaryMargins

🤖 Generated with [Claude Code](https://claude.ai/code)