### PR TITLE
preserve precise position on page for layout and view size changes

### DIFF
--- a/packages/pdfrx/example/viewer/lib/main.dart
+++ b/packages/pdfrx/example/viewer/lib/main.dart
@@ -312,21 +312,6 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
                         useAlternativeFitScaleAsMinScale: false,
                         maxScale: 8,
                         //scrollPhysics: const BouncingScrollPhysics(),
-                        onViewSizeChanged: (viewSize, oldViewSize, controller) {
-                          if (oldViewSize != null) {
-                            //
-                            // Calculate the matrix to keep the center position during device
-                            // screen rotation
-                            //
-                            // The most important thing here is that the transformation matrix
-                            // is not changed on the view change.
-                            final centerPosition = controller.value.calcPosition(oldViewSize);
-                            final newMatrix = controller.calcMatrixFor(centerPosition);
-                            // Don't change the matrix in sync; the callback might be called
-                            // during widget-tree's build process.
-                            Future.delayed(const Duration(milliseconds: 200), () => controller.goTo(newMatrix));
-                          }
-                        },
                         viewerOverlayBuilder: (context, size, handleLinkTap) => [
                           //
                           // Example use of GestureDetector to handle custom gestures

--- a/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
@@ -448,7 +448,7 @@ class _PdfViewerState extends State<PdfViewer>
                   onPointerHover: (event) => _handlePointerEvent(event, event.localPosition, event.kind),
                   child: Stack(
                     children: [
-                      iv.InteractiveViewer(
+                      iv.InteractiveViewer.withAnimationControl(
                         transformationController: _txController,
                         constrained: false,
                         boundaryMargin:
@@ -557,6 +557,9 @@ class _PdfViewerState extends State<PdfViewer>
   void _updateLayout(Size viewSize) {
     if (viewSize.height <= 0) return; // For fix blank pdf when restore window from minimize on Windows
     final currentPageNumber = _guessCurrentPageNumber();
+    final Rect oldVisibleRect = _initialized ? _visibleRect : Rect.zero;
+    final PdfPageLayout? oldLayout = _layout;
+    final oldMinScale = _minScale;
     final oldSize = _viewSize;
     final isViewSizeChanged = oldSize != viewSize;
     _viewSize = viewSize;
@@ -594,8 +597,55 @@ class _PdfViewerState extends State<PdfViewer>
     } else if (isLayoutChanged || isViewSizeChanged) {
       Future.microtask(() async {
         if (mounted) {
-          await _goToPage(pageNumber: currentPageNumber ?? _calcInitialPageNumber());
-          callOnViewerSizeChanged();
+          // preserve the current zoom whilst respecting the new minScale
+          final zoomTo = _currentZoom < _minScale || _currentZoom == oldMinScale ? _minScale : _currentZoom;
+          if (isLayoutChanged) {
+            // if the layout changed, calculate the top-left position in the document
+            // before the layout change and go to that position in the new layout
+
+            if (oldLayout != null && currentPageNumber != null) {
+              // The top-left position of the screen (oldVisibleRect.topLeft) may be
+              // in the boundary margin, or a margin between pages, and it could be
+              // the current page or one of the neighboring pages
+              final PdfPageHitTestResult? hit = _getClosestPageHit(currentPageNumber, oldLayout, oldVisibleRect);
+              final pageNumber = hit?.page.pageNumber ?? currentPageNumber;
+
+              // Compute relative position within the old pageRect
+              final Rect oldPageRect = oldLayout.pageLayouts[pageNumber - 1];
+              final Rect newPageRect = _layout!.pageLayouts[pageNumber - 1];
+              final Offset oldOffset = oldVisibleRect.topLeft - oldPageRect.topLeft;
+              final double fracX = oldOffset.dx / oldPageRect.width;
+              final double fracY = oldOffset.dy / oldPageRect.height;
+
+              // Map into new layoutRect
+              final Offset newOffset = Offset(
+                newPageRect.left + fracX * newPageRect.width,
+                newPageRect.top + fracY * newPageRect.height,
+              );
+
+              // preseve the position after a layout change
+              await _goToPosition(documentOffset: newOffset, zoom: zoomTo);
+            }
+          } else {
+            if (zoomTo != _currentZoom) {
+              // layout hasn't changed, but size and zoom has
+              final double zoomChange = zoomTo / _currentZoom;
+              final vec.Vector3 pivot = vec.Vector3(_txController.value.x, _txController.value.y, 0);
+
+              final Matrix4 pivotScale = Matrix4.identity()
+                ..translateByVector3(pivot)
+                ..scaleByDouble(zoomChange, zoomChange, zoomChange, 1)
+                ..translateByVector3(-pivot / zoomChange);
+
+              final Matrix4 zoomPivoted = pivotScale * _txController.value;
+              _clampToNearestBoundary(zoomPivoted, viewSize: viewSize);
+            } else {
+              // size changes (e.g. rotation) can still cause out-of-bounds matricies
+              // so clamp here
+              _clampToNearestBoundary(_txController.value, viewSize: viewSize);
+            } 
+            callOnViewerSizeChanged();
+          }
         }
       });
     } else if (currentPageNumber != null && _pageNumber != currentPageNumber) {
@@ -603,8 +653,82 @@ class _PdfViewerState extends State<PdfViewer>
     }
   }
 
+  /// Shift any overshoot back to the nearest content boundary
+  void _clampToNearestBoundary(Matrix4 candidate, {required Size viewSize}) {
+    _stopAnimationsAndClampBoundaries(candidate, viewSize: viewSize);
+  }
+
+  /// Stop InteractiveViewer animations and apply boundary clamping
+  void _stopAnimationsAndClampBoundaries(Matrix4 candidate, {required Size viewSize}) {
+    if (_isInteractionGoingOn) return;
+
+    // Stop any active animations and apply the clamped matrix
+    if (iv.InteractiveViewer.hasActiveAnimations) {
+      iv.InteractiveViewer.stopAnimations();
+    }
+
+    // Apply the clamped matrix
+    _txController.value = _calcMatrixForClampedToNearestBoundary(candidate, viewSize: viewSize);
+  }
+
   int _calcInitialPageNumber() {
     return widget.params.calculateInitialPageNumber?.call(_document!, _controller!) ?? widget.initialPageNumber;
+  }
+
+  PdfPageHitTestResult? _getClosestPageHit(int currentPageNumber, PdfPageLayout oldLayout, ui.Rect oldVisibleRect) {
+    for (final pageIndex in <int>[currentPageNumber, currentPageNumber - 1, currentPageNumber + 1]) {
+      if (pageIndex >= 1 && pageIndex <= oldLayout.pageLayouts.length) {
+        final rec = _nudgeHitTest(oldVisibleRect.topLeft, layout: oldLayout, pageNumber: pageIndex);
+        if (rec != null) {
+          return rec.hit;
+        }
+      }
+    }
+    return null;
+  }
+
+  /// Hit-tests a point against a given layout and optional page number.
+  PdfPageHitTestResult? _hitTestWithLayout({
+    required Offset point,
+    required PdfPageLayout layout,
+    required int pageNumber,
+  }) {
+    final pages = _document?.pages;
+    if (pages == null) return null;
+    if (pageNumber >= layout.pageLayouts.length) {
+      return null;
+    }
+
+    final rect = layout.pageLayouts[pageNumber];
+    if (rect.contains(point)) {
+      final page = pages[pageNumber];
+      final Offset local = point - rect.topLeft;
+      final PdfPoint pdfOffset = local.toPdfPoint(page: page, scaledPageSize: rect.size);
+      return PdfPageHitTestResult(page: page, offset: pdfOffset);
+    } else {
+      return null;
+    }
+  }
+
+  // Attempts to nudge the point on the x axis until a valid page hit is found.
+  ({Offset point, PdfPageHitTestResult hit})? _nudgeHitTest(Offset start, {PdfPageLayout? layout, int? pageNumber}) {
+    const double epsViewPx = 1.0;
+    final double epsDoc = epsViewPx / _currentZoom;
+
+    Offset tryPoint = start;
+    Offset tryOffset = Offset.zero;
+    final PdfPageLayout? useLayout = layout;
+    for (int i = 0; i < 500; i++) {
+      final PdfPageHitTestResult? result = useLayout != null && pageNumber != null
+          ? _hitTestWithLayout(point: tryPoint, layout: useLayout, pageNumber: pageNumber)
+          : _getPdfPageHitTestResult(tryPoint, useDocumentLayoutCoordinates: true);
+      if (result != null) {
+        return (point: tryOffset, hit: result);
+      }
+      tryOffset += Offset(epsDoc, 0);
+      tryPoint = tryPoint.translate(epsDoc, 0);
+    }
+    return null;
   }
 
   void _startInteraction() {
@@ -1620,6 +1744,28 @@ class _PdfViewerState extends State<PdfViewer>
       duration: duration,
     );
     _setCurrentPageNumber(targetPageNumber);
+  }
+
+  /// Scrolls/zooms so that the specified PDF document coordinate appears at
+  /// the top-left corner of the viewport.
+  Future<void> _goToPosition({
+    required Offset documentOffset,
+    Duration duration = const Duration(milliseconds: 0),
+    double? zoom,
+  }) async {
+    // Clear any cached partial images to avoid stale tiles after
+    // going to the new matrix
+    _imageCache.releasePartialImages();
+
+    zoom = zoom ?? _currentZoom;
+    final double tx = -documentOffset.dx * zoom;
+    final double ty = -documentOffset.dy * zoom;
+
+    final Matrix4 m = Matrix4.compose(vec.Vector3(tx, ty, 0), vec.Quaternion.identity(), vec.Vector3(zoom, zoom, zoom));
+
+    _adjustBoundaryMargins(_viewSize!, zoom);
+    final Matrix4 clamped = _calcMatrixForClampedToNearestBoundary(m, viewSize: _viewSize!);
+    await _goTo(clamped, duration: duration);
   }
 
   Future<void> _goToRectInsidePage({
@@ -2871,6 +3017,17 @@ class _PdfPageImageCache {
   void addCancellationToken(int pageNumber, PdfPageRenderCancellationToken token) {
     var tokens = cancellationTokens.putIfAbsent(pageNumber, () => []);
     tokens.add(token);
+  }
+
+  void releasePartialImages() {
+    for (final request in pageImagePartialRenderingRequests.values) {
+      request.cancel();
+    }
+    pageImagePartialRenderingRequests.clear();
+    for (final image in pageImagesPartial.values) {
+      image.image.dispose();
+    }
+    pageImagesPartial.clear();
   }
 
   void releaseAllImages() {


### PR DESCRIPTION
In the current implementation of PdfView, when layout or view size changes, _goToPage() is called which will likely change the zoom and position of the page that is currently being viewed. If the user was in the midst of reading the document, they must re-orient and find their previous position, which is undesirable.

This PR includes a change that retains the user's precise position (relative to the top left of the page) when there are size changes (for example rotation of a device), and tries to retain the current zoom level where possible. It will also keep the document from going out of bounds. Even if the document layout changes (for example different layouts might be setup for landscape vs portrait viewing), the position is maintained according to the previous position in the PDF document coordinate space. The attached videos show a before and after this change.

Some implementation details:

- Any current animations in the InteractiveViewer are stopped so that these animations do not interfere with any changes to the matrix we make
- a new _goToPosition method has been added which goes to a specific offset within the document
- Partial images in the cache are removed as these may appear in the incorrect position
- when the layout or size changes, _updateLayout  finds the closest point within the PdfPage to the top left corner of the screen in the old page layout and translates the position of this point in Pdf document space to the new page layout.
- the onViewSizeChanged method in the viewer example has been removed, as this is redundant with this change

https://github.com/user-attachments/assets/5e9157af-91e7-4d63-92a5-8c61f25bef0e
https://github.com/user-attachments/assets/f09bdc62-de1a-4fd9-a6d6-ad5421006e23

