### PR TITLE
Fix #618: Guard _getFocusNode against deactivated BuildContext

### DIFF
--- a/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
@@ -3210,7 +3210,12 @@ class _PdfViewerState extends State<PdfViewer>
   }
 
   FocusNode? _getFocusNode() {
-    return _contextForFocusNode != null ? Focus.maybeOf(_contextForFocusNode!) : null;
+    final ctx = _contextForFocusNode;
+    // The context may be deactivated when the viewer is disposed mid-gesture
+    // (e.g. onLinkTap navigates to another screen before the tap finishes).
+    // Touching a deactivated element's ancestor inherited widgets asserts.
+    if (ctx == null || !ctx.mounted) return null;
+    return Focus.maybeOf(ctx);
   }
 
   void _requestFocus() {


### PR DESCRIPTION
## Summary

- If the user's `onLinkTap` synchronously navigates to another screen, the `PdfViewer` element is deactivated while the gesture pipeline is still running. `_requestFocus` then reached `Focus.maybeOf` with a deactivated `BuildContext`, which asserts in `dependOnInheritedWidgetOfExactType` (\"Looking up a deactivated widget's ancestor is unsafe\").
- Check `context.mounted` before performing the inherited-widget lookup so `_getFocusNode` returns `null` for a disposed viewer instead of crashing.

Fixes #618.

## Test plan
- [x] `flutter analyze`
- [ ] Manually: open a PDF with many links, tap a link, immediately navigate away — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)