### PR TITLE
Fix inverted guard in selectAllText() causing null dereference

### DIFF
--- a/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
@@ -3460,7 +3460,7 @@ class _PdfViewerState extends State<PdfViewer>
 
   @override
   Future<void> selectAllText() async {
-    if (_document!.pages.isEmpty && _layout != null) return;
+    if (_document!.pages.isEmpty || _layout == null) return;
     PdfPageText? first;
     for (var i = 1; i <= _document!.pages.length; i++) {
       final text = await _loadTextAsync(i);


### PR DESCRIPTION
I wanted to use pdfrx, so I ran a code review on it and found a minor bug.
It is rare in practice but can happen, and the fix is small, so I'd like to fix it.

`_layout` is null for a short time after a document is loaded, before its layout is ready. In this time, `selectAllText()` can be called by Cmd/Ctrl+A. The old guard condition was wrong, so it did not return and crashed on `_layout!`.