### PR TITLE
Fix stream closed crash on document dispose race condition

### DIFF
--- a/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
+++ b/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
@@ -659,7 +659,7 @@ class _PdfDocumentPdfium extends PdfDocument {
   /// Notify missing fonts by sending [PdfDocumentMissingFontsEvent].
   Future<void> _notifyMissingFonts() async {
     final lastMissingFonts = await _getAndClearMissingFonts();
-    if (lastMissingFonts.isNotEmpty) {
+    if (lastMissingFonts.isNotEmpty && !isDisposed) {
       subject.add(PdfDocumentMissingFontsEvent(this, lastMissingFonts));
     }
   }
@@ -704,7 +704,9 @@ class _PdfDocumentPdfium extends PdfDocument {
   }
 
   void _notifyDocumentLoadComplete() {
-    subject.add(PdfDocumentLoadCompleteEvent(this));
+    if (!isDisposed) {
+      subject.add(PdfDocumentLoadCompleteEvent(this));
+    }
   }
 
   /// Loads pages in the document in a time-limited manner.
@@ -890,7 +892,9 @@ class _PdfDocumentPdfium extends PdfDocument {
     }
 
     _pages = List.unmodifiable(pages);
-    subject.add(PdfDocumentPageStatusChangedEvent(this, changes: changes));
+    if (!isDisposed) {
+      subject.add(PdfDocumentPageStatusChangedEvent(this, changes: changes));
+    }
   }
 
   /// Don't handle [_pages] directly unless you really understand what you're doing; use [pages] getter/setter instead.

--- a/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
+++ b/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
@@ -1110,7 +1110,9 @@ class _PdfDocumentPdfium extends PdfDocument {
   }
 
   void _notifyDocumentLoadComplete() {
-    subject.add(PdfDocumentLoadCompleteEvent(this));
+    if (!isDisposed) {
+      subject.add(PdfDocumentLoadCompleteEvent(this));
+    }
   }
 
   /// Loads pages in the document in a time-limited manner.
@@ -1296,7 +1298,9 @@ class _PdfDocumentPdfium extends PdfDocument {
     }
 
     _pages = List.unmodifiable(pages);
-    subject.add(PdfDocumentPageStatusChangedEvent(this, changes: changes));
+    if (!isDisposed) {
+      subject.add(PdfDocumentPageStatusChangedEvent(this, changes: changes));
+    }
   }
 
   /// Don't handle [_pages] directly unless you really understand what you're doing; use [pages] getter/setter instead.


### PR DESCRIPTION
## Summary

- `subject.add()` throws `StateError: Cannot add event after closing` when a PDF document is disposed while background operations are still running
- This is a race condition between `dispose()` (which closes the stream) and async operations like page loading and font checking that try to emit events after disposal
- Added `isDisposed` guards before all `subject.add()` calls in three locations

## Affected methods

- `_notifyMissingFonts()` — can fire after async `_getAndClearMissingFonts()` completes post-dispose
- `_notifyDocumentLoadComplete()` — can be called after progressive page loading completes post-dispose
- `pages` setter — can emit `PdfDocumentPageStatusChangedEvent` after dispose

## Fix

Added `!isDisposed` checks before each `subject.add()` call to silently skip event emission when the document has already been disposed.