### PR TITLE
Fix pdfrxInitialize calls in tests failing on macOS

### DIFF
--- a/packages/pdfium_dart/hook/link.dart
+++ b/packages/pdfium_dart/hook/link.dart
@@ -16,8 +16,10 @@ void main(List<String> args) async {
     final pdfiumProvidedByFlutter =
         input.metadata[_darwinPdfiumProviderMetadataKey] ==
         _pdfiumFlutterXcframeworkProvider;
+    // On macOS, PDFium is linked into the app by the XCFramework, but Flutter tests still need to load the PDFium asset
+    // directly. Therefore we omit the PDFium asset only for iOS when provided by Flutter, but include it for macOS.
     final shouldOmitDarwinPdfiumAsset =
-        pdfiumProvidedByFlutter && (targetOS == OS.iOS || targetOS == OS.macOS);
+        pdfiumProvidedByFlutter && targetOS == OS.iOS;
 
     for (final asset in input.assets.encodedAssets) {
       final isPdfiumAsset =

--- a/packages/pdfium_dart/lib/src/pdfium_loader.dart
+++ b/packages/pdfium_dart/lib/src/pdfium_loader.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'pdfium_bindings.dart' as pdfium_bindings;
 
 const _isFlutter = bool.fromEnvironment('dart.library.ui');
+bool get _isFlutterTest => Platform.environment.containsKey('FLUTTER_TEST');
 
 /// Helper function to get PDFium instance.
 ///
@@ -38,7 +39,8 @@ DynamicLibrary _getModule({String? modulePath}) {
   if (modulePath != null) return DynamicLibrary.open(modulePath);
   try {
     // For Flutter on iOS/macOS, PDFium is linked into the app by the XCFramework.
-    if (_isFlutter && (Platform.isIOS || Platform.isMacOS)) {
+    if ((_isFlutter && !_isFlutterTest) &&
+        (Platform.isIOS || Platform.isMacOS)) {
       return DynamicLibrary.process();
     }
     return DynamicLibrary.open(_getModuleFileName());


### PR DESCRIPTION
Fixes #640.

Flutter tests using pdfrx pass after applying this fix.

Pdfrx's [pdf_viewer_test.dart](https://github.com/espresso3389/pdfrx/blob/master/packages/pdfrx/test/pdf_viewer_test.dart) still fails on macOS even with this fix, because the `native_assets.yaml` file is not generated in the pdfrx workspace when tests are run. This seems to be an issue in Dart build hooks, not pdfrx itself.
