### PR TITLE
fix: clamp generated space rects to avoid huge selectable gaps (table column gaps)

### DIFF
--- a/packages/pdfrx_engine/lib/src/pdf_text_formatter.dart
+++ b/packages/pdfrx_engine/lib/src/pdf_text_formatter.dart
@@ -24,6 +24,15 @@ final class PdfTextFormatter {
   /// characters covers the entire gap (hundreds of points), so a drag
   /// selection highlights the whole gap and jumps across it at once.
   static const _maxSpaceExtentToLineHeightRatio = 1.5;
+
+  /// Maximum extent of a *generated* (point-box) space rect, as a ratio to
+  /// the line height (or the line width for vertical text).
+  ///
+  /// A generated space has a degenerate char box (zero width and height), so
+  /// its rect is entirely synthesized from the surrounding characters. Keep it
+  /// close to a typical space advance (~0.25em) so selecting a word does not
+  /// visually bleed into a large gap next to it.
+  static const _generatedSpaceExtentToLineHeightRatio = 0.25;
   static final _reNewLine = RegExp(r'\r?\n', unicode: true);
 
   /// Load structured text with character bounding boxes for the page.
@@ -80,19 +89,31 @@ final class PdfTextFormatter {
             // Clamp the space extent so a generated space representing a large
             // gap (e.g. a table column gap) does not become one huge selectable
             // rect; the rect stays attached to the preceding character and the
-            // remaining gap is left unselectable.
+            // remaining gap is left unselectable. Generated spaces (degenerate
+            // point boxes) get a typical space advance, real spaces keep their
+            // gap up to a looser limit.
+            var isGeneratedGap = true;
+            for (var i = wordStart; i < wordEnd; i++) {
+              final r = inputCharRects[i];
+              if (r.width > 0 || r.height > 0) {
+                isGeneratedGap = false;
+                break;
+              }
+            }
+            final extentRatio =
+                isGeneratedGap ? _generatedSpaceExtentToLineHeightRatio : _maxSpaceExtentToLineHeightRatio;
             switch (dir) {
               case PdfTextDirection.ltr:
               case PdfTextDirection.unknown:
-                final maxExtent = bounds.height * _maxSpaceExtentToLineHeightRatio;
+                final maxExtent = bounds.height * extentRatio;
                 final right = a.right < b.left ? b.left : a.right;
                 outputCharRects.add(PdfRect(a.right, bounds.top, math.min(right, a.right + maxExtent), bounds.bottom));
               case PdfTextDirection.rtl:
-                final maxExtent = bounds.height * _maxSpaceExtentToLineHeightRatio;
+                final maxExtent = bounds.height * extentRatio;
                 final right = b.right < a.left ? a.left : b.right;
                 outputCharRects.add(PdfRect(math.max(b.right, right - maxExtent), bounds.top, right, bounds.bottom));
               case PdfTextDirection.vrtl:
-                final maxExtent = bounds.width * _maxSpaceExtentToLineHeightRatio;
+                final maxExtent = bounds.width * extentRatio;
                 final bottom = a.bottom > b.top ? b.top : a.bottom;
                 outputCharRects.add(PdfRect(bounds.left, a.bottom, bounds.right, math.max(bottom, a.bottom - maxExtent)));
             }

--- a/packages/pdfrx_engine/lib/src/pdf_text_formatter.dart
+++ b/packages/pdfrx_engine/lib/src/pdf_text_formatter.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+import 'dart:math' as math;
 
 import 'package:vector_math/vector_math_64.dart';
 
@@ -13,6 +14,16 @@ import 'utils/unmodifiable_list.dart';
 /// The class provides functions to load structured text with character bounding boxes.
 final class PdfTextFormatter {
   static final _reSpaces = RegExp(r'(\s+)', unicode: true);
+
+  /// Maximum extent of a combined space rect, as a ratio to the line height
+  /// (or the line width for vertical text).
+  ///
+  /// PDFium inserts zero-width *generated* spaces to represent large gaps
+  /// between text runs sharing the same baseline (e.g. table column gaps).
+  /// Without a limit, the space rect interpolated between the surrounding
+  /// characters covers the entire gap (hundreds of points), so a drag
+  /// selection highlights the whole gap and jumps across it at once.
+  static const _maxSpaceExtentToLineHeightRatio = 1.5;
   static final _reNewLine = RegExp(r'\r?\n', unicode: true);
 
   /// Load structured text with character bounding boxes for the page.
@@ -66,14 +77,24 @@ final class PdfTextFormatter {
             // combine several spaces into one space
             final a = inputCharRects[wordStart - 1];
             final b = inputCharRects[wordEnd];
+            // Clamp the space extent so a generated space representing a large
+            // gap (e.g. a table column gap) does not become one huge selectable
+            // rect; the rect stays attached to the preceding character and the
+            // remaining gap is left unselectable.
             switch (dir) {
               case PdfTextDirection.ltr:
               case PdfTextDirection.unknown:
-                outputCharRects.add(PdfRect(a.right, bounds.top, a.right < b.left ? b.left : a.right, bounds.bottom));
+                final maxExtent = bounds.height * _maxSpaceExtentToLineHeightRatio;
+                final right = a.right < b.left ? b.left : a.right;
+                outputCharRects.add(PdfRect(a.right, bounds.top, math.min(right, a.right + maxExtent), bounds.bottom));
               case PdfTextDirection.rtl:
-                outputCharRects.add(PdfRect(b.right, bounds.top, b.right < a.left ? a.left : b.right, bounds.bottom));
+                final maxExtent = bounds.height * _maxSpaceExtentToLineHeightRatio;
+                final right = b.right < a.left ? a.left : b.right;
+                outputCharRects.add(PdfRect(math.max(b.right, right - maxExtent), bounds.top, right, bounds.bottom));
               case PdfTextDirection.vrtl:
-                outputCharRects.add(PdfRect(bounds.left, a.bottom, bounds.right, a.bottom > b.top ? b.top : a.bottom));
+                final maxExtent = bounds.width * _maxSpaceExtentToLineHeightRatio;
+                final bottom = a.bottom > b.top ? b.top : a.bottom;
+                outputCharRects.add(PdfRect(bounds.left, a.bottom, bounds.right, math.max(bottom, a.bottom - maxExtent)));
             }
             outputText.write(' ');
           }

--- a/packages/pdfrx_engine/test/pdf_text_formatter_test.dart
+++ b/packages/pdfrx_engine/test/pdf_text_formatter_test.dart
@@ -54,9 +54,27 @@ void main() {
       final spaceRect = text.charRects[2];
       // Attached to the preceding character...
       expect(spaceRect.left, 10);
-      // ...and clamped to 1.5x line height (10pt) instead of the 190pt gap.
-      expect(spaceRect.width, lessThanOrEqualTo(15));
+      // ...and clamped to a typical space advance (0.25x line height of 10pt)
+      // instead of the 190pt gap.
+      expect(spaceRect.width, lessThanOrEqualTo(2.5));
       expect(spaceRect.right, lessThan(200));
+    });
+
+    test('clamps a real wide space rect to 1.5x line height', () async {
+      // A real space glyph (non-degenerate box) spanning an unusually wide gap
+      // keeps spanning it up to the looser 1.5x line-height limit.
+      final raw = PdfPageRawText('ab cd', [
+        const PdfRect(0, 10, 5, 0), // a
+        const PdfRect(5, 10, 10, 0), // b
+        const PdfRect(10, 10, 60, 0), // space (real glyph, 50pt wide)
+        const PdfRect(200, 10, 205, 0), // c
+        const PdfRect(205, 10, 210, 0), // d
+      ]);
+      final text = await PdfTextFormatter.loadStructuredText(_FakePage(raw), pageNumberOverride: null);
+
+      final spaceRect = text.charRects[2];
+      expect(spaceRect.left, 10);
+      expect(spaceRect.width, lessThanOrEqualTo(15));
     });
   });
 }

--- a/packages/pdfrx_engine/test/pdf_text_formatter_test.dart
+++ b/packages/pdfrx_engine/test/pdf_text_formatter_test.dart
@@ -1,0 +1,62 @@
+import 'package:pdfrx_engine/pdfrx_engine.dart';
+import 'package:pdfrx_engine/src/pdf_text_formatter.dart';
+import 'package:test/test.dart';
+
+/// Fake page that only supports [loadText]; that is all
+/// [PdfTextFormatter.loadStructuredText] needs besides [pageNumber].
+class _FakePage implements PdfPage {
+  _FakePage(this._rawText);
+
+  final PdfPageRawText _rawText;
+
+  @override
+  int get pageNumber => 1;
+
+  @override
+  Future<PdfPageRawText?> loadText() async => _rawText;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('PdfTextFormatter space rect clamping', () {
+    test('keeps a normal-width space rect spanning the whole gap', () async {
+      // "ab cd" on one line; the space is a real 3pt gap.
+      final raw = PdfPageRawText('ab cd', [
+        const PdfRect(0, 10, 5, 0), // a
+        const PdfRect(5, 10, 10, 0), // b
+        const PdfRect(10, 10, 13, 0), // space (real, 3pt wide)
+        const PdfRect(13, 10, 18, 0), // c
+        const PdfRect(18, 10, 23, 0), // d
+      ]);
+      final text = await PdfTextFormatter.loadStructuredText(_FakePage(raw), pageNumberOverride: null);
+
+      expect(text.fullText, 'ab cd');
+      final spaceRect = text.charRects[2];
+      expect(spaceRect.left, 10);
+      expect(spaceRect.right, 13);
+    });
+
+    test('clamps a generated space rect representing a huge column gap', () async {
+      // Simulates a table row merged into one line by PDFium: a zero-width
+      // generated space stands for a ~190pt column gap.
+      final raw = PdfPageRawText('ab cd', [
+        const PdfRect(0, 10, 5, 0), // a
+        const PdfRect(5, 10, 10, 0), // b
+        const PdfRect(10, 10, 10, 10), // generated space (degenerate box)
+        const PdfRect(200, 10, 205, 0), // c (far column)
+        const PdfRect(205, 10, 210, 0), // d
+      ]);
+      final text = await PdfTextFormatter.loadStructuredText(_FakePage(raw), pageNumberOverride: null);
+
+      expect(text.fullText, 'ab cd');
+      final spaceRect = text.charRects[2];
+      // Attached to the preceding character...
+      expect(spaceRect.left, 10);
+      // ...and clamped to 1.5x line height (10pt) instead of the 190pt gap.
+      expect(spaceRect.width, lessThanOrEqualTo(15));
+      expect(spaceRect.right, lessThan(200));
+    });
+  });
+}


### PR DESCRIPTION
Fixes #667

PDFium inserts zero-width *generated* spaces to represent large gaps between text runs sharing the same baseline (e.g. table column gaps). `PdfTextFormatter` interpolated the space rect between the surrounding characters, so a single selectable space could cover the entire gap (~180pt measured on a real table PDF): drag selection highlighted the whole gap and jumped across it at once, and selecting a word next to the gap visually bled into the blank area.

### Changes

- `packages/pdfrx_engine/lib/src/pdf_text_formatter.dart`
  - Clamp the combined space rect extent, keeping it attached to the preceding character (handles ltr/rtl/vrtl).
  - Distinguish *generated* spaces (all merged char boxes degenerate, zero width and height) from real space glyphs:
    - generated spaces are clamped to 0.25x line height (~a typical space advance);
    - real space glyphs keep spanning their gap up to a looser 1.5x line height limit.
- `packages/pdfrx_engine/test/pdf_text_formatter_test.dart` (new)
  - normal space keeps spanning its gap;
  - generated space over a ~190pt column gap is clamped to a typical space advance;
  - real wide space glyph is clamped to the 1.5x line height limit.

### Tests

- `dart test test/pdf_text_formatter_test.dart` in `packages/pdfrx_engine`: all pass.
- `dart analyze`: no new issues.
