### PR TITLE
Fix #587: NaN/Infinity toInt in InteractiveViewer fling end

### DIFF
--- a/packages/pdfrx/lib/src/widgets/interactive_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/interactive_viewer.dart
@@ -1746,7 +1746,11 @@ enum _GestureType { pan, scale, rotate }
 // Given a velocity and drag, calculate the time at which motion will come to
 // a stop, within the margin of effectivelyMotionless.
 double _getFinalTime(double velocity, double drag, {double effectivelyMotionless = 0.5}) {
-  return math.log(effectivelyMotionless / velocity) / math.log(drag / 100);
+  final t = math.log(effectivelyMotionless / velocity) / math.log(drag / 100);
+  // log(x/0) or log(1)==0 in the denominator can produce NaN/Infinity, which
+  // later crashes Duration.round() with "Infinity or NaN toInt". See #587.
+  if (!t.isFinite || t < 0) return 0;
+  return t;
 }
 
 // Return the translation from the given Matrix4 as an Offset.


### PR DESCRIPTION
## Summary

- `_getFinalTime` computes `log(effectivelyMotionless / velocity) / log(drag / 100)`. When `velocity == 0`, `drag == 100` (log(1) == 0), or `drag <= 0`, the result is `NaN` or `±Infinity`. The value is later fed to `Duration(milliseconds: (tFinal * 1000).round())`, and `.round()` on a non-finite double throws `Unsupported operation: Infinity or NaN toInt`.
- Clamp non-finite or negative results to `0` at the source. Both callers in `_onScaleEnd` (fling pan and fling scale) pick up the fix.

Fixes #587.

## Test plan
- [x] `flutter analyze`

🤖 Generated with [Claude Code](https://claude.com/claude-code)