### PR TITLE
Fix PDFium build hook output path per platform

### DIFF
--- a/packages/pdfium_dart/hook/build.dart
+++ b/packages/pdfium_dart/hook/build.dart
@@ -16,7 +16,7 @@ void main(List<String> args) async {
     final target = _PdfiumTarget.fromCodeConfig(input.config.code);
     final outputSubdir = _pdfiumRelease.replaceAll('%2F', '_');
     final outputFile = input.outputDirectoryShared.resolve(
-      '$outputSubdir/${target.archiveArch}/${target.libraryFileName}',
+      '$outputSubdir/${target.archivePlatform}-${target.archiveArch}/${target.libraryFileName}',
     );
 
     await _downloadPdfium(


### PR DESCRIPTION
Fixes an issue where the Linux `libpdfium.so` and the Android `libpdfium.so` can get mixed up:
If `libpdfium.so` exists from a previous Linux build, Android builds also use it which leads to incompatibility and Google Play warnings.
This PR separates the outputFile path by platform to avoid these conflicts.