### PR TITLE
tweak: use reproducible libpdfium.so location

### DIFF
--- a/packages/pdfium_dart/hook/build.dart
+++ b/packages/pdfium_dart/hook/build.dart
@@ -14,7 +14,10 @@ void main(List<String> args) async {
     if (input.config.code.targetOS == OS.iOS) return;
 
     final target = _PdfiumTarget.fromCodeConfig(input.config.code);
-    final outputFile = input.outputDirectory.resolve(target.libraryFileName);
+    final outputSubdir = _pdfiumRelease.replaceAll('%2F', '_');
+    final outputFile = input.outputDirectoryShared.resolve(
+      '$outputSubdir/${target.libraryFileName}',
+    );
 
     await _downloadPdfium(
       outputFile: outputFile,


### PR DESCRIPTION
For Flathub, builds are done offline so when we need to download things, we need to download them before the actual build. We use [flatpak-flutter](https://github.com/TheAppgineer/flatpak-flutter) to download a binary into the correct place.

But pdfrx_dart 0.2.0 moves to using build_hooks which automatically create a hash of the hook. Currently the location will be `my_app/.dart_tool/hooks_runner/shared/pdfium_dart/build/6b4ebf10e7/libpdfium.so`. This presents a maintenance problem for flatpak-flutter since this hash can change at any time leading to lots of churn.

The docs actually recommend using `input.outputDirectoryShared` instead of `input.outputDirectory` so the cache isn't invalidated unnecessarily. This PR switches to `input.outputDirectoryShared` to get this reproducible location: `my_app/.dart_tool/hooks_runner/shared/pdfium_dart/build/chromium_7811/libpdfium.so`. This lets flatpak-flutter use a fixed location for this binary.