### PR TITLE
Test Windows ARM64 with Flutter stable

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -251,12 +251,13 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Flutter (master branch for ARM64 support)
+      - name: Setup Flutter
         shell: pwsh
         run: |
-          git clone https://github.com/flutter/flutter.git --depth 1 C:\flutter
+          git clone https://github.com/flutter/flutter.git --depth 1 --branch stable C:\flutter
           echo "C:\flutter\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           C:\flutter\bin\flutter.bat config --no-enable-android
+          C:\flutter\bin\flutter.bat channel stable
           C:\flutter\bin\flutter.bat doctor -v
 
       - name: Install dependencies


### PR DESCRIPTION
## What changed

- Configure the Windows ARM64 job to clone the Flutter stable channel.
- Keep the setup consistent with the other platform jobs.

## Why

Verify that Windows ARM64 builds now work with the latest Flutter stable release instead of Flutter master.

## Validation

- GitHub Actions Build Test workflow on the native windows-11-arm runner.