### PR TITLE
doc: Performance Considerations

### DIFF
--- a/doc/Performance-Considerations.md
+++ b/doc/Performance-Considerations.md
@@ -1,0 +1,3 @@
+# Performance Considerations
+
+After `pdfrx` is first initialized, memory from Pdfium will not be cleaned up until the application terminates. Please see [#430](https://github.com/espresso3389/pdfrx/issues/430) and [#184](https://github.com/espresso3389/pdfrx/issues/184) for more info.


### PR DESCRIPTION
Follow up to #519.

Although the memory from Pdfium not cleaned up on close may not be relevant for all users, it is good to mention in the docs as it can be a deciding factor in choosing what pdf package to use (or to roll your own on web).