### PR TITLE
Fix null check crash in _loadTextAsync when document is unloaded

### DIFF
--- a/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
@@ -1628,7 +1628,9 @@ class _PdfViewerState extends State<PdfViewer>
   /// and [onTextLoaded] callback will be called when the text is loaded.
   /// If [onTextLoaded] is not provided and [invalidate] is true, the widget will be rebuilt when the text is loaded.
   PdfPageText? _getCachedTextOrDelayLoadText(int pageNumber, {void Function()? onTextLoaded, bool invalidate = true}) {
-    final page = _document!.pages[pageNumber - 1];
+    final document = _document;
+    if (document == null || pageNumber > document.pages.length) return null;
+    final page = document.pages[pageNumber - 1];
     if (!page.isLoaded) return null;
     if (_textCache.containsKey(pageNumber)) return _textCache[pageNumber];
     if (onTextLoaded == null && invalidate) {
@@ -1639,12 +1641,19 @@ class _PdfViewerState extends State<PdfViewer>
   }
 
   Future<PdfPageText?> _loadTextAsync(int pageNumber, {void Function()? onTextLoaded}) async {
-    final page = _document!.pages[pageNumber - 1];
+    final document = _document;
+    if (document == null || pageNumber > document.pages.length) return null;
+    final page = document.pages[pageNumber - 1];
     if (!page.isLoaded) return null;
     if (_textCache.containsKey(pageNumber)) return _textCache[pageNumber]!;
     return await synchronized(() async {
       if (_textCache.containsKey(pageNumber)) return _textCache[pageNumber]!;
-      final page = _document!.pages[pageNumber - 1];
+      // The document may be unloaded or replaced while this closure waits in
+      // the synchronized queue (e.g. the tab/page was closed or the widget
+      // switched documents); bail out instead of crashing on _document!.
+      final document = _document;
+      if (document == null || !mounted || pageNumber > document.pages.length) return null;
+      final page = document.pages[pageNumber - 1];
       if (!page.isLoaded) return null;
       final text = await page.loadStructuredText();
       _textCache[pageNumber] = text;


### PR DESCRIPTION
## Summary
- `_loadTextAsync` defers work into a `synchronized()` closure; if the widget's document is unloaded/replaced before the queued closure runs, the closure dereferences `_document!` and throws `Null check operator used on a null value`.
- This is straightforward to hit in apps that keep a `PdfViewer` mounted but swap/clear its document dynamically (e.g. tab hibernation / lazy-loading multiple documents to save memory) while a page-text load is queued from a previous document.
- Guards `_document` (and the page index, in case the document was swapped for one with fewer pages) in both `_loadTextAsync` and `_getCachedTextOrDelayLoadText`, and re-checks inside the queued closure where the original race occurs.

## Stack trace observed in production (pdfrx 2.2.24, Android arm64)
```
Null check operator used on a null value
#0      _PdfViewerState._loadTextAsync.<anonymous closure> (package:pdfrx/src/widgets/pdf_viewer.dart:1425)
#1      objectSynchronized.<anonymous closure> (package:synchronized/src/extension_impl.dart:37)
#2      BasicLock.synchronized (package:synchronized/src/basic_lock.dart:36)
<asynchronous suspension>
#3      objectSynchronized (package:synchronized/src/extension_impl.dart:36)
<asynchronous suspension>
#4      _PdfViewerState._loadTextAsync (package:pdfrx/src/widgets/pdf_viewer.dart:1423)
<asynchronous suspension>
```

## Test plan
- [x] Reproduced against our app (ThinkSink): document is unloaded on tab hibernation while a queued text-load resolves later — crash observed pre-fix, gone post-fix.
- [ ] No existing pdfrx test covers this path; happy to add one if maintainers point me at the right harness/fixture for `PdfViewer` document-lifecycle tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)