### PR TITLE
Fix crash in loadStructuredText when text starts with newline

### DIFF
--- a/packages/pdfrx_engine/lib/src/pdf_text_formatter.dart
+++ b/packages/pdfrx_engine/lib/src/pdf_text_formatter.dart
@@ -189,7 +189,7 @@ final class PdfTextFormatter {
     for (final match in _reNewLine.allMatches(inputFullText)) {
       if (lineStart < match.start) {
         handleLine(lineStart, match.start, newLineEnd: match.end);
-      } else {
+      } else if (outputCharRects.isNotEmpty) {
         final lastRect = outputCharRects.last;
         outputCharRects.add(PdfRect(lastRect.left, lastRect.top, lastRect.left, lastRect.bottom));
         outputText.write('\n');


### PR DESCRIPTION
## Summary

- `PdfTextFormatter.format()` crashes with `StateError: Bad state: No element` when PDF text begins with a newline character
- When the first character is a newline, `outputCharRects` is still empty at the point where the code accesses `.last`
- Added `isNotEmpty` guard to prevent the crash

## Reproduction

Load a PDF page where the structured text content starts with a `\n` character and call `loadStructuredText()`.

## Fix

Added `outputCharRects.isNotEmpty` check before accessing `outputCharRects.last` in the newline handling branch of `PdfTextFormatter.format()`.