### PR TITLE
Fix pdfrxInitialize race condition

### DIFF
--- a/packages/pdfrx_engine/lib/src/native/worker.dart
+++ b/packages/pdfrx_engine/lib/src/native/worker.dart
@@ -30,7 +30,7 @@ class BackgroundWorker {
       _sendPort = await receivePort.first as SendPort;
 
       // propagate the pdfium module path to the worker
-      _compute((params) {
+      await _compute((params) {
         Pdfrx.pdfiumModulePath = params.modulePath;
         Pdfrx.pdfiumNativeBindings = params.bindings;
       }, (modulePath: Pdfrx.pdfiumModulePath, bindings: Pdfrx.pdfiumNativeBindings));


### PR DESCRIPTION
Pure-Dart pdfrxInitialize downloads dynamic library to a temp directory, but then fails to open it because of race condition in setting Pdfrx.pdfiumModulePath.

Pdfrx.pdfiumModulePath value is set in pdfrxInitialize, but the value needs to be propagated to isolate.

The isolate is started in BackgroundWorker, but it starts with Pdfrx.pdfiumModulePath set to null. Before BackgroundWorker manages to set isolate's Pdfrx.pdfiumModulePath, initialization code tries to open pdfium.dll/.so. It ends up with
```
ArgumentError (Invalid argument(s): Failed to load dynamic library 'pdfium.dll': The specified module could not be found.
 (error code: 126))
```

Solution is to wait for Pdfrx.pdfiumModulePath to be set when creating the isolate.
