### PR TITLE
Add handleOffset to PdfTextSelectionParams

### DIFF
--- a/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
@@ -2186,17 +2186,18 @@ class _PdfViewerState extends State<PdfViewer>
       final builder = widget.params.textSelectionParams?.buildSelectionHandle ?? _buildDefaultSelectionHandle;
 
       if (_textSelA != null) {
+        final offset = widget.params.textSelectionParams?.handleOffset?.call(_textSelA!) ?? Offset.zero;
         switch (_textSelA!.direction) {
           case PdfTextDirection.ltr:
           case PdfTextDirection.unknown:
-            aRight = viewSize.width - rectA.left;
-            aBottom = viewSize.height - rectA.top;
+            aRight = viewSize.width - rectA.left - offset.dx;
+            aBottom = viewSize.height - rectA.top - offset.dy;
           case PdfTextDirection.rtl:
-            aLeft = rectA.right;
-            aBottom = viewSize.height - rectA.top;
+            aLeft = rectA.right + offset.dx;
+            aBottom = viewSize.height - rectA.top - offset.dy;
           case PdfTextDirection.vrtl:
-            aLeft = rectA.right;
-            aBottom = viewSize.height - rectA.top;
+            aLeft = rectA.right + offset.dx;
+            aBottom = viewSize.height - rectA.top - offset.dy;
         }
         anchorA = builder(
           context,
@@ -2209,17 +2210,18 @@ class _PdfViewerState extends State<PdfViewer>
         );
       }
       if (_textSelB != null) {
+        final offset = widget.params.textSelectionParams?.handleOffset?.call(_textSelB!) ?? Offset.zero;
         switch (_textSelB!.direction) {
           case PdfTextDirection.ltr:
           case PdfTextDirection.unknown:
-            bLeft = rectB.right;
-            bTop = rectB.bottom;
+            bLeft = rectB.right + offset.dx;
+            bTop = rectB.bottom + offset.dy;
           case PdfTextDirection.rtl:
-            bRight = viewSize.width - rectB.left;
-            bTop = rectB.bottom;
+            bRight = viewSize.width - rectB.left - offset.dx;
+            bTop = rectB.bottom + offset.dy;
           case PdfTextDirection.vrtl:
-            bRight = viewSize.width - rectB.left;
-            bTop = rectB.bottom;
+            bRight = viewSize.width - rectB.left - offset.dx;
+            bTop = rectB.bottom + offset.dy;
         }
         anchorB = builder(
           context,

--- a/packages/pdfrx/lib/src/widgets/pdf_viewer_params.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer_params.dart
@@ -741,6 +741,7 @@ class PdfTextSelectionParams {
     this.enableSelectionHandles,
     this.showContextMenuAutomatically,
     this.buildSelectionHandle,
+    this.handleOffset,
     this.onTextSelectionChange,
     this.magnifier,
   });
@@ -767,6 +768,12 @@ class PdfTextSelectionParams {
   /// - If the function is null, the default anchor handle will be used.
   final PdfViewerTextSelectionAnchorHandleBuilder? buildSelectionHandle;
 
+  /// Optional callback to calculate the offset for the anchor handles.
+  ///
+  /// This callback is called for each anchor handle to determine the offset
+  /// to apply to the handle's default position. If null, defaults to [Offset.zero].
+  final PdfViewerHandleOffsetCallback? handleOffset;
+
   /// Function to be notified when the text selection is changed.
   final PdfViewerTextSelectionChangeCallback? onTextSelectionChange;
 
@@ -778,6 +785,7 @@ class PdfTextSelectionParams {
     if (identical(this, other)) return true;
     return other is PdfTextSelectionParams &&
         other.buildSelectionHandle == buildSelectionHandle &&
+        other.handleOffset == handleOffset &&
         other.onTextSelectionChange == onTextSelectionChange &&
         other.enableSelectionHandles == enableSelectionHandles &&
         other.showContextMenuAutomatically == showContextMenuAutomatically &&
@@ -787,6 +795,7 @@ class PdfTextSelectionParams {
   @override
   int get hashCode =>
       buildSelectionHandle.hashCode ^
+      handleOffset.hashCode ^
       onTextSelectionChange.hashCode ^
       enableSelectionHandles.hashCode ^
       showContextMenuAutomatically.hashCode ^
@@ -913,6 +922,17 @@ typedef PdfViewerTextSelectionAnchorHandleBuilder =
       PdfTextSelectionAnchor anchor,
       PdfViewerTextSelectionAnchorHandleState state,
     );
+
+/// Function to calculate the offset for an anchor handle.
+///
+/// This callback is called for each anchor handle to determine the offset
+/// to apply to the handle's default position.
+///
+/// The callback receives the [PdfTextSelectionAnchor] and should return an [Offset]
+/// that positions the handle widget relative to the anchor point:
+/// - For anchor A (LTR): default anchor point is text's top-left, widget's bottom-right
+/// - For anchor B (LTR): default anchor point is text's bottom-right, widget's top-left
+typedef PdfViewerHandleOffsetCallback = Offset Function(PdfTextSelectionAnchor anchor);
 
 /// Function to be notified when the text selection is changed.
 ///


### PR DESCRIPTION
This non-breaking change enables an optional handleOffset to be applied for handle anchor positioning to enable native appearance anchors for iOS and Android - see iOS example attached.

![IMG_14D74C115530-1](https://github.com/user-attachments/assets/30b6031f-4856-4590-806e-d6755080ee2e)
