### PR TITLE
[codex] Add macOS Flutter test regression coverage

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -156,6 +156,10 @@ jobs:
         working-directory: packages/pdfrx/example/viewer
         run: flutter build macos --debug --verbose
 
+      - name: Prepare PDFium native asset for macOS Flutter tests - ${{ matrix.package_manager }}
+        working-directory: packages/pdfium_dart
+        run: dart test test/pdfium_test.dart
+
       - name: Test pdfrx on macOS - ${{ matrix.package_manager }}
         working-directory: packages/pdfrx
         run: flutter test test/pdfium_loading_test.dart

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -156,6 +156,10 @@ jobs:
         working-directory: packages/pdfrx/example/viewer
         run: flutter build macos --debug --verbose
 
+      - name: Test pdfrx on macOS - ${{ matrix.package_manager }}
+        working-directory: packages/pdfrx
+        run: flutter test test/pdfium_loading_test.dart
+
   # Linux build
   linux:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.build_linux }}

--- a/packages/pdfium_dart/hook/link.dart
+++ b/packages/pdfium_dart/hook/link.dart
@@ -6,28 +6,29 @@ const _pdfiumFlutterXcframeworkProvider = 'pdfium_flutter_xcframework';
 const _pdfiumAssetId = 'package:pdfium_dart/libpdfium';
 
 void main(List<String> args) async {
-  await link(args, (input, output) async {
-    if (!input.config.buildCodeAssets) {
-      output.assets.addEncodedAssets(input.assets.encodedAssets);
-      return;
-    }
+  await link(args, linkPdfiumAssets);
+}
 
-    final targetOS = input.config.code.targetOS;
-    final pdfiumProvidedByFlutter =
-        input.metadata[_darwinPdfiumProviderMetadataKey] ==
-        _pdfiumFlutterXcframeworkProvider;
-    // On macOS, PDFium is linked into the app by the XCFramework, but Flutter tests still need to load the PDFium asset
-    // directly. Therefore we omit the PDFium asset only for iOS when provided by Flutter, but include it for macOS.
-    final shouldOmitDarwinPdfiumAsset =
-        pdfiumProvidedByFlutter && targetOS == OS.iOS;
+Future<void> linkPdfiumAssets(LinkInput input, LinkOutputBuilder output) async {
+  if (!input.config.buildCodeAssets) {
+    output.assets.addEncodedAssets(input.assets.encodedAssets);
+    return;
+  }
 
-    for (final asset in input.assets.encodedAssets) {
-      final isPdfiumAsset =
-          asset.isCodeAsset &&
-          CodeAsset.fromEncoded(asset).id == _pdfiumAssetId;
-      if (shouldOmitDarwinPdfiumAsset && isPdfiumAsset) continue;
+  final targetOS = input.config.code.targetOS;
+  final pdfiumProvidedByFlutter =
+      input.metadata[_darwinPdfiumProviderMetadataKey] ==
+      _pdfiumFlutterXcframeworkProvider;
+  // On macOS, PDFium is linked into the app by the XCFramework, but Flutter tests still need to load the PDFium asset
+  // directly. Therefore we omit the PDFium asset only for iOS when provided by Flutter, but include it for macOS.
+  final shouldOmitDarwinPdfiumAsset =
+      pdfiumProvidedByFlutter && targetOS == OS.iOS;
 
-      output.assets.addEncodedAsset(asset);
-    }
-  });
+  for (final asset in input.assets.encodedAssets) {
+    final isPdfiumAsset =
+        asset.isCodeAsset && CodeAsset.fromEncoded(asset).id == _pdfiumAssetId;
+    if (shouldOmitDarwinPdfiumAsset && isPdfiumAsset) continue;
+
+    output.assets.addEncodedAsset(asset);
+  }
 }

--- a/packages/pdfium_dart/test/link_hook_test.dart
+++ b/packages/pdfium_dart/test/link_hook_test.dart
@@ -1,0 +1,90 @@
+import 'dart:io';
+
+import 'package:code_assets/code_assets.dart';
+import 'package:hooks/hooks.dart';
+import 'package:test/test.dart';
+
+import '../hook/link.dart' as link_hook;
+
+const _darwinPdfiumProviderMetadataKey = 'darwin_pdfium_provider';
+const _pdfiumFlutterXcframeworkProvider = 'pdfium_flutter_xcframework';
+const _pdfiumAssetId = 'package:pdfium_dart/libpdfium';
+
+void main() {
+  group('link hook', () {
+    test('keeps PDFium native asset for macOS Flutter tests', () async {
+      final input = _linkInput(
+        targetOS: OS.macOS,
+        pdfiumProvidedByFlutter: true,
+      );
+      final output = LinkOutputBuilder();
+
+      await link_hook.linkPdfiumAssets(input, output);
+
+      expect(_assetIds(output), contains(_pdfiumAssetId));
+    });
+
+    test('omits PDFium native asset for iOS Flutter apps', () async {
+      final input = _linkInput(targetOS: OS.iOS, pdfiumProvidedByFlutter: true);
+      final output = LinkOutputBuilder();
+
+      await link_hook.linkPdfiumAssets(input, output);
+
+      expect(_assetIds(output), isNot(contains(_pdfiumAssetId)));
+    });
+  });
+}
+
+LinkInput _linkInput({
+  required OS targetOS,
+  required bool pdfiumProvidedByFlutter,
+}) {
+  final tempUri = Directory.systemTemp.uri;
+  final builder = LinkInputBuilder()
+    ..setupShared(
+      packageRoot: Directory.current.uri,
+      packageName: 'pdfium_dart',
+      outputDirectoryShared: tempUri,
+      outputFile: tempUri.resolve('pdfium_dart_link_output.json'),
+    )
+    ..setupLink(
+      assets: [_pdfiumAsset()],
+      assetsFromLinking: [
+        if (pdfiumProvidedByFlutter)
+          EncodedAsset('hooks/metadata', {
+            'key': _darwinPdfiumProviderMetadataKey,
+            'value': _pdfiumFlutterXcframeworkProvider,
+          }),
+      ],
+      recordedUsesFile: null,
+    );
+
+  builder.addExtension(
+    CodeAssetExtension(
+      targetArchitecture: Architecture.current,
+      targetOS: targetOS,
+      linkModePreference: LinkModePreference.dynamic,
+      iOS: targetOS == OS.iOS
+          ? IOSCodeConfig(targetSdk: IOSSdk.iPhoneOS, targetVersion: 17)
+          : null,
+      macOS: targetOS == OS.macOS ? MacOSCodeConfig(targetVersion: 13) : null,
+    ),
+  );
+  return builder.build();
+}
+
+EncodedAsset _pdfiumAsset() {
+  return CodeAsset(
+    package: 'pdfium_dart',
+    name: 'libpdfium',
+    linkMode: DynamicLoadingBundled(),
+    file: Directory.current.uri.resolve('test/pdfium_test.dart'),
+  ).encode();
+}
+
+List<String> _assetIds(LinkOutputBuilder output) {
+  return LinkOutput(output.json).assets.encodedAssets
+      .where((asset) => asset.isCodeAsset)
+      .map((asset) => CodeAsset.fromEncoded(asset).id)
+      .toList();
+}

--- a/packages/pdfrx/test/pdfium_loading_test.dart
+++ b/packages/pdfrx/test/pdfium_loading_test.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdfium_flutter/pdfium_flutter.dart';
+
+void main() {
+  testWidgets('loads PDFium in Flutter test environment', (tester) async {
+    final pdfium = pdfiumBindings;
+
+    expect(pdfium.FPDF_GetLastError(), isA<int>());
+  });
+}


### PR DESCRIPTION
Adds regression coverage for the macOS Flutter test PDFium loading issue fixed by #641.\n\nChanges:\n- exposes the pdfium_dart link hook logic for direct testing\n- verifies macOS keeps the PDFium native asset while iOS still omits it when Flutter provides the XCFramework\n- adds a focused pdfrx Flutter test that loads PDFium bindings in the Flutter test environment\n- runs that focused test in the macOS GitHub Actions job\n\nLocal validation:\n- dart test test/link_hook_test.dart\n- dart analyze in packages/pdfium_dart\n- flutter test test/pdfium_loading_test.dart\n\nNote: flutter analyze in packages/pdfrx still reports the pre-existing unused private function warning in lib/src/widgets/pdf_viewer.dart.