### PR TITLE
Draft PR - FitMode and layout enhancements

### DIFF
--- a/packages/pdfrx/example/viewer/lib/main.dart
+++ b/packages/pdfrx/example/viewer/lib/main.dart
@@ -309,8 +309,8 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
                           },
                         ),
                         keyHandlerParams: PdfViewerKeyHandlerParams(autofocus: true),
-                        useAlternativeFitScaleAsMinScale: false,
                         maxScale: 8,
+                        //fitMode: FitMode.fill,
                         //scrollPhysics: PdfViewerParams.getScrollPhysics(context),
                         viewerOverlayBuilder: (context, size, handleLinkTap) => [
                           //
@@ -341,28 +341,28 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
                             controller: controller,
                             orientation: ScrollbarOrientation.right,
                             thumbSize: const Size(40, 25),
-                            thumbBuilder: (context, thumbSize, pageNumber, controller) => Container(
+                            /*   thumbBuilder: (context, thumbSize, pageNumber, controller) => Container(
                               color: Colors.black,
                               child: isHorizontalLayout
                                   ? null
                                   : Center(
                                       child: Text(pageNumber.toString(), style: const TextStyle(color: Colors.white)),
                                     ),
-                            ),
+                            ), */
                           ),
                           // Just a simple horizontal scroll thumb on the bottom
                           PdfViewerScrollThumb(
                             controller: controller,
                             orientation: ScrollbarOrientation.bottom,
                             thumbSize: const Size(40, 25),
-                            thumbBuilder: (context, thumbSize, pageNumber, controller) => Container(
+                            /*thumbBuilder: (context, thumbSize, pageNumber, controller) => Container(
                               color: Colors.black,
                               child: !isHorizontalLayout
                                   ? null
                                   : Center(
                                       child: Text(pageNumber.toString(), style: const TextStyle(color: Colors.white)),
                                     ),
-                            ),
+                            ), */
                           ),
                         ],
                         //
@@ -470,61 +470,31 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
   /// Page reading order; true to L-to-R that is commonly used by books like manga or such
   var isRightToLeftReadingOrder = false;
 
-  /// Use the first page as cover page
-  var needCoverPage = true;
-
   late final List<PdfPageLayoutFunction?> _layoutPages = [
-    // The default layout
     null,
-    // Horizontal layout
-    (pages, params) {
+    // Horizontal layout (using built-in layout class)
+    (pages, params, helper) =>
+        SinglePagesLayout.fromPages(pages, params, helper: helper, scrollDirection: Axis.horizontal),
+
+    // Facing pages layout (using built-in layout class)
+    (pages, params, helper) => FacingPagesLayout.fromPages(
+      pages,
+      params,
+      helper: helper,
+      firstPageIsCoverPage: true,
+      isRightToLeftReadingOrder: isRightToLeftReadingOrder,
+    ),
+
+    // Custom layout example - horizontal strip layout
+    (pages, params, helper) {
       final height = pages.fold(0.0, (prev, page) => max(prev, page.height)) + params.margin * 2;
       final pageLayouts = <Rect>[];
       double x = params.margin;
       for (var page in pages) {
-        pageLayouts.add(
-          Rect.fromLTWH(
-            x,
-            (height - page.height) / 2, // center vertically
-            page.width,
-            page.height,
-          ),
-        );
+        pageLayouts.add(Rect.fromLTWH(x, (height - page.height) / 2, page.width, page.height));
         x += page.width + params.margin;
       }
       return PdfPageLayout(pageLayouts: pageLayouts, documentSize: Size(x, height));
-    },
-    // Facing pages layout
-    (pages, params) {
-      final width = pages.fold(0.0, (prev, page) => max(prev, page.width));
-
-      final pageLayouts = <Rect>[];
-      final offset = needCoverPage ? 1 : 0;
-      double y = params.margin;
-      for (int i = 0; i < pages.length; i++) {
-        final page = pages[i];
-        final pos = i + offset;
-        final isLeft = isRightToLeftReadingOrder ? (pos & 1) == 1 : (pos & 1) == 0;
-
-        final otherSide = (pos ^ 1) - offset;
-        final h = 0 <= otherSide && otherSide < pages.length ? max(page.height, pages[otherSide].height) : page.height;
-
-        pageLayouts.add(
-          Rect.fromLTWH(
-            isLeft ? width + params.margin - page.width : params.margin * 2 + width,
-            y + (h - page.height) / 2,
-            page.width,
-            page.height,
-          ),
-        );
-        if (pos & 1 == 1 || i + 1 == pages.length) {
-          y += h + params.margin;
-        }
-      }
-      return PdfPageLayout(
-        pageLayouts: pageLayouts,
-        documentSize: Size((params.margin + width) * 2 + params.margin, y),
-      );
     },
   ];
 

--- a/packages/pdfrx/lib/pdfrx.dart
+++ b/packages/pdfrx/lib/pdfrx.dart
@@ -3,6 +3,7 @@ export 'package:pdfrx_engine/pdfrx_engine.dart';
 
 export 'src/pdf_document_ref.dart';
 export 'src/pdfrx_flutter.dart';
+export 'src/widgets/pdf_page_layout.dart';
 export 'src/widgets/pdf_text_searcher.dart';
 export 'src/widgets/pdf_viewer.dart';
 export 'src/widgets/pdf_viewer_params.dart';

--- a/packages/pdfrx/lib/src/widgets/pdf_page_layout.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_page_layout.dart
@@ -1,0 +1,883 @@
+// Copyright (c) 2024 Espresso Systems Inc.
+// This file is part of pdfrx.
+
+import 'dart:math';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import '../../pdfrx.dart';
+
+/// Helper class to hold layout calculation results.
+class LayoutResult {
+  LayoutResult({required this.pageLayouts, required this.documentSize});
+  final List<Rect> pageLayouts;
+  final Size documentSize;
+}
+
+/// Helper class for viewport calculations with margins.
+///
+/// Bundles viewport size with boundary and content margins, providing
+/// convenient getters for calculating available space and inflating dimensions.
+///
+/// **Example usage:**
+/// ```dart
+/// final helper = PdfLayoutHelper(
+///   viewportSize: viewportSize,
+///   boundaryMargin: params.boundaryMargin,
+///   margin: params.margin,
+/// );
+///
+/// // Get available space for content
+/// final width = helper.availableWidth;
+/// final height = helper.availableHeight;
+///
+/// // Add margins to content dimensions
+/// final totalWidth = helper.widthWithMargins(contentWidth);
+/// ```
+class PdfLayoutHelper {
+  const PdfLayoutHelper({required this.viewportSize, this.boundaryMargin, this.margin = 0.0});
+
+  final Size viewportSize;
+  final EdgeInsets? boundaryMargin;
+  final double margin;
+
+  /// Horizontal boundary margin (0 if infinite or null).
+  double get boundaryMarginHorizontal {
+    return boundaryMargin?.horizontal == double.infinity ? 0 : boundaryMargin?.horizontal ?? 0;
+  }
+
+  /// Vertical boundary margin (0 if infinite or null).
+  double get boundaryMarginVertical {
+    return boundaryMargin?.vertical == double.infinity ? 0 : boundaryMargin?.vertical ?? 0;
+  }
+
+  /// Available width after subtracting boundary margins and content margins (margin * 2).
+  double get availableWidth {
+    return viewportSize.width - boundaryMarginHorizontal - margin * 2;
+  }
+
+  /// Available height after subtracting boundary margins and content margins (margin * 2).
+  double get availableHeight {
+    return viewportSize.height - boundaryMarginVertical - margin * 2;
+  }
+
+  double get viewportWidth => viewportSize.width;
+  double get viewportHeight => viewportSize.height;
+
+  /// Add horizontal boundary margin and content margins to a content width.
+  double widthWithMargins(double contentWidth) {
+    return contentWidth + boundaryMarginHorizontal + margin * 2;
+  }
+
+  /// Add vertical boundary margin and content margins to a content height.
+  double heightWithMargins(double contentHeight) {
+    return contentHeight + boundaryMarginVertical + margin * 2;
+  }
+}
+
+/// Defines page layout.
+///
+/// **Simple usage (backward compatible):**
+/// Create instances directly with pre-computed page layouts:
+/// ```dart
+/// return PdfPageLayout(
+///   pageLayouts: pageLayouts,  // List<Rect> of page positions
+///   documentSize: Size(width, height),
+/// );
+/// ```
+///
+/// **Advanced usage (subclassing):**
+/// For dynamic layouts that respond to viewport changes or fit modes:
+/// 1. Extend this class and override [layoutBuilder] for custom positioning logic
+/// 2. Override [primaryAxis] if not vertical scrolling
+/// 3. Override [calculateFitScale] for custom scaling logic
+///
+/// **Document size and margin handling:**
+/// Use [PdfLayoutHelper.widthWithMargins] and [PdfLayoutHelper.heightWithMargins] to properly
+/// include both boundary margins and content margins in your document size calculations.
+/// The helper handles the complexity of margin application so you don't have to.
+///
+/// **Scaling considerations:**
+/// - [calculateFitScale] returns the scale based on [FitMode] strategy
+/// - This is typically used as the minimum scale for the InteractiveViewer,
+///   unless an explicit [PdfViewerParams.minScale] parameter is set
+/// - Override only if default implementation doesn't fit your layout's needs
+class PdfPageLayout {
+  PdfPageLayout({required this.pageLayouts, required this.documentSize})
+    : primaryAxis = documentSize.height >= documentSize.width ? Axis.vertical : Axis.horizontal {
+    margin = impliedMargin();
+  }
+
+  /// Page rectangles positioned within the document coordinate space.
+  ///
+  /// Each rect represents a page's position and size. The rects include positioning
+  /// with spacing between pages, but the rect dimensions themselves are
+  /// the page sizes WITHOUT margins added to width/height.
+  ///
+  /// Use [getPageRectWithMargins] to get a page rect with margins included.
+  final List<Rect> pageLayouts;
+
+  /// Total document size including content margins.
+  ///
+  /// This is the size of the scrollable content area and includes [margin] spacing
+  /// on all sides. Does NOT include boundary margins - those are handled separately
+  /// at the viewport level.
+  ///
+  final Size documentSize;
+
+  /// The primary scroll axis for this layout.
+  ///
+  /// In the base class, derived from document dimensions: [Axis.vertical] if
+  /// height >= width, otherwise [Axis.horizontal].
+  ///
+  /// Subclasses can override this to use explicit scroll direction instead.
+  /// For example, [SinglePagesLayout] overrides to use its scroll direction parameter.
+  ///
+  /// Determines the direction of scrolling and page layout.
+  final Axis primaryAxis;
+
+  /// Content margin around the document edges.
+  ///
+  /// Calculated automatically via [impliedMargin] based on the spacing
+  /// between page dimensions and document size.
+  ///
+  /// See [getPageRectWithMargins] to get page bounds including margins.
+  late double margin;
+
+  /// Each layout implements its own calculation logic.
+  /// Optional [helper] can be used for fit mode calculations.
+  ///
+  /// The default implementation returns the existing layout, which supports
+  /// backward compatibility with pre-computed layouts.
+  LayoutResult layoutBuilder(List<PdfPage> pages, PdfViewerParams params, {PdfLayoutHelper? helper}) {
+    return LayoutResult(pageLayouts: pageLayouts, documentSize: documentSize);
+  }
+
+  /// Gets the maximum width across all layout units.
+  /// For single page layouts, this is the maximum page width.
+  /// For spread layouts, this can be overridden to return the maximum spread width.
+  double getMaxWidth({bool withMargins = false}) =>
+      pageLayouts.fold(0.0, (maximum, rect) => max(maximum, rect.width)) + (withMargins ? margin * 2 : 0);
+
+  /// Calculates the implied margin based on document size and max page dimensions.
+  /// This assumes pages are centered within the document size.
+  double impliedMargin() => primaryAxis == Axis.vertical
+      ? (documentSize.width - getMaxWidth()) / 2
+      : (documentSize.height - getMaxHeight()) / 2;
+
+  Rect getPageRectWithMargins(int pageNumber) {
+    if (pageNumber < 1 || pageNumber > pageLayouts.length) {
+      throw RangeError('Invalid page number $pageNumber');
+    }
+    final pageRect = pageLayouts[pageNumber - 1];
+    return Rect.fromLTWH(
+      pageRect.left - margin,
+      pageRect.top - margin,
+      pageRect.width + margin * 2,
+      pageRect.height + margin * 2,
+    );
+  }
+
+  /// Gets the maximum height across all layout units.
+  /// For single page layouts, this is the maximum page height.
+  /// For spread layouts, this can be overridden to return the maximum spread height.
+  double getMaxHeight({bool withMargins = false}) =>
+      pageLayouts.fold(0.0, (maximum, rect) => max(maximum, rect.height)) + (withMargins ? margin * 2 : 0);
+
+  /// Gets the dimensions for a specific page number.
+  /// For single page layouts, returns the page dimensions.
+  /// For spread layouts, should return the spread dimensions containing the page.
+  /// Returns null if pageNumber is invalid.
+  Size? getPageDimensions(int pageNumber, {bool withMargins = false}) {
+    if (pageNumber < 1 || pageNumber > pageLayouts.length) {
+      return null;
+    }
+    final pageRect = pageLayouts[pageNumber - 1];
+    return pageRect.size + (withMargins ? Offset(margin * 2, margin * 2) : Offset.zero);
+  }
+
+  /// Calculates page sizes based on fit mode and scroll direction, to enable independent
+  /// page scaling for documents with mixed page sizes to provide optimal viewing experience.
+  ///
+  /// **Scaling behavior:**
+  /// For each page, calculates a scale such that the page PLUS margins fits the viewport:
+  /// `scale = viewport / (pageSize + boundaryMargin + margin*2)`
+  ///
+  /// Returns the scaled page sizes WITHOUT margins included in the dimensions:
+  /// `scaledPageSize = pageSize * scale`
+  ///
+  /// The margins should then applied separately during layout positioning - for example
+  /// see [layoutSequentialPages].
+  ///
+  /// **Normalization:**
+  /// For FitMode.fit and FitMode.fill with multiple pages, cross-axis dimensions are normalized
+  /// to ensure consistent visual spacing when pages have different aspect ratios.
+  ///
+  /// **Use this when:** You want standard PDF scaling behavior but custom positioning logic.
+  ///
+  /// **Example:**
+  /// ```dart
+  /// final sizes = calculatePageSizes(
+  ///   pages: pages,
+  ///   fitMode: FitMode.fill,
+  ///   scrollAxis: Axis.vertical,
+  ///   helper: helper,  // Provides viewport and margin info
+  /// );
+  /// // sizes[i] is the scaled page size (without margins included in the dimensions)
+  /// // Then use sizes for custom layout positioning, adding margins as needed
+  /// ```
+  ///
+  /// See also: [calculateFitScale] for document-level scaling
+  static List<Size> calculatePageSizes({
+    required List<PdfPage> pages,
+    required FitMode fitMode,
+    required Axis scrollAxis,
+    required PdfLayoutHelper helper,
+  }) {
+    if (fitMode == FitMode.none || fitMode == FitMode.cover) {
+      // No scaling, use pdf document dimensions
+      return pages.map((page) => Size(page.width, page.height)).toList();
+    }
+
+    // Calculate initial scales for each page independently
+    final scales = pages.map((page) {
+      return calculateFitScaleForDimensions(
+        width: page.width,
+        height: page.height,
+        helper: helper,
+        mode: fitMode,
+        scrollAxis: scrollAxis,
+      );
+    }).toList();
+
+    // For FitMode.fill and FitMode.fit, normalize scales to ensure uniform cross-axis dimensions
+    if ((fitMode == FitMode.fill || fitMode == FitMode.fit) && scales.length > 1) {
+      final normalizedSizes = _normalizePageSizes(
+        pages: pages,
+        scales: scales,
+        scrollAxis: scrollAxis,
+        fitMode: fitMode,
+        helper: helper,
+      );
+      if (normalizedSizes != null) return normalizedSizes;
+    }
+
+    // Apply calculated scales
+    return List.generate(pages.length, (i) => Size(pages[i].width * scales[i], pages[i].height * scales[i]));
+  }
+
+  /// Normalizes page sizes to ensure uniform cross-axis dimensions for constrained pages.
+  /// Returns null if normalization is not needed or not applicable.
+  ///
+  /// For documents with mixed page sizes, independent page scaling results in varying margins
+  /// so we normalize cross-axis dimensions to be the same for constrained pages, so that the
+  /// margins are consistent between pages.
+  static List<Size>? _normalizePageSizes({
+    required List<PdfPage> pages,
+    required List<double> scales,
+    required Axis scrollAxis,
+    required FitMode fitMode,
+    required PdfLayoutHelper helper,
+  }) {
+    // Find pages that are constrained by the cross-axis (not primary axis)
+    final crossAxisConstrainedPages = <int>[];
+
+    for (var i = 0; i < pages.length; i++) {
+      final page = pages[i];
+      final widthWithMargins = helper.widthWithMargins(page.width);
+      final heightWithMargins = helper.heightWithMargins(page.height);
+
+      final crossAxisScale = scrollAxis == Axis.vertical
+          ? helper.viewportWidth / widthWithMargins
+          : helper.viewportHeight / heightWithMargins;
+      final primaryAxisScale = scrollAxis == Axis.vertical
+          ? helper.viewportHeight / heightWithMargins
+          : helper.viewportWidth / widthWithMargins;
+
+      // For fill mode: always constrained by cross-axis
+      // For fit mode: only if cross-axis is the limiting factor
+      if (fitMode == FitMode.fill || crossAxisScale <= primaryAxisScale) {
+        crossAxisConstrainedPages.add(i);
+      }
+    }
+
+    if (crossAxisConstrainedPages.isEmpty) return null;
+
+    // Calculate cross-axis sizes for constrained pages
+    final constrainedCrossAxisSizes = crossAxisConstrainedPages.map((i) {
+      final page = pages[i];
+      return scrollAxis == Axis.vertical ? page.width * scales[i] : page.height * scales[i];
+    }).toList();
+
+    final minSize = constrainedCrossAxisSizes.reduce(min);
+    final maxSize = constrainedCrossAxisSizes.reduce(max);
+
+    // Only normalize if sizes differ by more than 0.5%
+    const similarityThreshold = 0.005;
+    if ((maxSize - minSize) / minSize <= similarityThreshold) return null;
+
+    // Determine target cross-axis size
+    var targetSize = maxSize;
+
+    // For fit mode, ensure no page exceeds its original fit scale
+    if (fitMode == FitMode.fit) {
+      for (var i in crossAxisConstrainedPages) {
+        final page = pages[i];
+        final pageCrossAxisSize = scrollAxis == Axis.vertical ? page.width : page.height;
+        final requiredScale = targetSize / pageCrossAxisSize;
+
+        if (requiredScale > scales[i]) {
+          targetSize = pageCrossAxisSize * scales[i];
+        }
+      }
+    }
+
+    // Apply normalization
+    return pages.asMap().entries.map((entry) {
+      final i = entry.key;
+      final page = entry.value;
+
+      if (crossAxisConstrainedPages.contains(i)) {
+        // Normalize to target cross-axis size
+        final pageCrossAxisSize = scrollAxis == Axis.vertical ? page.width : page.height;
+        final newScale = targetSize / pageCrossAxisSize;
+        return Size(page.width * newScale, page.height * newScale);
+      } else {
+        // Keep original scale for primary-axis constrained pages
+        return Size(page.width * scales[i], page.height * scales[i]);
+      }
+    }).toList();
+  }
+
+  /// Calculate the scale factor for given dimensions based on fit mode.
+  /// This is the core logic used by both [calculatePageSizes] and [calculateFitScale].
+  ///
+  /// **Important:** Margins are in PDF points and scale with content. The calculation accounts
+  /// for this by dividing viewport by (width + margin*2), ensuring the scaled page + scaled margins
+  /// fit within the viewport.
+  ///
+  /// **Note:** [FitMode.cover] is not supported here as it requires document-level dimensions.
+  /// Use [calculateFitScale] instead for cover mode.
+  static double calculateFitScaleForDimensions({
+    required double width,
+    required double height,
+    required PdfLayoutHelper helper,
+    required FitMode mode,
+    required Axis scrollAxis,
+  }) {
+    assert(mode != FitMode.cover, 'FitMode.cover requires document-level calculation. Use calculateFitScale instead.');
+
+    // Both margins and boundaryMargins are in PDF points and scale with the content
+    // So we need: scale = viewport / (pageSize + margin*2 + boundaryMargin)
+    // This ensures: (pageSize + margin*2 + boundaryMargin) * scale = viewport
+    final widthWithMargins = helper.widthWithMargins(width);
+    final heightWithMargins = helper.heightWithMargins(height);
+
+    switch (mode) {
+      case FitMode.fit:
+        // Scale to fit viewport (letterbox) - content + all margins must fit
+        return min(helper.viewportWidth / widthWithMargins, helper.viewportHeight / heightWithMargins);
+
+      case FitMode.fill:
+        // Scale to fill cross-axis - content + all margins on cross-axis must fit
+        return scrollAxis == Axis.vertical
+            ? helper.viewportWidth / widthWithMargins
+            : helper.viewportHeight / heightWithMargins;
+
+      case FitMode.cover:
+        // Cover mode not supported at page level - requires full document dimensions
+        // This should be caught by the assertion above
+        throw UnsupportedError('FitMode.cover requires document-level calculation');
+
+      case FitMode.none:
+        return 1.0;
+    }
+  }
+
+  /// Positions pre-sized pages sequentially along a scroll axis.
+  ///
+  /// This is a building block for creating simple scrolling layouts. It handles the
+  /// geometry of positioning pages one after another, with optional centering
+  /// perpendicular to the scroll direction.
+  ///
+  /// **Use this when:** You have pre-calculated page sizes and need to position them
+  /// sequentially (vertical or horizontal scrolling).
+  ///
+  /// **Parameters:**
+  /// - [pageSizes]: Pre-calculated size for each page
+  /// - [scrollAxis]: Direction of scrolling (vertical or horizontal)
+  /// - [margin]: Margin around pages
+  /// - [centerPerpendicular]: Whether to center pages perpendicular to scroll axis
+  ///
+  /// **Example:**
+  /// ```dart
+  /// final sizes = pages.map((p) => Size(p.width, p.height)).toList();
+  /// return layoutSequentialPages(
+  ///   pageSizes: sizes,
+  ///   scrollAxis: Axis.vertical,
+  ///   margin: 8.0,
+  ///   centerPerpendicular: true,
+  /// );
+  /// ```
+  LayoutResult layoutSequentialPages({
+    required List<Size> pageSizes,
+    required Axis scrollAxis,
+    required double margin,
+    bool centerPerpendicular = false,
+  }) {
+    final isVertical = scrollAxis == Axis.vertical;
+    final pageLayouts = <Rect>[];
+    var scrollPosition = margin;
+    var maxCrossAxis = 0.0;
+
+    // Track max cross-axis dimension (needed for centering and document size)
+    for (var size in pageSizes) {
+      maxCrossAxis = max(maxCrossAxis, isVertical ? size.width : size.height);
+    }
+
+    // Layout pages along scroll axis
+    for (var size in pageSizes) {
+      final rect = isVertical
+          ? Rect.fromLTWH(margin, scrollPosition, size.width, size.height)
+          : Rect.fromLTWH(scrollPosition, margin, size.width, size.height);
+      pageLayouts.add(rect);
+      scrollPosition += (isVertical ? size.height : size.width) + margin;
+    }
+
+    // Center perpendicular to scroll if requested
+    final finalLayouts = centerPerpendicular
+        ? pageLayouts.map((rect) {
+            if (isVertical) {
+              final xOffset = (maxCrossAxis - rect.width) / 2;
+              return rect.translate(xOffset, 0);
+            } else {
+              final yOffset = (maxCrossAxis - rect.height) / 2;
+              return rect.translate(0, yOffset);
+            }
+          }).toList()
+        : pageLayouts;
+
+    final docSize = isVertical
+        ? Size(maxCrossAxis + margin * 2, scrollPosition)
+        : Size(scrollPosition, maxCrossAxis + margin * 2);
+
+    return LayoutResult(pageLayouts: finalLayouts, documentSize: docSize);
+  }
+
+  /// Calculates the scale to display content according to the [FitMode] strategy.
+  ///
+  /// This value determines how content should be scaled based on the fit mode and is
+  /// typically used as the minimum scale for the InteractiveViewer (though an explicit
+  /// [PdfViewerParams.minScale] parameter may override this).
+  ///
+  /// **Calculation:**
+  /// Uses the maximum page dimensions from [getMaxWidth] and [getMaxHeight], then calculates:
+  /// `scale = viewport / (maxPageDimension + boundaryMargin + margin*2)`
+  ///
+  /// This ensures the largest page plus all margins fits within the viewport when scaled.
+  ///
+  /// **Return value behavior by mode:**
+  /// - [FitMode.fit]: Scale to fit largest page + margins within viewport (both axes)
+  /// - [FitMode.fill]: Scale to fill viewport on cross-axis (width for vertical scroll)
+  /// - [FitMode.cover]: Scale to fill viewport on largest axis (may crop content)
+  /// - [FitMode.none]: Returns 1.0 (no scaling)
+  ///
+  /// **Custom layouts:**
+  /// Override this method for custom scaling logic, or override [getMaxWidth] and [getMaxHeight]
+  /// to change the dimensions used (e.g., spread width instead of page width).
+  ///
+  /// See also: [calculatePageSizes] for page-level scaling
+  double calculateFitScale(PdfLayoutHelper helper, FitMode mode, {int? pageNumber}) {
+    // FitMode.cover is special - it uses different logic
+    if (mode == FitMode.cover) {
+      final double width;
+      final double height;
+
+      // This matches legacy _coverScale calculation: viewport / (documentSize + boundaryMargin)
+      width = documentSize.width;
+      height = documentSize.height;
+      final widthWithMargins = width + helper.boundaryMarginHorizontal;
+      final heightWithMargins = height + helper.boundaryMarginVertical;
+      return max(helper.viewportWidth / widthWithMargins, helper.viewportHeight / heightWithMargins);
+    }
+
+    final width = getMaxWidth();
+    final height = getMaxHeight();
+
+    // Use the core calculation logic for fit/fill/none
+    return calculateFitScaleForDimensions(
+      width: width,
+      height: height,
+      helper: helper,
+      mode: mode,
+      scrollAxis: primaryAxis,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! PdfPageLayout) return false;
+    // Use runtimeType to ensure subclasses with additional fields aren't considered equal
+    if (runtimeType != other.runtimeType) return false;
+    return listEquals(pageLayouts, other.pageLayouts) && documentSize == other.documentSize;
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, Object.hashAll(pageLayouts), documentSize);
+}
+
+/// Spread-aware layout base class.
+///
+/// This class extends [PdfPageLayout] to support layouts that group multiple pages
+/// into "spreads" (e.g., facing pages). It provides spread-specific functionality
+/// while maintaining compatibility with the base page layout system.
+///
+/// **Key concepts:**
+/// - A "spread" is a layout unit that may contain one or more pages
+/// - [spreadLayouts] contains the bounds of each spread (indexed by spread index, 0-based)
+/// - [pageToSpreadIndex] maps page numbers (1-based) to spread indices (0-based)
+///
+/// **Example: Facing pages layout**
+/// - Page 1 (cover): spread 0
+/// - Pages 2-3: spread 1
+/// - Pages 4-5: spread 2
+/// - pageToSpreadIndex = [0, 1, 1, 2, 2, ...]  (0-based: index 0 = page 1)
+/// - spreadLayouts = [Rect(cover bounds), Rect(pages 2-3 bounds), Rect(pages 4-5 bounds), ...]
+abstract class PdfSpreadLayout extends PdfPageLayout {
+  PdfSpreadLayout({
+    required super.pageLayouts,
+    required super.documentSize,
+    required this.spreadLayouts,
+    required this.pageToSpreadIndex,
+  });
+
+  /// List of spread bounds, indexed by spread index
+  ///
+  /// Each Rect represents the bounds of one spread in document coordinates.
+  /// Use [getSpreadBounds] to get the spread for a specific page number.
+  final List<Rect> spreadLayouts;
+
+  /// Maps page number to spread index.
+  ///
+  /// - Example: `pageToSpreadIndex[0]` = spread index for page 1
+  final List<int> pageToSpreadIndex;
+
+  /// Get the spread index for a given page number.
+  int getSpreadIndex(int pageNumber) => pageToSpreadIndex[pageNumber - 1];
+
+  /// Get the spread bounds for a given page number.
+  Rect getSpreadBounds(int pageNumber) {
+    return spreadLayouts[pageToSpreadIndex[pageNumber - 1]];
+  }
+
+  /// Get the page range (first, last) for the spread containing pageNumber.
+  ({int first, int last}) getPageRange(int pageNumber) {
+    final spreadIndex = pageToSpreadIndex[pageNumber - 1];
+    var first = -1;
+    var last = -1;
+    for (var i = 0; i < pageToSpreadIndex.length; i++) {
+      if (pageToSpreadIndex[i] == spreadIndex) {
+        if (first == -1) first = i + 1; // Convert to 1-based
+        last = i + 1; // Convert to 1-based
+      }
+    }
+    return (first: first, last: last);
+  }
+
+  /// Get the first page number of the spread containing pageNumber.
+  int getSpreadFirstPage(int pageNumber) => getPageRange(pageNumber).first;
+
+  /// Get the last page number of the spread containing pageNumber.
+  int getSpreadLastPage(int pageNumber) => getPageRange(pageNumber).last;
+
+  /// Get the first page number of a spread by its index.
+  int? getFirstPageOfSpread(int spreadIndex) {
+    if (spreadIndex < 0 || spreadIndex >= spreadLayouts.length) {
+      return null;
+    }
+    for (var i = 0; i < pageToSpreadIndex.length; i++) {
+      if (pageToSpreadIndex[i] == spreadIndex) {
+        return i + 1; // Convert to 1-based page number
+      }
+    }
+    return null;
+  }
+
+  /// Gets the spread dimensions for a page number
+  @override
+  Size? getPageDimensions(int pageNumber, {bool withMargins = false}) {
+    if (pageNumber < 1 || pageNumber > pageToSpreadIndex.length) {
+      return null;
+    }
+    final spreadBounds = getSpreadBounds(pageNumber);
+    return spreadBounds.size + (withMargins ? Offset(margin * 2, margin * 2) : Offset.zero);
+  }
+
+  /// Gets the maximum spread width across all spreads.
+  @override
+  double getMaxWidth({bool withMargins = false}) {
+    final maxWidthNoMargins = spreadLayouts.fold(0.0, (maximum, rect) => max(maximum, rect.width));
+    return maxWidthNoMargins + (withMargins ? margin * 2 : 0);
+  }
+
+  /// Gets the maximum spread height across all spreads.
+  @override
+  double getMaxHeight({bool withMargins = false}) {
+    final maxHeightNoMargins = spreadLayouts.fold(0.0, (maximum, rect) => max(maximum, rect.height));
+    return maxHeightNoMargins + (withMargins ? margin * 2 : 0);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! PdfSpreadLayout) return false;
+    return super == other &&
+        listEquals(spreadLayouts, other.spreadLayouts) &&
+        listEquals(pageToSpreadIndex, other.pageToSpreadIndex);
+  }
+
+  @override
+  int get hashCode => Object.hash(super.hashCode, Object.hashAll(spreadLayouts), Object.hashAll(pageToSpreadIndex));
+}
+
+/// Single pages layout implementation supporting both vertical and horizontal scrolling.
+///
+/// This layout displays pages one after another in either a vertical or horizontal
+/// scrolling direction. The scroll direction is specified when creating the layout.
+///
+/// Example usage:
+/// ```dart
+/// // Vertical scrolling (default)
+/// layoutPages: (pages, params, {viewport}) =>
+///   SinglePagesLayout.fromPages(pages, params, helper: helper),
+///
+/// // Horizontal scrolling
+/// layoutPages: (pages, params, {viewport}) =>
+///   SinglePagesLayout.fromPages(
+///     pages,
+///     params,
+///     helper: helper,
+///     scrollDirection: Axis.horizontal,
+///   ),
+/// ```
+class SinglePagesLayout extends PdfPageLayout {
+  SinglePagesLayout({required super.pageLayouts, required super.documentSize, required this.scrollDirection});
+
+  /// Create a single pages layout from pages and parameters.
+  ///
+  /// The [scrollDirection] parameter determines whether pages scroll vertically (default)
+  /// or horizontally.
+  factory SinglePagesLayout.fromPages(
+    List<PdfPage> pages,
+    PdfViewerParams params, {
+    PdfLayoutHelper? helper,
+    Axis scrollDirection = Axis.vertical,
+  }) {
+    final layout = SinglePagesLayout(pageLayouts: [], documentSize: Size.zero, scrollDirection: scrollDirection);
+    final result = layout.layoutBuilder(pages, params, helper: helper);
+    return SinglePagesLayout(
+      pageLayouts: result.pageLayouts,
+      documentSize: result.documentSize,
+      scrollDirection: scrollDirection,
+    );
+  }
+
+  final Axis scrollDirection;
+
+  @override
+  Axis get primaryAxis => scrollDirection;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! SinglePagesLayout) return false;
+    return super == other && scrollDirection == other.scrollDirection;
+  }
+
+  @override
+  int get hashCode => Object.hash(super.hashCode, scrollDirection);
+
+  @override
+  LayoutResult layoutBuilder(List<PdfPage> pages, PdfViewerParams params, {PdfLayoutHelper? helper}) {
+    assert(helper != null, 'SinglePagesLayout requires PdfLayoutHelper for fit modes other than none or cover');
+    final pageSizes = PdfPageLayout.calculatePageSizes(
+      pages: pages,
+      fitMode: params.fitMode,
+      scrollAxis: scrollDirection,
+      helper: helper!,
+    );
+
+    final centerPerpendicular =
+        params.fitMode == FitMode.fit || params.fitMode == FitMode.none || params.fitMode == FitMode.cover;
+
+    return layoutSequentialPages(
+      pageSizes: pageSizes,
+      scrollAxis: scrollDirection,
+      margin: params.margin,
+      centerPerpendicular: centerPerpendicular,
+    );
+  }
+}
+
+/// Facing pages layout implementation.
+class FacingPagesLayout extends PdfSpreadLayout {
+  FacingPagesLayout({
+    required super.pageLayouts,
+    required super.documentSize,
+    required super.spreadLayouts,
+    required super.pageToSpreadIndex,
+  });
+
+  /// Create a facing pages layout from pages and parameters.
+  factory FacingPagesLayout.fromPages(
+    List<PdfPage> pages,
+    PdfViewerParams params, {
+    PdfLayoutHelper? helper,
+    bool firstPageIsCoverPage = false,
+    bool isRightToLeftReadingOrder = false,
+    double gutter = 4.0, // gap between left/right pages
+  }) {
+    if (pages.isEmpty) {
+      return FacingPagesLayout(pageLayouts: [], documentSize: Size.zero, spreadLayouts: [], pageToSpreadIndex: []);
+    }
+
+    // For fit/fill/cover modes with viewport scaling, we need helper
+    final scaleToViewport =
+        params.fitMode == FitMode.fit || params.fitMode == FitMode.fill || params.fitMode == FitMode.cover;
+    assert(
+      !scaleToViewport || helper != null,
+      'FitMode.${params.fitMode.name} requires PdfLayoutHelper for FacingPagesLayout.',
+    );
+    if (scaleToViewport && helper == null) {
+      return FacingPagesLayout(pageLayouts: [], documentSize: Size.zero, spreadLayouts: [], pageToSpreadIndex: []);
+    }
+
+    final pageLayouts = <Rect>[];
+    final spreadLayouts = <Rect>[];
+    final pageToSpreadIndex = List<int>.filled(pages.length, 0);
+    var y = params.margin;
+    var spreadIndex = 0;
+    var pageIndex = 0;
+
+    // Available space for content
+    final availableWidth = scaleToViewport ? helper!.availableWidth : 0.0;
+    final availableHeight = scaleToViewport ? helper!.availableHeight : 0.0;
+
+    // Handle cover page if needed
+    if (firstPageIsCoverPage && pages.isNotEmpty) {
+      final coverPage = pages[0];
+      final coverSize = scaleToViewport
+          ? _calculatePageSize(
+              page: coverPage,
+              targetWidth: availableWidth,
+              availableHeight: availableHeight,
+              fitMode: params.fitMode,
+            )
+          : Size(coverPage.width, coverPage.height);
+
+      final coverX = scaleToViewport ? params.margin + (availableWidth - coverSize.width) / 2 : params.margin;
+      pageLayouts.add(Rect.fromLTWH(coverX, y, coverSize.width, coverSize.height));
+      pageToSpreadIndex[0] = spreadIndex; // Page 1 is at index 0
+      spreadLayouts.add(pageLayouts.last);
+
+      spreadIndex++;
+      y += coverSize.height + params.margin;
+      pageIndex = 1;
+    }
+
+    // Process remaining pages as spreads (pairs)
+    while (pageIndex < pages.length) {
+      final leftPage = pages[pageIndex];
+      final rightPageIndex = pageIndex + 1;
+      final rightPage = rightPageIndex < pages.length ? pages[rightPageIndex] : null;
+
+      // Calculate page dimensions
+      final leftSize = scaleToViewport
+          ? _calculatePageSize(
+              page: leftPage,
+              targetWidth: rightPage != null ? (availableWidth - gutter) / 2 : availableWidth,
+              availableHeight: availableHeight,
+              fitMode: params.fitMode,
+            )
+          : Size(leftPage.width, leftPage.height);
+
+      final rightSize = rightPage != null && scaleToViewport
+          ? _calculatePageSize(
+              page: rightPage,
+              targetWidth: (availableWidth - gutter) / 2,
+              availableHeight: availableHeight,
+              fitMode: params.fitMode,
+            )
+          : Size(rightPage?.width ?? 0.0, rightPage?.height ?? 0.0);
+
+      // Calculate spread dimensions
+      final spreadWidth = rightPage != null ? leftSize.width + gutter + rightSize.width : leftSize.width;
+      final spreadHeight = max(leftSize.height, rightSize.height);
+      final spreadX = scaleToViewport ? params.margin + (availableWidth - spreadWidth) / 2 : params.margin;
+
+      spreadLayouts.add(Rect.fromLTWH(spreadX, y, spreadWidth, spreadHeight));
+
+      // Layout pages within spread (RTL vs LTR)
+      final leftX = isRightToLeftReadingOrder && rightPage != null ? spreadX + rightSize.width + gutter : spreadX;
+      final rightX = isRightToLeftReadingOrder ? spreadX : spreadX + leftSize.width + gutter;
+
+      pageLayouts.add(Rect.fromLTWH(leftX, y + (spreadHeight - leftSize.height) / 2, leftSize.width, leftSize.height));
+      pageToSpreadIndex[pageIndex] = spreadIndex; // 0-based indexing
+
+      if (rightPage != null) {
+        pageLayouts.add(
+          Rect.fromLTWH(rightX, y + (spreadHeight - rightSize.height) / 2, rightSize.width, rightSize.height),
+        );
+        pageToSpreadIndex[rightPageIndex] = spreadIndex; // 0-based indexing
+      }
+
+      spreadIndex++;
+      y += spreadHeight + params.margin;
+      pageIndex += rightPage != null ? 2 : 1;
+    }
+
+    // Calculate document width based on content
+    final maxSpreadRight = spreadLayouts.fold(0.0, (maximum, rect) => max(maximum, rect.right));
+    final documentWidth = maxSpreadRight + params.margin;
+
+    return FacingPagesLayout(
+      pageLayouts: pageLayouts,
+      documentSize: Size(documentWidth, y),
+      spreadLayouts: spreadLayouts,
+      pageToSpreadIndex: pageToSpreadIndex,
+    );
+  }
+
+  @override
+  Axis get primaryAxis => Axis.vertical; // Typically vertical for facing pages
+
+  @override
+  LayoutResult layoutBuilder(List<PdfPage> pages, PdfViewerParams params, {PdfLayoutHelper? helper}) {
+    // For the base layoutBuilder, use default parameters (no cover, LTR, no gutter)
+    final layout = FacingPagesLayout.fromPages(
+      pages,
+      params,
+      helper: helper,
+      firstPageIsCoverPage: false,
+      isRightToLeftReadingOrder: false,
+      gutter: 0.0,
+    );
+    return LayoutResult(pageLayouts: layout.pageLayouts, documentSize: layout.documentSize);
+  }
+}
+
+/// FacingPagesLayout Helper function to calculate page dimensions for a single page
+Size _calculatePageSize({
+  required PdfPage page,
+  required double targetWidth,
+  required double availableHeight,
+  required FitMode fitMode,
+}) {
+  if (fitMode == FitMode.fit) {
+    final scale = min(targetWidth / page.width, availableHeight / page.height);
+    return Size(page.width * scale, page.height * scale);
+  } else {
+    final scale = targetWidth / page.width;
+    return Size(targetWidth, page.height * scale);
+  }
+}


### PR DESCRIPTION
### Overview
This is a draft PR for an enhanced page layout system that provides support for more complex layouts and page/document scaling, and includes some 'out of the box' implementations for common layouts.

#### 1. **Page Layout System** (`pdf_page_layout.dart`)
Extends upon the existing page layout system as follows:

- **`PdfPageLayout`** - Base class for all page layouts has been enhanced
  - Supports custom layout strategies via `layoutBuilder` callback
  - Provides `calculateFitScale()` for FitMode-aware scaling
  - Maintains backward compatibility with direct instantiation, but with a new helper argument added to the signature for backwards compatible page layouts:
 
> ```dart
>   typedef PdfPageLayoutFunction =
>    PdfPageLayout Function(List<PdfPage> pages, PdfViewerParams params, PdfLayoutHelper helper);
> ```


> ```dart
> class PdfPageLayout {
>   PdfPageLayout({required this.pageLayouts, required this.documentSize});
>   
>   // NEW: Dynamic layout calculation support
>   final LayoutBuilder? layoutBuilder;
>   
>   // NEW: Automatic primary axis detection
>   final Axis primaryAxis;
>   
>   // NEW: Built-in FitMode calculations
>   double calculateFitScale(PdfLayoutHelper helper, FitMode mode, {int? pageNumber});
>   
>   // NEW: Page size calculations for different modes
>   List<Size> calculatePageSizes({required PdfLayoutHelper helper, required FitMode mode});
>   
>   // ... plus helper methods for common operations
> }
> 
> ```

- **`PdfSpreadLayout`** - Abstract base for spread-aware layouts (facing pages, book mode)
  - Provides `pageToSpreadIndex` mapping for efficient page-to-spread lookups
  - Supports spread-specific scaling calculations
  - Setup to support future 'discrete' page transition mode [see separate PR that incorporates this]

- **`SinglePagesLayout`** - Single-column page layout (default)
  - Pages arranged in a single vertical or horizontal column
  - Independently scales pages of different sizes and aspect ratios according to FitMode for optimal viewing experience
  - Supports cross-axis centering of pages
  
- **`FacingPagesLayout`** - Facing pages (book-style) layout
  - Groups pages into spreads with optional cover page
  - Calculates scale based on spread width rather than individual page width

- **`PdfLayoutHelper`** - Utility class for viewport and margin calculations
  - Simplifies margin handling (boundary margins + content margins)
  - Provides convenient getters for available space calculations that custom PdfPageLayout classes can use

#### 2. **FitMode Support** (`pdf_viewer_params.dart`)
Introduces `FitMode` enum for controlling how pages are scaled to fit the viewport:

- **`FitMode.fit`** - Fit entire page within viewport (shows whole page, may have letterboxing)
- **`FitMode.fill`** - Fill viewport on cross-axis (width for vertical scroll, height for horizontal)
- **`FitMode.cover`** - Fill viewport completely (may crop content on one axis)
- **`FitMode.none`** - No automatic scaling (1:1 scale)

`FitMode.fit` provides equivalent behavior to `useAlternativeFitScaleAsMinScale`, and the proposal is to deprecate the latter in preference to the former. 

`FitMode.cover` provides equivalent behavior to the default scaling where `useAlternativeFitScaleAsMinScale` was false.

#### 3. **Scroll Thumb Enhancements** (`pdf_viewer_scroll_thumb.dart`)
- Added `visiblePageRangeBuilder` for displaying page ranges (e.g., "1-4" for spreads) - also useful for other layouts where zooming out would display multiple pages at once
- Added `useVisiblePageRange` parameter to enable range display
- Automatically uses `controller.visiblePageRange` when available


https://github.com/user-attachments/assets/8f961ad7-460e-4406-8881-9fb73856c5fa


https://github.com/user-attachments/assets/12b2ad4f-3ff2-446a-9b95-0199f2ffe0c0


