### PR TITLE
fix: use DragStartBehavior.down for free text-drag selection (off-by-slop start anchor on touch)

### DIFF
--- a/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
@@ -659,6 +659,13 @@ class _PdfViewerState extends State<PdfViewer>
                                       cursor: SystemMouseCursors.text,
                                       hitTestBehavior: HitTestBehavior.deferToChild,
                                       child: GestureDetector(
+                                        // Use DragStartBehavior.down so onPanStart reports the
+                                        // original pointer-down position instead of the post-slop
+                                        // position. With the default DragStartBehavior.start, free
+                                        // text-drag selection begins ~kTouchSlop (18px) after the
+                                        // touch-down, skipping the first 1-2 characters on touch
+                                        // devices (notably iPad/tablets).
+                                        dragStartBehavior: DragStartBehavior.down,
                                         onPanStart: enableSelectionHandles ? null : _onTextPanStart,
                                         onPanUpdate: enableSelectionHandles ? null : _onTextPanUpdate,
                                         onPanEnd: enableSelectionHandles ? null : _onTextPanEnd,


### PR DESCRIPTION
## Problem

Free text-drag selection starts **1–2 characters after** the touch-down point on touch devices (notably iPad/tablets). Dragging from a character selects starting from the next one or two characters.

## Root cause

The text-selection `GestureDetector` (the one wiring `onPanStart: _onTextPanStart`) does not set `dragStartBehavior`, so it defaults to `DragStartBehavior.start`.

With `DragStartBehavior.start`, the pan gesture is only recognized **after the pointer moves past the slop** (`kTouchSlop ≈ 18 logical px` for touch), and `onPanStart`'s `localPosition` is the *post-slop* position rather than the original touch-down. Since `_onTextPanStart` uses `details.localPosition` to compute the start anchor (`_selA = _findTextAndIndexForPoint(details.localPosition)`), the selection start is offset by the slop — about 1–2 characters at typical zoom on high-DPI touch screens. Mouse/stylus have much smaller slop, so it's only noticeable on touch.

## Fix

Set `dragStartBehavior: DragStartBehavior.down` on that `GestureDetector` so `onPanStart` reports the original pointer-down position. Selection then starts exactly where the user pressed. `onPanUpdate`/`onPanEnd` already use absolute `localPosition`, so end-tracking is unaffected.

```diff
 child: GestureDetector(
+  dragStartBehavior: DragStartBehavior.down,
   onPanStart: enableSelectionHandles ? null : _onTextPanStart,
   onPanUpdate: enableSelectionHandles ? null : _onTextPanUpdate,
   onPanEnd: enableSelectionHandles ? null : _onTextPanEnd,
```

Only the free-drag selection `GestureDetector` is changed; the selection-handle pan recognizers are untouched.
