### PR TITLE
fix: key text selection stack children to avoid context menu remount

### DIFF
--- a/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
@@ -2827,6 +2827,9 @@ class _PdfViewerState extends State<PdfViewer>
         if (magnifier != null && !isPositionalWidget(magnifier)) {
           final offset = magnifierPosition;
           magnifier = AnimatedPositioned(
+            // Keyed so inserting/removing sibling selection widgets does not
+            // remount this subtree via keyless index matching.
+            key: const Key('pdfrxMagnifierPositioned'),
             duration: _previousMagnifierRect != null ? magnifierParams.animationDuration : Duration.zero,
             left: offset.dx,
             top: offset.dy,
@@ -2943,6 +2946,10 @@ class _PdfViewerState extends State<PdfViewer>
                   Offset.zero);
 
         contextMenu = Positioned(
+          // Keyed so appearing/disappearing selection handles do not remount
+          // the context menu subtree (losing its state) via keyless index
+          // matching of the surrounding Stack children.
+          key: const Key('pdfrxContextMenuPositioned'),
           left: offset.dx,
           top: offset.dy,
           child: WidgetSizeSniffer(
@@ -2966,6 +2973,7 @@ class _PdfViewerState extends State<PdfViewer>
     return [
       if (anchorA != null)
         Positioned(
+          key: const Key('pdfrxAnchorAPositioned'),
           left: aLeft,
           right: aRight,
           bottom: aBottom,
@@ -2991,6 +2999,7 @@ class _PdfViewerState extends State<PdfViewer>
         ),
       if (anchorB != null)
         Positioned(
+          key: const Key('pdfrxAnchorBPositioned'),
           left: bLeft,
           top: bTop,
           right: bRight,


### PR DESCRIPTION
Fixes #668

The widgets returned by `_placeTextSelectionWidgets` (anchor handles, magnifier, context menu) are keyless `Positioned`/`AnimatedPositioned` siblings. When selection handles appear or disappear while the context menu is visible (e.g. an app toggles `textSelectionParams.enableSelectionHandles` after a selection settles), keyless index matching updates the old context menu slot into an anchor handle, unmounting and re-inflating the context menu subtree. A stateful context menu (async dictionary popup etc.) then loses its state and visibly flickers/reloads.

### Changes

- `packages/pdfrx/lib/src/widgets/pdf_viewer.dart`: give each of the four stack children a stable key so Flutter reconciles them by key and the context menu element survives sibling insertions/removals.

### Tests

- `flutter analyze`: no issues.
- Verified manually: with a stateful custom context menu, toggling selection handles no longer resets the menu state.
