### PR TITLE
Fix #585: Stop swallowing KeyUpEvent for keys pdfrx did not handle

### DIFF
--- a/packages/pdfrx/lib/src/widgets/internals/pdf_viewer_key_handler.dart
+++ b/packages/pdfrx/lib/src/widgets/internals/pdf_viewer_key_handler.dart
@@ -6,7 +6,7 @@ import 'package:flutter/services.dart';
 import '../../../pdfrx.dart';
 
 /// A widget that handles key events for the PDF viewer.
-class PdfViewerKeyHandler extends StatelessWidget {
+class PdfViewerKeyHandler extends StatefulWidget {
   const PdfViewerKeyHandler({
     required this.child,
     required this.onKeyRepeat,
@@ -24,33 +24,46 @@ class PdfViewerKeyHandler extends StatelessWidget {
   final Widget child;
 
   @override
+  State<PdfViewerKeyHandler> createState() => _PdfViewerKeyHandlerState();
+}
+
+class _PdfViewerKeyHandlerState extends State<PdfViewerKeyHandler> {
+  // Tracks keys whose KeyDown we reported as handled, so we can also claim
+  // their matching KeyUp. Unhandled keys (e.g. Android system back) must fall
+  // through to let the platform process them. See #585.
+  final _handledKeys = <LogicalKeyboardKey>{};
+
+  @override
   Widget build(BuildContext context) {
     final childBuilder = Builder(
       builder: (context) {
         final focusNode = Focus.maybeOf(context);
         if (focusNode == null) {
-          return child;
+          return widget.child;
         }
-        return ListenableBuilder(listenable: focusNode, builder: (context, _) => child);
+        return ListenableBuilder(listenable: focusNode, builder: (context, _) => widget.child);
       },
     );
-    if (!params.enabled) {
+    if (!widget.params.enabled) {
       return childBuilder;
     }
 
     return Focus(
-      focusNode: params.focusNode,
-      parentNode: params.parentNode,
-      autofocus: params.autofocus,
-      canRequestFocus: params.canRequestFocus,
-      onFocusChange: onFocusChange,
+      focusNode: widget.params.focusNode,
+      parentNode: widget.params.parentNode,
+      autofocus: widget.params.autofocus,
+      canRequestFocus: widget.params.canRequestFocus,
+      onFocusChange: widget.onFocusChange,
       onKeyEvent: (node, event) {
         if (event is KeyDownEvent || event is KeyRepeatEvent) {
-          if (onKeyRepeat(params, event.logicalKey, event is KeyDownEvent)) {
+          if (widget.onKeyRepeat(widget.params, event.logicalKey, event is KeyDownEvent)) {
+            _handledKeys.add(event.logicalKey);
             return KeyEventResult.handled;
           }
         } else if (event is KeyUpEvent) {
-          return KeyEventResult.handled;
+          if (_handledKeys.remove(event.logicalKey)) {
+            return KeyEventResult.handled;
+          }
         }
         return KeyEventResult.ignored;
       },

--- a/packages/pdfrx/test/pdf_viewer_key_handler_test.dart
+++ b/packages/pdfrx/test/pdf_viewer_key_handler_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdfrx/pdfrx.dart';
+import 'package:pdfrx/src/widgets/internals/pdf_viewer_key_handler.dart';
+
+void main() {
+  Future<KeyEventResult?> sendKeyEvent(WidgetTester tester, KeyEvent event) async {
+    final focusNode = Focus.of(tester.element(find.byType(SizedBox)));
+    return focusNode.onKeyEvent?.call(focusNode, event);
+  }
+
+  testWidgets('KeyUp is ignored when KeyDown was not handled (regression for #585)', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PdfViewerKeyHandler(
+          params: const PdfViewerKeyHandlerParams(),
+          onKeyRepeat: (_, _, _) => false,
+          child: const SizedBox(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    const downEvent = KeyDownEvent(
+      physicalKey: PhysicalKeyboardKey.escape,
+      logicalKey: LogicalKeyboardKey.escape,
+      timeStamp: Duration.zero,
+    );
+    const upEvent = KeyUpEvent(
+      physicalKey: PhysicalKeyboardKey.escape,
+      logicalKey: LogicalKeyboardKey.escape,
+      timeStamp: Duration.zero,
+    );
+
+    expect(await sendKeyEvent(tester, downEvent), KeyEventResult.ignored);
+    expect(await sendKeyEvent(tester, upEvent), KeyEventResult.ignored);
+  });
+
+  testWidgets('KeyUp is handled only when KeyDown was handled', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PdfViewerKeyHandler(
+          params: const PdfViewerKeyHandlerParams(),
+          onKeyRepeat: (_, key, _) => key == LogicalKeyboardKey.arrowDown,
+          child: const SizedBox(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    const handledDown = KeyDownEvent(
+      physicalKey: PhysicalKeyboardKey.arrowDown,
+      logicalKey: LogicalKeyboardKey.arrowDown,
+      timeStamp: Duration.zero,
+    );
+    const handledUp = KeyUpEvent(
+      physicalKey: PhysicalKeyboardKey.arrowDown,
+      logicalKey: LogicalKeyboardKey.arrowDown,
+      timeStamp: Duration.zero,
+    );
+    const otherUp = KeyUpEvent(
+      physicalKey: PhysicalKeyboardKey.arrowUp,
+      logicalKey: LogicalKeyboardKey.arrowUp,
+      timeStamp: Duration.zero,
+    );
+
+    expect(await sendKeyEvent(tester, handledDown), KeyEventResult.handled);
+    expect(await sendKeyEvent(tester, handledUp), KeyEventResult.handled);
+    expect(await sendKeyEvent(tester, handledUp), KeyEventResult.ignored);
+    expect(await sendKeyEvent(tester, otherUp), KeyEventResult.ignored);
+  });
+}


### PR DESCRIPTION
## Summary

- `PdfViewerKeyHandler` unconditionally returned `KeyEventResult.handled` for every `KeyUpEvent`, so once the viewer had focus Android never saw the `KeyUp` for the system back button and the predictive-back gesture failed to complete.
- Track the set of `LogicalKeyboardKey` values whose `KeyDown` we actually handled and only claim the matching `KeyUp`. Other keys fall through to the platform.
- Adds a widget test covering both the regression (unhandled KeyUp must pass through) and the positive case (handled KeyDown ⇒ handled KeyUp).

Fixes #585.

## Test plan
- [x] `flutter test test/pdf_viewer_key_handler_test.dart`
- [x] Manually verified on Android 16 (physical device) with `example/pdf_combine`: pinch-zoom → predictive-back gesture navigates correctly, no regression in keyboard navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)