### PR TITLE
Fix PDFium initialization flag set in the wrong isolate

### DIFF
--- a/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
+++ b/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
@@ -9,6 +9,7 @@ import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:pdfium_dart/pdfium_dart.dart' as pdfium_bindings;
 import 'package:rxdart/rxdart.dart';
 import 'package:synchronized/extension.dart';
@@ -43,15 +44,20 @@ List<String> _fontPaths = const [];
 bool _initialized = false;
 final _initSync = Object();
 
+/// Whether PDFium has been initialized on the caller's isolate.
+@visibleForTesting
+bool get isPdfiumInitialized => _initialized;
+
 /// Initializes PDFium library.
 Future<void> _init() async {
   if (_initialized) return;
   await _initSync.synchronized(() async {
     if (_initialized) return;
-    BackgroundWorker.compute((params) {
+    await BackgroundWorker.compute((params) {
       pdfium.FPDF_InitLibrary();
-      _initialized = true;
     }, null);
+    // Set on this isolate, not inside the worker callback: top-level variables are per-isolate.
+    _initialized = true;
   });
 
   await _installFontMapper();

--- a/packages/pdfrx_engine/pubspec.yaml
+++ b/packages/pdfrx_engine/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   crypto:
   ffi:
   http:
+  meta:
   path:
   rxdart:
   synchronized:

--- a/packages/pdfrx_engine/test/pdf_document_test.dart
+++ b/packages/pdfrx_engine/test/pdf_document_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:pdfrx_engine/pdfrx_engine.dart';
+import 'package:pdfrx_engine/src/native/pdfrx_pdfium.dart' show isPdfiumInitialized;
 import 'package:test/test.dart';
 
 import 'utils.dart';
@@ -14,6 +15,16 @@ void main() {
   setUp(() => pdfrxInitialize(tmpPath: tmpRoot.path));
 
   test('PdfDocument.openFile', () async => await testDocument(await PdfDocument.openFile(testPdfFile.path)));
+  test('PDFium is initialized on the caller isolate', () async {
+    // Reset so this test owns its precondition instead of depending on order.
+    await PdfrxEntryFunctions.instance.stopBackgroundWorker();
+    expect(isPdfiumInitialized, isFalse);
+
+    // Opening a document initializes PDFium. The flag must be set on the caller's
+    // isolate; if set on the worker isolate, it stays false here.
+    await PdfDocument.openFile(testPdfFile.path).then((doc) => doc.dispose());
+    expect(isPdfiumInitialized, isTrue);
+  });
   test('PdfDocument.openData', () async {
     final data = await testPdfFile.readAsBytes();
     await testDocument(await PdfDocument.openData(data));


### PR DESCRIPTION
The old code set `_initialized = true` inside `BackgroundWorker.compute()`, which runs in a worker isolate, so the flag was never set on the caller isolate (top-level variables are not shared between isolates). The init guard therefore never triggered, and PDFium was initialized again on every call. The call was also not awaited.

This PR sets the flag on the caller isolate (after awaiting the worker), and adds a test for it.