### PR TITLE
Fix openData deadlock: use FPDF_LoadMemDocument for in-memory data

### DIFF
--- a/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
+++ b/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
@@ -295,6 +295,10 @@ class PdfrxEntryFunctionsImpl implements PdfrxEntryFunctions {
     required int? maxSizeToCacheOnMemory,
     required void Function()? onDispose,
   }) {
+    // Data is already in memory; always use FPDF_LoadMemDocument to avoid
+    // PdfiumFileAccess callback path which deadlocks on repeated open/close.
+    maxSizeToCacheOnMemory ??= data.length;
+
     return openCustom(
       read: (buffer, position, size) {
         if (position + size > data.length) {


### PR DESCRIPTION
Hi,

Thank you for developing pdfrx.  It's nice to use not blocking library like this from flutter.

I have one problem.  My app is using openData after loading entire pdf, but it hangs in the middle of openData often if I open >10MB pdf.

I notice openData receives a Uint8List that is already fully in memory. However, when the fileSize exceeds maxSizeToCacheOnMemory (default 1MB), openCustom falls through to FPDF_LoadCustomDocument which uses PdfiumFileAccess with condition variables. This path deadlocks after repeated open/close cycles.

Since the data is already in memory, I modify the code always use FPDF_LoadMemDocument by setting maxSizeToCacheOnMemory to data.length when not specified.

After this modification, openData is very stable for me.  Please consider to use this patch or disable condition variable path in openData.  Thank you!