### PR TITLE
Remove ffi and move http to dev_dependencies in pdfrx

### DIFF
--- a/packages/pdfrx/pubspec.yaml
+++ b/packages/pdfrx/pubspec.yaml
@@ -18,10 +18,8 @@ dependencies:
   pdfium_flutter: ^0.2.1
   collection:
   crypto:
-  ffi:
   flutter:
     sdk: flutter
-  http:
   path:
   path_provider:
   rxdart:
@@ -36,6 +34,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints:
   archive:
+  http:
 
 executables:
   remove_darwin_pdfium_modules:


### PR DESCRIPTION
### Changes

- Removed `ffi` from dependencies (it was not directly used in pdfrx)
- Moved `http` from dependencies to `dev_dependencies` (only used in tests)

### Reason

`ffi` was not directly referenced in the pdfrx package itself, and `http` was only used in test code.