### PR TITLE
Add scrollPhysicsScale and FixedOverScrollPhysics

### DIFF
--- a/packages/pdfrx/example/viewer/lib/main.dart
+++ b/packages/pdfrx/example/viewer/lib/main.dart
@@ -311,7 +311,7 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
                         keyHandlerParams: PdfViewerKeyHandlerParams(autofocus: true),
                         useAlternativeFitScaleAsMinScale: false,
                         maxScale: 8,
-                        //scrollPhysics: const BouncingScrollPhysics(),
+                        //scrollPhysics: PdfViewerParams.getScrollPhysics(context),
                         viewerOverlayBuilder: (context, size, handleLinkTap) => [
                           //
                           // Example use of GestureDetector to handle custom gestures

--- a/packages/pdfrx/lib/pdfrx.dart
+++ b/packages/pdfrx/lib/pdfrx.dart
@@ -8,3 +8,4 @@ export 'src/widgets/pdf_viewer.dart';
 export 'src/widgets/pdf_viewer_params.dart';
 export 'src/widgets/pdf_viewer_scroll_thumb.dart';
 export 'src/widgets/pdf_widgets.dart';
+export 'src/utils/fixed_overscroll_physics.dart';

--- a/packages/pdfrx/lib/src/utils/edge_insets_extensions.dart
+++ b/packages/pdfrx/lib/src/utils/edge_insets_extensions.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+/// Extensions for EdgeInsets to provide additional utility methods.
+extension EdgeInsetsExtensions on EdgeInsets {
+  /// Returns true if any of the EdgeInsets values (left, top, right, bottom) are infinite.
+  bool get containsInfinite => left.isInfinite || right.isInfinite || top.isInfinite || bottom.isInfinite;
+
+  /// Inflates a given Rect by the EdgeInsets values if all values are finite, otherwise retruns the rect
+  Rect inflateRectIfFinite(Rect rect) {
+    if (containsInfinite) return rect;
+    return inflateRect(rect);
+  }
+}

--- a/packages/pdfrx/lib/src/utils/fixed_overscroll_physics.dart
+++ b/packages/pdfrx/lib/src/utils/fixed_overscroll_physics.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/widgets.dart';
+
+/// A ScrollPhysics that lets you overscroll by up to [maxOverscroll]
+/// and then springs back to the content bounds.
+class FixedOverscrollPhysics extends ClampingScrollPhysics {
+  const FixedOverscrollPhysics({super.parent, this.maxOverscroll = 200.0});
+
+  /// How far (in logical pixels) the user can overscroll.
+  final double maxOverscroll;
+
+  @override
+  FixedOverscrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return FixedOverscrollPhysics(parent: buildParent(ancestor), maxOverscroll: maxOverscroll);
+  }
+
+  @override
+  double applyBoundaryConditions(ScrollMetrics position, double value) {
+    // Overscroll allowed to a specific maximum [maxOverscroll] to replicate
+    // the behavior of popular PDF readers on Android.
+
+    // If we're within the allowed overscroll zone, allow it (return 0).
+    if (value < position.minScrollExtent && value >= position.minScrollExtent - maxOverscroll) {
+      return 0.0;
+    }
+    if (value > position.maxScrollExtent && value <= position.maxScrollExtent + maxOverscroll) {
+      return 0.0;
+    }
+
+    if (value <= position.minScrollExtent - maxOverscroll) {
+      return value - (position.minScrollExtent - maxOverscroll);
+    } else if (value >= position.maxScrollExtent + maxOverscroll) {
+      return value - (position.maxScrollExtent + maxOverscroll);
+    }
+    return 0.0;
+  }
+
+  @override
+  Simulation? createBallisticSimulation(ScrollMetrics position, double velocity) {
+    final tolerance = toleranceFor(position);
+
+    if (velocity.abs() >= tolerance.velocity || position.outOfRange) {
+      return _HybridScrollSimulation(
+        position: position,
+        velocity: velocity,
+        tolerance: tolerance,
+        maxOverscroll: maxOverscroll,
+      );
+    }
+    return null;
+  }
+}
+
+/// A simulation that behaves like ClampingScrollPhysics when within bounds
+/// and switches to a custom BouncingScrollSimulation when exceeding bounds.
+class _HybridScrollSimulation extends Simulation {
+  _HybridScrollSimulation({
+    required ScrollMetrics position,
+    required double velocity,
+    required this.tolerance,
+    required this.maxOverscroll,
+  }) : _minExtent = position.minScrollExtent,
+       _maxExtent = position.maxScrollExtent {
+    final currentPosition = position.pixels;
+    final isOutOfBounds = currentPosition < _minExtent || currentPosition > _maxExtent;
+    final isInOverscrollZone =
+        (currentPosition >= _minExtent - maxOverscroll && currentPosition < _minExtent) ||
+        (currentPosition > _maxExtent && currentPosition <= _maxExtent + maxOverscroll);
+
+    // If already out of bounds or in overscroll zone, start with bouncing simulation
+    if (isOutOfBounds || isInOverscrollZone) {
+      _createBouncingSimulation(currentPosition, velocity);
+    } else {
+      // Within content bounds - use clamping behavior
+      _currentSimulation = ClampingScrollSimulation(position: currentPosition, velocity: velocity);
+    }
+  }
+
+  final double _minExtent;
+  final double _maxExtent;
+  final double maxOverscroll;
+  final Tolerance tolerance;
+
+  late Simulation _currentSimulation;
+  bool _hasSwitchedToBouncing = false;
+
+  @override
+  double x(double time) {
+    final position = _currentSimulation.x(time);
+
+    // Check if we need to switch to bouncing simulation
+    if (!_hasSwitchedToBouncing) {
+      final wouldExceedBounds = position < _minExtent || position > _maxExtent;
+
+      if (wouldExceedBounds) {
+        _switchToBouncingSimulation(position, dx(time));
+      }
+    }
+
+    return _currentSimulation.x(time);
+  }
+
+  @override
+  double dx(double time) => _currentSimulation.dx(time);
+
+  @override
+  bool isDone(double time) => _currentSimulation.isDone(time);
+
+  void _switchToBouncingSimulation(double position, double velocity) {
+    _hasSwitchedToBouncing = true;
+    _createBouncingSimulation(position, velocity);
+  }
+
+  void _createBouncingSimulation(double position, double velocity) {
+    // A spring with considerably less mass and higher stiffness than the default
+    // iOS BouncingScrollSimulation which results in hardly any overscroll on
+    // fling, and a quick snap back to the content bounds when dragged, to replicate
+    // similar behavior found in several popular PDF readers on Android.
+
+    final spring = SpringDescription.withDampingRatio(mass: 0.3, stiffness: 1500.0, ratio: 3);
+
+    _currentSimulation = BouncingScrollSimulation(
+      spring: spring,
+      position: position,
+      velocity: velocity,
+      leadingExtent: _minExtent,
+      trailingExtent: _maxExtent,
+      tolerance: tolerance,
+    );
+  }
+}

--- a/packages/pdfrx/lib/src/utils/fixed_overscroll_physics.dart
+++ b/packages/pdfrx/lib/src/utils/fixed_overscroll_physics.dart
@@ -56,10 +56,11 @@ class _HybridScrollSimulation extends Simulation {
   _HybridScrollSimulation({
     required ScrollMetrics position,
     required double velocity,
-    required this.tolerance,
+    required Tolerance tolerance,
     required this.maxOverscroll,
   }) : _minExtent = position.minScrollExtent,
-       _maxExtent = position.maxScrollExtent {
+       _maxExtent = position.maxScrollExtent,
+       _tolerance = tolerance {
     final currentPosition = position.pixels;
     final isOutOfBounds = currentPosition < _minExtent || currentPosition > _maxExtent;
     final isInOverscrollZone =
@@ -78,7 +79,9 @@ class _HybridScrollSimulation extends Simulation {
   final double _minExtent;
   final double _maxExtent;
   final double maxOverscroll;
-  final Tolerance tolerance;
+  @override
+  Tolerance get tolerance => _tolerance;
+  final Tolerance _tolerance;
 
   late Simulation _currentSimulation;
   bool _hasSwitchedToBouncing = false;

--- a/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
@@ -13,6 +13,7 @@ import 'package:synchronized/extension.dart';
 import 'package:vector_math/vector_math_64.dart' as vec;
 
 import '../../pdfrx.dart';
+import '../utils/edge_insets_extensions.dart';
 import '../utils/platform.dart';
 import 'interactive_viewer.dart' as iv;
 import 'internals/pdf_error_widget.dart';
@@ -467,6 +468,7 @@ class _PdfViewerState extends State<PdfViewer>
                         interactionEndFrictionCoefficient: widget.params.interactionEndFrictionCoefficient,
                         onWheelDelta: widget.params.scrollByMouseWheel != null ? _onWheelDelta : null,
                         scrollPhysics: widget.params.scrollPhysics,
+                        scrollPhysicsScale: widget.params.scrollPhysicsScale,
                         scrollPhysicsAutoAdjustBoundaries: false,
                         // PDF pages
                         child: GestureDetector(
@@ -530,7 +532,7 @@ class _PdfViewerState extends State<PdfViewer>
 
   Offset _calcOverscroll(Matrix4 m, {required Size viewSize}) {
     final boundaryMargin = _adjustedBoundaryMargins;
-    if (_edgeInsetContainsInfinite(boundaryMargin)) {
+    if (boundaryMargin?.containsInfinite == true) {
       return Offset.zero;
     }
 
@@ -1012,17 +1014,12 @@ class _PdfViewerState extends State<PdfViewer>
 
   static bool _areZoomsAlmostIdentical(double z1, double z2) => (z1 - z2).abs() < 0.01;
 
-  bool _edgeInsetContainsInfinite(EdgeInsets? e) {
-    if (e == null) return false;
-    return e.left.isInfinite || e.right.isInfinite || e.top.isInfinite || e.bottom.isInfinite;
-  }
-
   // Auto-adjust boundaries when content is smaller than the view, centering
   // the content and ensuring InteractiveViewer's scrollPhysics works when specified
   void _adjustBoundaryMargins(Size viewSize, double zoom) {
     final boundaryMargin = widget.params.boundaryMargin ?? EdgeInsets.zero;
 
-    if (_edgeInsetContainsInfinite(boundaryMargin)) {
+    if (boundaryMargin.containsInfinite) {
       _adjustedBoundaryMargins = boundaryMargin;
       return;
     }
@@ -1572,7 +1569,7 @@ class _PdfViewerState extends State<PdfViewer>
     final pageRect = _layout!.pageLayouts[pageNumber - 1].inflate(widget.params.margin);
 
     // If boundaryMargin is infinite, don't inflate the rect
-    final targetRect = (_edgeInsetContainsInfinite(boundaryMargin)) ? pageRect : boundaryMargin.inflateRect(pageRect);
+    final targetRect = boundaryMargin.inflateRectIfFinite(pageRect);
 
     return _calcMatrixForArea(rect: targetRect, anchor: anchor, zoomMax: _currentZoom);
   }

--- a/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
@@ -532,7 +532,7 @@ class _PdfViewerState extends State<PdfViewer>
 
   Offset _calcOverscroll(Matrix4 m, {required Size viewSize}) {
     final boundaryMargin = _adjustedBoundaryMargins;
-    if (boundaryMargin?.containsInfinite == true) {
+    if (boundaryMargin.containsInfinite) {
       return Offset.zero;
     }
 
@@ -3276,7 +3276,7 @@ class PdfTextSelectionAnchor {
   }
 
   @override
-  operator ==(Object other) {
+  bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is! PdfTextSelectionAnchor) return false;
     return rect == other.rect &&

--- a/packages/pdfrx/lib/src/widgets/pdf_viewer_params.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer_params.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
@@ -71,6 +72,7 @@ class PdfViewerParams {
     this.behaviorControlParams = const PdfViewerBehaviorControlParams(),
     this.forceReload = false,
     this.scrollPhysics,
+    this.scrollPhysicsScale,
   });
 
   /// Margin around the page.
@@ -539,12 +541,34 @@ class PdfViewerParams {
 
   /// Scroll physics for the viewer.
   ///
-  /// If null, it works like [ClampingScrollPhysics] on all platforms.
-  /// If you want bouncing effect, set this to [BouncingScrollPhysics].
+  /// If null, default InteractiveViewer physics is used on all platforms. This physics clamps to boundaries,
+  /// does not allow zooming beyond the min/max scale, and flings on panning come to rest quickly relative to
+  /// Scrollables in Flutter (such as SingleChildScrollView).
+  ///
+  /// A convenience function [getScrollPhysics] is provided to get platform-specific default scroll physics.
+  /// If you want no overscroll, but still want the physics for panning to be similar to other Scrollables,
+  /// you can use
+  /// [ClampingScrollPhysics()].
   ///
   /// If the value is set non-null, it disables [normalizeMatrix].
-  /// If you set [boundaryMargin] to `EdgeInsets.all(double.infinity)`, it effectively disables [scrollPhysics].
+  ///
+  /// If you set [boundaryMargin] to `EdgeInsets.all(double.infinity)`, this will enable scrolling
+  /// beyond the boundaries regardless of which [ScrollPhysics] is used.
   final ScrollPhysics? scrollPhysics;
+
+  /// Scroll physics for scaling within the viewer. If null, it uses the same value as [scrollPhysics].
+  final ScrollPhysics? scrollPhysicsScale;
+
+  /// A convenience function to get platform-specific default scroll physics.
+  /// On iOS/MacOS this is [BouncingScrollPhysics()], and on Android this is [FixedOverscrollPhysics()], a
+  /// custom ScrollPhysics that allows fixed overscroll on pan/zoom and snapback.
+  static ScrollPhysics getScrollPhysics(BuildContext context) {
+    if (Platform.isAndroid) {
+      return const FixedOverscrollPhysics();
+    } else {
+      return ScrollConfiguration.of(context).getScrollPhysics(context);
+    }
+  }
 
   /// Determine whether the viewer needs to be reloaded or not.
   ///

--- a/packages/pdfrx/lib/src/widgets/pdf_viewer_params.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer_params.dart
@@ -1407,7 +1407,7 @@ class PdfViewerKeyHandlerParams {
   final FocusNode? parentNode;
 
   @override
-  operator ==(covariant PdfViewerKeyHandlerParams other) {
+  bool operator ==(covariant PdfViewerKeyHandlerParams other) {
     if (identical(this, other)) return true;
 
     return other.autofocus == autofocus &&

--- a/packages/pdfrx/lib/src/widgets/pdf_viewer_params.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer_params.dart
@@ -548,7 +548,7 @@ class PdfViewerParams {
   /// A convenience function [getScrollPhysics] is provided to get platform-specific default scroll physics.
   /// If you want no overscroll, but still want the physics for panning to be similar to other Scrollables,
   /// you can use
-  /// [ClampingScrollPhysics()].
+  /// `ClampingScrollPhysics()`.
   ///
   /// If the value is set non-null, it disables [normalizeMatrix].
   ///
@@ -560,7 +560,7 @@ class PdfViewerParams {
   final ScrollPhysics? scrollPhysicsScale;
 
   /// A convenience function to get platform-specific default scroll physics.
-  /// On iOS/MacOS this is [BouncingScrollPhysics()], and on Android this is [FixedOverscrollPhysics()], a
+  /// On iOS/MacOS this is `BouncingScrollPhysics()`, and on Android this is `FixedOverscrollPhysics()`, a
   /// custom ScrollPhysics that allows fixed overscroll on pan/zoom and snapback.
   static ScrollPhysics getScrollPhysics(BuildContext context) {
     if (Platform.isAndroid) {

--- a/packages/pdfrx/lib/src/widgets/pdf_viewer_scroll_thumb.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer_scroll_thumb.dart
@@ -53,8 +53,18 @@ class _PdfViewerScrollThumbState extends State<PdfViewerScrollThumb> {
     final thumbSize = widget.thumbSize ?? const Size(25, 40);
     final view = widget.controller.visibleRect;
     final all = widget.controller.documentSize;
-    if (all.height <= view.height) return const SizedBox();
-    final y = -widget.controller.value.y / (all.height - view.height);
+    final boundaryMargin = widget.controller.params.boundaryMargin;
+
+    final effectiveDocHeight = boundaryMargin == null || boundaryMargin.vertical.isInfinite
+        ? all.height
+        : all.height + boundaryMargin.vertical;
+
+    if (effectiveDocHeight <= view.height) return const SizedBox();
+
+    final scrollRange = effectiveDocHeight - view.height;
+    final minScrollY = boundaryMargin == null || boundaryMargin.vertical.isInfinite ? 0.0 : -boundaryMargin.top;
+
+    final y = (-widget.controller.value.y - minScrollY) / scrollRange;
     final vh = view.height * widget.controller.currentZoom - thumbSize.height;
     final top = y * vh;
     return Positioned(
@@ -87,7 +97,7 @@ class _PdfViewerScrollThumbState extends State<PdfViewerScrollThumb> {
         onPanUpdate: (details) {
           final y = (_panStartOffset + details.localPosition.dy) / vh;
           final m = widget.controller.value.clone();
-          m.y = -y * (all.height - view.height);
+          m.y = -(y * scrollRange + minScrollY);
           widget.controller.value = m;
         },
       ),
@@ -98,8 +108,18 @@ class _PdfViewerScrollThumbState extends State<PdfViewerScrollThumb> {
     final thumbSize = widget.thumbSize ?? const Size(40, 25);
     final view = widget.controller.visibleRect;
     final all = widget.controller.documentSize;
-    if (all.width <= view.width) return const SizedBox();
-    final x = -widget.controller.value.x / (all.width - view.width);
+    final boundaryMargin = widget.controller.params.boundaryMargin;
+
+    final effectiveDocWidth = boundaryMargin == null || boundaryMargin.horizontal.isInfinite
+        ? all.width
+        : all.width + boundaryMargin.horizontal;
+
+    if (effectiveDocWidth <= view.width) return const SizedBox();
+
+    final scrollRange = effectiveDocWidth - view.width;
+    final minScrollX = boundaryMargin == null || boundaryMargin.horizontal.isInfinite ? 0.0 : -boundaryMargin.left;
+
+    final x = (-widget.controller.value.x - minScrollX) / scrollRange;
     final vw = view.width * widget.controller.currentZoom - thumbSize.width;
     final left = x * vw;
     return Positioned(
@@ -132,7 +152,7 @@ class _PdfViewerScrollThumbState extends State<PdfViewerScrollThumb> {
         onPanUpdate: (details) {
           final x = (_panStartOffset + details.localPosition.dx) / vw;
           final m = widget.controller.value.clone();
-          m.x = -x * (all.width - view.width);
+          m.x = -(x * scrollRange + minScrollX);
           widget.controller.value = m;
         },
       ),


### PR DESCRIPTION
I forgot to add the scrollPhysicsScale argument, which enables different scrollPhysics for scaling and an associated FixedOverScrollPhysics which enables ClampingScrollPhysics for panning and a modified BouncingScrollPhysics for overshoot and snapback to replicate the behavior seen on several popular PDF readers on Android.  I think we should add this change now before releasing the scrollPhysics feature.

There is also a helper function to select the appropriate scrollPhysics for the platform: PdfViewerParams.getScrollPhysics(context). Currently it chooses the FixedOverScrollPhysics() for Android, and then falls through to  ScrollConfiguration.of(context).getScrollPhysics(context). A decision needs to be made as to whether FixedOverScrollPhysics() should apply for other platforms such as Windows.

I also made some changes to the documentation to reflect these changes.