### PR TITLE
fix: use DragStartBehavior.down for free text-drag selection

### DIFF
--- a/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
@@ -664,7 +664,7 @@ class _PdfViewerState extends State<PdfViewer>
                                         // position. With the default DragStartBehavior.start, free
                                         // text-drag selection begins ~kTouchSlop (18px) after the
                                         // touch-down, skipping the first 1-2 characters on touch
-                                        // devices (notably iPad/tablets).
+                                        // devices (notably iPad/tablets). See espresso3389/pdfrx#665.
                                         dragStartBehavior: DragStartBehavior.down,
                                         onPanStart: enableSelectionHandles ? null : _onTextPanStart,
                                         onPanUpdate: enableSelectionHandles ? null : _onTextPanUpdate,


### PR DESCRIPTION
Fixes espresso3389/pdfrx#665

The text selection `GestureDetector` used the default `DragStartBehavior.start`,
so `onPanStart` reported the post-slop position (~`kTouchSlop`, 18px). Free
text-drag selection therefore began 1-2 characters after the touch-down on
touch devices (notably iPad/tablets), skipping the first character(s).

Setting `dragStartBehavior: DragStartBehavior.down` makes `onPanStart` report
the original pointer-down position, so selection starts exactly where the
user pressed.

### Changes
- `packages/pdfrx/lib/src/widgets/pdf_viewer.dart`: set
  `dragStartBehavior: DragStartBehavior.down` on the free text-drag selection
  `GestureDetector`.
