### PR TITLE
Smooth Scroll & Zoom interactions

### DIFF
--- a/packages/pdfrx/lib/pdfrx.dart
+++ b/packages/pdfrx/lib/pdfrx.dart
@@ -3,9 +3,12 @@ export 'package:pdfrx_engine/pdfrx_engine.dart';
 
 export 'src/pdf_document_ref.dart';
 export 'src/pdfrx_flutter.dart';
+export 'src/utils/fixed_overscroll_physics.dart';
 export 'src/widgets/pdf_text_searcher.dart';
 export 'src/widgets/pdf_viewer.dart';
 export 'src/widgets/pdf_viewer_params.dart';
 export 'src/widgets/pdf_viewer_scroll_thumb.dart';
 export 'src/widgets/pdf_widgets.dart';
-export 'src/utils/fixed_overscroll_physics.dart';
+export 'src/widgets/scroll_interaction/pdf_viewer_scroll_interaction_delegate.dart';
+export 'src/widgets/scroll_interaction/pdf_viewer_scroll_interaction_delegate_instant.dart';
+export 'src/widgets/scroll_interaction/pdf_viewer_scroll_interaction_delegate_physics.dart';

--- a/packages/pdfrx/lib/src/widgets/interactive_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/interactive_viewer.dart
@@ -83,6 +83,7 @@ class InteractiveViewer extends StatefulWidget {
     this.alignment,
     this.trackpadScrollCausesScale = false,
     this.onWheelDelta,
+    this.onPointerScale,
     this.scrollPhysics,
     this.scrollPhysicsScale,
     this.scrollPhysicsAutoAdjustBoundaries = true,
@@ -131,6 +132,7 @@ class InteractiveViewer extends StatefulWidget {
     this.alignment,
     this.trackpadScrollCausesScale = false,
     this.onWheelDelta,
+    this.onPointerScale,
     this.scrollPhysics,
     this.scrollPhysicsScale,
     this.scrollPhysicsAutoAdjustBoundaries = true,
@@ -393,6 +395,9 @@ class InteractiveViewer extends StatefulWidget {
   /// To override the default mouse wheel behavior.
   ///
   final void Function(PointerScrollEvent event)? onWheelDelta;
+
+  /// To override the default pointer scale behavior.
+  final void Function(PointerScaleEvent event)? onPointerScale;
 
   // Used as the coefficient of friction in the inertial translation animation.
   // This value was eyeballed to give a feel similar to Google Photos.
@@ -1135,6 +1140,10 @@ class InteractiveViewerState extends State<InteractiveViewer> with TickerProvide
       }
       scaleChange = math.exp(-event.scrollDelta.dy / widget.scaleFactor);
     } else if (event is PointerScaleEvent) {
+      if (widget.onPointerScale != null) {
+        widget.onPointerScale!(event);
+        return;
+      }
       scaleChange = event.scale;
     } else {
       return;

--- a/packages/pdfrx/lib/src/widgets/pdf_viewer_params.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer_params.dart
@@ -50,6 +50,7 @@ class PdfViewerParams {
     this.onPageChanged,
     this.getPageRenderingScale,
     this.scrollByMouseWheel = 0.2,
+    this.scaleByPointerScale = 1.0,
     this.scrollHorizontallyByMouseWheel = false,
     this.enableKeyboardNavigation = true,
     this.scrollByArrowKey = 25.0,
@@ -73,6 +74,7 @@ class PdfViewerParams {
     this.forceReload = false,
     this.scrollPhysics,
     this.scrollPhysicsScale,
+    this.interactionDelegateProvider = const PdfViewerScrollInteractionDelegateProviderInstant(),
   });
 
   /// Margin around the page.
@@ -352,6 +354,15 @@ class PdfViewerParams {
   /// null to disable scroll-by-mouse-wheel.
   final double? scrollByMouseWheel;
 
+  /// Scale sensitivity for pointer scale events (e.g. Trackpad pinch) and Ctrl+Scroll zoom interactions.
+  ///
+  /// Defaults to 1.0.
+  /// *   Values < 1.0 reduce the zoom speed (finer control).
+  /// *   Values > 1.0 increase the zoom speed (faster).
+  ///
+  /// This factor is applied to the raw scale delta received from the platform to determine the target zoom level.
+  final double scaleByPointerScale;
+
   /// If true, the scroll direction is horizontal when the mouse wheel is scrolled in primary direction.
   final bool scrollHorizontallyByMouseWheel;
 
@@ -563,6 +574,14 @@ class PdfViewerParams {
   /// Scroll physics for scaling within the viewer. If null, it uses the same value as [scrollPhysics].
   final ScrollPhysics? scrollPhysicsScale;
 
+  /// Provider to create a delegate that handles scroll/zoom interactions (Mouse Wheel / Trackpad).
+  ///
+  /// Defaults to [PdfViewerScrollInteractionDelegateProviderInstant] which provides
+  /// instant updates (legacy behavior).
+  ///
+  /// To enable smooth, physics-based animations, use [PdfViewerScrollInteractionDelegateProviderPhysics].
+  final PdfViewerScrollInteractionDelegateProvider interactionDelegateProvider;
+
   /// A convenience function to get platform-specific default scroll physics.
   ///
   /// On iOS/MacOS this is [BouncingScrollPhysics], and on Android this is [FixedOverscrollPhysics], a
@@ -601,13 +620,15 @@ class PdfViewerParams {
         other.scaleEnabled != scaleEnabled ||
         other.interactionEndFrictionCoefficient != interactionEndFrictionCoefficient ||
         other.scrollByMouseWheel != scrollByMouseWheel ||
+        other.scaleByPointerScale != scaleByPointerScale ||
         other.scrollHorizontallyByMouseWheel != scrollHorizontallyByMouseWheel ||
         other.enableKeyboardNavigation != enableKeyboardNavigation ||
         other.scrollByArrowKey != scrollByArrowKey ||
         other.horizontalCacheExtent != horizontalCacheExtent ||
         other.verticalCacheExtent != verticalCacheExtent ||
         other.linkHandlerParams != linkHandlerParams ||
-        other.scrollPhysics != scrollPhysics;
+        other.scrollPhysics != scrollPhysics ||
+        other.interactionDelegateProvider != interactionDelegateProvider;
   }
 
   @override
@@ -648,6 +669,7 @@ class PdfViewerParams {
         other.onPageChanged == onPageChanged &&
         other.getPageRenderingScale == getPageRenderingScale &&
         other.scrollByMouseWheel == scrollByMouseWheel &&
+        other.scaleByPointerScale == scaleByPointerScale &&
         other.scrollHorizontallyByMouseWheel == scrollHorizontallyByMouseWheel &&
         other.enableKeyboardNavigation == enableKeyboardNavigation &&
         other.scrollByArrowKey == scrollByArrowKey &&
@@ -668,7 +690,8 @@ class PdfViewerParams {
         other.keyHandlerParams == keyHandlerParams &&
         other.behaviorControlParams == behaviorControlParams &&
         other.forceReload == forceReload &&
-        other.scrollPhysics == scrollPhysics;
+        other.scrollPhysics == scrollPhysics &&
+        other.interactionDelegateProvider == interactionDelegateProvider;
   }
 
   @override
@@ -707,6 +730,7 @@ class PdfViewerParams {
         onPageChanged.hashCode ^
         getPageRenderingScale.hashCode ^
         scrollByMouseWheel.hashCode ^
+        scaleByPointerScale.hashCode ^
         scrollHorizontallyByMouseWheel.hashCode ^
         enableKeyboardNavigation.hashCode ^
         scrollByArrowKey.hashCode ^
@@ -727,7 +751,8 @@ class PdfViewerParams {
         keyHandlerParams.hashCode ^
         behaviorControlParams.hashCode ^
         forceReload.hashCode ^
-        scrollPhysics.hashCode;
+        scrollPhysics.hashCode ^
+        interactionDelegateProvider.hashCode;
   }
 }
 

--- a/packages/pdfrx/lib/src/widgets/scroll_interaction/pdf_viewer_scroll_interaction_delegate.dart
+++ b/packages/pdfrx/lib/src/widgets/scroll_interaction/pdf_viewer_scroll_interaction_delegate.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/gestures.dart' show PointerScrollEvent;
+import 'package:flutter/scheduler.dart' show Ticker;
+import 'package:flutter/widgets.dart';
+
+import '../../../pdfrx.dart' show PdfViewerParams;
+import '../pdf_viewer.dart';
+import '../pdf_viewer_params.dart' show PdfViewerParams;
+
+/// Interface for a factory that creates [PdfViewerScrollInteractionDelegate] instances.
+///
+/// ### Why use a Provider class instead of a simple closure?
+/// [PdfViewerParams] relies on `operator ==` to determine if the viewer needs to be
+/// reloaded or updated. If we allowed passing a simple closure (e.g. `() => MyDelegate()`)
+/// in the params, it would likely be a different object instance on every `build` call,
+/// forcing the [PdfViewer] to dispose and recreate the delegate constantly.
+///
+/// By using a `const` Provider class with a proper `operator ==` implementation, we ensure
+/// that the delegate lifecycle is stable across rebuilds.
+abstract class PdfViewerScrollInteractionDelegateProvider {
+  const PdfViewerScrollInteractionDelegateProvider();
+
+  /// Creates the runtime delegate instance.
+  ///
+  /// This is called by [PdfViewerState] when the widget initializes or when the
+  /// provider configuration changes.
+  PdfViewerScrollInteractionDelegate create();
+
+  /// Subclasses must implement equality to prevent unnecessary delegate recreation.
+  @override
+  bool operator ==(Object other);
+
+  @override
+  int get hashCode;
+}
+
+/// The "Brain" for handling desktop-style pointer interactions (Mouse Wheel, Trackpad).
+///
+/// This delegate decouples the **Intent** (e.g., "User wants to pan 50 pixels") from
+/// the **Execution** (e.g., "Jump immediately" vs "Animate with friction").
+///
+/// Lifecycle:
+/// 1. [create] is called by the Provider.
+/// 2. [init] is called when the controller is attached.
+/// 3. [pan] / [zoom] are called on user interaction.
+/// 4. [stop] is called when the user interrupts (e.g., touches the screen).
+/// 5. [dispose] is called when the viewer is destroyed.
+abstract class PdfViewerScrollInteractionDelegate {
+  /// Called when the [PdfViewerState] is ready.
+  ///
+  /// [controller]: Used to read/write the transformation matrix.
+  /// [vsync]: Used to create [Ticker]s for physics-based animations.
+  void init(PdfViewerController controller, TickerProvider vsync);
+
+  /// Called when the delegate is being destroyed.
+  /// Implementations should dispose of any Tickers or listeners here.
+  void dispose();
+
+  /// Called when the user initiates a competing interaction (e.g., Touch Pan, Pinch Zoom).
+  ///
+  /// Implementations **must** stop any ongoing animations immediately to prevent
+  /// "fighting" with the user's gesture (e.g., don't keep animating scroll down
+  /// if the user is dragging up).
+  void stop();
+
+  /// Request a pan (scroll) operation.
+  ///
+  /// [delta] is the requested move distance in **viewport logical pixels**.
+  /// (e.g., [PointerScrollEvent.scrollDelta]).
+  void pan(Offset delta);
+
+  /// Request a zoom operation.
+  ///
+  /// [scale] is the relative scale factor (e.g., `1.1` means "increase zoom by 10%").
+  /// [focalPoint] is the pixel position in the viewport that should remain stationary
+  /// during the zoom (the anchor point).
+  void zoom(double scale, Offset focalPoint);
+}

--- a/packages/pdfrx/lib/src/widgets/scroll_interaction/pdf_viewer_scroll_interaction_delegate_instant.dart
+++ b/packages/pdfrx/lib/src/widgets/scroll_interaction/pdf_viewer_scroll_interaction_delegate_instant.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/widgets.dart';
+
+import '../pdf_viewer.dart';
+import 'pdf_viewer_scroll_interaction_delegate.dart';
+
+/// A provider that creates a [PdfViewerScrollInteractionDelegate] with **Instant** behavior.
+///
+/// This implementation applies scroll and zoom deltas immediately to the controller
+/// without any animation or physics. It replicates the legacy behavior of `pdfrx`.
+///
+/// Use this if you prefer a "raw" feel or need to minimize CPU usage.
+class PdfViewerScrollInteractionDelegateProviderInstant extends PdfViewerScrollInteractionDelegateProvider {
+  const PdfViewerScrollInteractionDelegateProviderInstant();
+
+  @override
+  PdfViewerScrollInteractionDelegate create() => _PdfViewerScrollInteractionDelegateInstant();
+
+  @override
+  bool operator ==(Object other) => other is PdfViewerScrollInteractionDelegateProviderInstant;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+/// Implementation of [PdfViewerScrollInteractionDelegate] that applies changes instantly.
+///
+/// This implementation performs no animation/tweening. It directly calculates the
+/// target matrix and sets it on the controller.
+class _PdfViewerScrollInteractionDelegateInstant implements PdfViewerScrollInteractionDelegate {
+  PdfViewerController? _controller;
+
+  @override
+  void init(PdfViewerController controller, TickerProvider vsync) {
+    _controller = controller;
+  }
+
+  @override
+  void dispose() {
+    _controller = null;
+  }
+
+  @override
+  void stop() {
+    // No animations to stop in the instant implementation.
+  }
+
+  @override
+  void pan(Offset delta) {
+    final controller = _controller;
+    if (controller == null || !controller.isReady) {
+      return;
+    }
+
+    // Clone the current matrix to apply translations.
+    final m = controller.value.clone();
+
+    // The [delta] is in viewport pixels. To translate the content within the matrix,
+    // we must divide by the current zoom level.
+    // e.g. If zoomed in 2x, moving 10 pixels on screen means moving 5 pixels in the document space.
+    // We *add* the delta because the matrix represents the content position.
+    m.translateByDouble(delta.dx, delta.dy, 0, 1);
+
+    // Apply the new matrix, ensuring it stays within the configured boundaries.
+    controller.value = controller.makeMatrixInSafeRange(m, forceClamp: true);
+  }
+
+  @override
+  void zoom(double scale, Offset focalPoint) {
+    final controller = _controller;
+    if (controller == null || !controller.isReady) {
+      return;
+    }
+
+    final currentZoom = controller.currentZoom;
+    final params = controller.params;
+
+    // Calculate the target zoom level, clamped to the min/max allowed by params.
+    final newZoom = (currentZoom * scale).clamp(params.minScale, params.maxScale);
+
+    // Optimization: Ignore negligible changes to prevent unnecessary rebuilds.
+    if ((newZoom - currentZoom).abs() < 0.0001) {
+      return;
+    }
+
+    // Apply the zoom instantly using the controller's helper, which handles
+    // the matrix math to keep [focalPoint] stationary.
+    controller.zoomOnLocalPosition(localPosition: focalPoint, newZoom: newZoom, duration: Duration.zero);
+  }
+}

--- a/packages/pdfrx/lib/src/widgets/scroll_interaction/pdf_viewer_scroll_interaction_delegate_physics.dart
+++ b/packages/pdfrx/lib/src/widgets/scroll_interaction/pdf_viewer_scroll_interaction_delegate_physics.dart
@@ -1,0 +1,255 @@
+import 'dart:math' as math;
+
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+import 'package:vector_math/vector_math_64.dart' as vec;
+
+import '../pdf_viewer.dart';
+import 'pdf_viewer_scroll_interaction_delegate.dart';
+
+/// A provider that creates a [PdfViewerScrollInteractionDelegate] with **Physics-based** behavior.
+///
+/// This implementation provides smooth, additive animations for scroll (pan) and zoom interactions,
+/// similar to browser or desktop OS behavior.
+///
+/// It uses exponential decay to smoothly transition to the target state, allowing for
+/// "catch-up" animations when rapid events (like continuous scroll wheel or trackpad gestures) occur.
+class PdfViewerScrollInteractionDelegateProviderPhysics extends PdfViewerScrollInteractionDelegateProvider {
+  const PdfViewerScrollInteractionDelegateProviderPhysics({this.panFriction = 12.0, this.zoomFriction = 12.0});
+
+  /// Friction factor for panning. Higher means stops faster. Default 12.0.
+  ///
+  /// Controls the "weight" of the scroll physics.
+  final double panFriction;
+
+  /// Friction factor for zooming. Higher means stops faster. Default 12.0.
+  ///
+  /// Controls the "weight" of the zoom physics.
+  final double zoomFriction;
+
+  @override
+  PdfViewerScrollInteractionDelegate create() =>
+      _PdfViewerScrollInteractionDelegatePhysics(panFriction: panFriction, zoomFriction: zoomFriction);
+
+  @override
+  bool operator ==(Object other) =>
+      other is PdfViewerScrollInteractionDelegateProviderPhysics &&
+      other.panFriction == panFriction &&
+      other.zoomFriction == zoomFriction;
+
+  @override
+  int get hashCode => Object.hash(panFriction, zoomFriction);
+}
+
+/// Implementation of [PdfViewerScrollInteractionDelegate] that uses physics simulations
+/// to animate pan and zoom transitions.
+///
+/// This delegate handles [Ticker] management to drive the animations frame-by-frame.
+class _PdfViewerScrollInteractionDelegatePhysics implements PdfViewerScrollInteractionDelegate {
+  _PdfViewerScrollInteractionDelegatePhysics({required this.panFriction, required this.zoomFriction});
+
+  final double panFriction;
+  final double zoomFriction;
+
+  PdfViewerController? _controller;
+  TickerProvider? _vsync;
+
+  // --- Pan Physics State ---
+  Ticker? _panTicker;
+
+  /// The target translation offset (tx, ty) the physics simulation is moving towards.
+  Offset? _panTarget;
+  Duration? _lastPanFrameTime;
+
+  // --- Zoom Physics State ---
+  Ticker? _zoomTicker;
+
+  /// The target zoom level the physics simulation is scaling towards.
+  double? _zoomTarget;
+  Duration? _lastZoomFrameTime;
+  Offset? _lastFocalPoint;
+
+  /// Pixel distance threshold to stop animation
+  static const double _kEpsilon = 0.5;
+
+  /// Scale threshold to stop animation
+  static const double _kScaleEpsilon = 0.0001;
+
+  @override
+  void init(PdfViewerController controller, TickerProvider vsync) {
+    _controller = controller;
+    _vsync = vsync;
+  }
+
+  @override
+  void dispose() {
+    stop();
+    _controller = null;
+    _vsync = null;
+  }
+
+  @override
+  void stop() {
+    _panTicker?.dispose();
+    _panTicker = null;
+    _panTarget = null;
+
+    _zoomTicker?.dispose();
+    _zoomTicker = null;
+    _zoomTarget = null;
+  }
+
+  @override
+  void pan(Offset delta) {
+    final controller = _controller;
+    final vsync = _vsync;
+    if (controller == null || !controller.isReady || vsync == null) {
+      return;
+    }
+
+    // Stop zoom if panning starts.
+    // Explicit panning (e.g. scroll wheel) takes precedence over an ongoing zoom animation.
+    _zoomTicker?.dispose();
+    _zoomTicker = null;
+    _zoomTarget = null;
+
+    // Initialize target with current translation if not already animating
+    if (_panTarget == null) {
+      final currentTrans = controller.value.getTranslation();
+      _panTarget = Offset(currentTrans.x, currentTrans.y);
+    }
+
+    // Accumulate delta.
+    // [delta] is "viewport pixels to move".
+    // e.g. Scroll Down -> delta.y is negative -> visual content moves up -> matrix translation y decreases.
+    // So we add the delta to the target translation.
+    _panTarget = _panTarget! + delta;
+
+    if (_panTicker == null) {
+      _lastPanFrameTime = null;
+      _panTicker = vsync.createTicker(_onPanTick)..start();
+    }
+  }
+
+  void _onPanTick(Duration elapsed) {
+    final controller = _controller;
+    if (controller == null || _panTarget == null) {
+      _panTicker?.dispose();
+      _panTicker = null;
+      return;
+    }
+
+    final dt = _lastPanFrameTime == null
+        ? (1.0 / 60.0) // assuming 60 FPS for the first frame
+        : (elapsed - _lastPanFrameTime!).inMicroseconds / 1000000.0;
+    _lastPanFrameTime = elapsed;
+
+    final currentTransVec = controller.value.getTranslation();
+    final currentTrans = Offset(currentTransVec.x, currentTransVec.y);
+
+    final diff = _panTarget! - currentTrans;
+
+    // Stop if close enough to target
+    if (diff.distance < _kEpsilon) {
+      _applyTranslation(_panTarget!);
+      _panTicker?.dispose();
+      _panTicker = null;
+      _panTarget = null;
+      return;
+    }
+
+    // Exponential Decay: Move a percentage of the remaining distance
+    final alpha = 1.0 - math.exp(-panFriction * dt);
+    final newTrans = currentTrans + diff * alpha;
+
+    _applyTranslation(newTrans);
+  }
+
+  void _applyTranslation(Offset translation) {
+    final controller = _controller;
+    if (controller == null) return;
+
+    // Reconstruct matrix with new translation, preserving current rotation/scale
+    final currentMatrix = controller.value;
+
+    final newMatrix = currentMatrix.clone();
+    newMatrix.setTranslation(vec.Vector3(translation.dx, translation.dy, 0.0));
+
+    // Apply and clamp to boundaries
+    controller.value = controller.makeMatrixInSafeRange(newMatrix, forceClamp: true);
+
+    // Update target if we hit a boundary to prevent "sticky" physics trying to push through.
+    // If the actual translation after clamping differs significantly from the requested translation,
+    // we adjust the target to match the clamped reality for that axis.
+    final actualTransVec = controller.value.getTranslation();
+    final actualTrans = Offset(actualTransVec.x, actualTransVec.y);
+
+    if (_panTarget != null) {
+      // If we clamped, adjust the target so we don't keep trying to move past edge
+      if ((actualTrans.dx - translation.dx).abs() > 1.0) {
+        _panTarget = Offset(actualTrans.dx, _panTarget!.dy);
+      }
+      if ((actualTrans.dy - translation.dy).abs() > 1.0) {
+        _panTarget = Offset(_panTarget!.dx, actualTrans.dy);
+      }
+    }
+  }
+
+  @override
+  void zoom(double scaleFactor, Offset focalPoint) {
+    final controller = _controller;
+    final vsync = _vsync;
+    if (controller == null || !controller.isReady || vsync == null) return;
+
+    // Stop pan if zoom starts
+    _panTicker?.dispose();
+    _panTicker = null;
+    _panTarget = null;
+
+    final currentZoom = controller.currentZoom;
+    _zoomTarget ??= currentZoom;
+
+    // Apply accumulated scale to target
+    _zoomTarget = (_zoomTarget! * scaleFactor).clamp(controller.minScale, controller.params.maxScale);
+
+    // Update last focal point for the animation tick
+    _lastFocalPoint = focalPoint;
+
+    if (_zoomTicker == null) {
+      _lastZoomFrameTime = null;
+      _zoomTicker = vsync.createTicker(_onZoomTick)..start();
+    }
+  }
+
+  void _onZoomTick(Duration elapsed) {
+    final controller = _controller;
+    if (controller == null || _zoomTarget == null || _lastFocalPoint == null) {
+      _zoomTicker?.dispose();
+      _zoomTicker = null;
+      return;
+    }
+
+    final dt = _lastZoomFrameTime == null ? 1.0 / 60.0 : (elapsed - _lastZoomFrameTime!).inMicroseconds / 1000000.0;
+    _lastZoomFrameTime = elapsed;
+
+    final currentZoom = controller.currentZoom;
+    final diff = _zoomTarget! - currentZoom;
+
+    // Stop if close enough
+    if (diff.abs() < _kScaleEpsilon) {
+      // Snap to target
+      controller.zoomOnLocalPosition(localPosition: _lastFocalPoint!, newZoom: _zoomTarget!, duration: Duration.zero);
+      _zoomTicker?.dispose();
+      _zoomTicker = null;
+      _zoomTarget = null;
+      return;
+    }
+
+    // Exponential Decay
+    final alpha = 1.0 - math.exp(-zoomFriction * dt);
+    final newZoom = currentZoom + diff * alpha;
+
+    // Use controller's helper which handles the matrix math to keep focal point stationary
+    controller.zoomOnLocalPosition(localPosition: _lastFocalPoint!, newZoom: newZoom, duration: Duration.zero);
+  }
+}


### PR DESCRIPTION
*(I initially created this pull request on the wrong branch, so this pull request now is correct and replaces https://github.com/espresso3389/pdfrx/pull/580)*

Currently, mouse wheel scrolling and trackpad zooming in `pdfrx` feel "janky" because they translate inputs directly into instant matrix updates. While functional, it lacks the smooth, organic feel users expect from modern web browsers or native PDF readers. Rapid inputs (like a fast scroll wheel) result in jarring visual jumps rather than fluid motion.

We wanted to bring the high-quality, physics-based animation feel to `pdfrx` without forcing a breaking change on existing users.

### The Solution: Pluggable Interaction Architecture
To solve this, we refactored the input handling logic out of the core widget and into a delegate pattern:

*   **`PdfViewerScrollInteractionDelegate`**: An abstract base class that defines how `pan` and `zoom` requests are executed.
*   **`PdfViewerScrollInteractionDelegateProvider`**: A factory pattern used in `PdfViewerParams`. We use a provider class (instead of a simple callback) to ensure `const` equality works correctly, preventing unnecessary delegate recreation/disposals during widget rebuilds.

We implemented two concrete versions:
1.  **`...ProviderInstant` (Default)**: Replicates the exact behavior of the current version. Inputs result in immediate matrix updates. **This ensures no breaking changes for existing users.**
2.  **`...ProviderPhysics` (New)**: Uses `Ticker`s and exponential decay math to animate transitions. It handles "additive" animation, meaning if you scroll while an animation is running, the velocity accumulates smoothly rather than resetting. This feels significantly better on Desktop and Web.

### Additional Improvements
While refactoring the input logic, we added:
*   **Shift + Scroll Support**: Holding `Shift` while scrolling the mouse wheel now triggers horizontal scrolling, a standard desktop interaction pattern that was previously missing.
*   **Trackpad Pinch / Browser Zoom**: We improved how `PointerScaleEvent` (e.g., trackpad pinch or Ctrl+Scroll in some browsers) is handled, routing it through the same delegate system for consistent behavior.

### How to Use
To enable the new smooth scrolling, users simply pass the physics provider in the params.

```dart
PdfViewer.asset(
  'assets/document.pdf',
  params: PdfViewerParams(
    // Enable the physics-based interaction
    interactionDelegateProvider: const PdfViewerScrollInteractionDelegateProviderPhysics(),
    
    // Optional: Tune sensitivity (see below)
    scrollByMouseWheel: 1.0, 
    scaleByPointerScale: 0.3,
  ),
);
```

### Configuration & Recommended Values
We introduced a new parameter `scaleByPointerScale` to `PdfViewerParams`.
*   This acts as a sensitivity multiplier for trackpad pinch events and Ctrl+Scroll zooming.
*   **Default:** `1.0` (Preserves legacy behavior/sensitivity).

**Our Recommendation:**
The default sensitivity values felt to aggressive when zooming and to little when scrolling to us. We found these values provide a better feel:
*   `scrollByMouseWheel`: **1.0** (Default is 0.2)
*   `scaleByPointerScale`: **0.3** (Default is 1.0)

### Closing
Thanks for building `pdfrx`! It is a fantastic library. We hope this architectural improvement helps make it the go-to choice for high-fidelity Flutter PDF viewing on all platforms. We would love to see this merged!