### PR TITLE
Improve progressive PDF loading and page link caching

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -287,6 +287,10 @@ jobs:
         working-directory: packages/pdfrx/example/viewer
         run: flutter pub get
 
+      - name: Test PDFium worker metadata
+        working-directory: packages/pdfrx
+        run: node --test test/pdfium_worker_metadata_test.cjs
+
       - name: Build Web
         working-directory: packages/pdfrx/example/viewer
         run: flutter build web --verbose

--- a/packages/pdfrx/assets/pdfium_worker.js
+++ b/packages/pdfrx/assets/pdfium_worker.js
@@ -1446,38 +1446,15 @@ function _loadDocument(docHandle, useProgressiveLoading, onDispose) {
  */
 function _loadPagesInLimitedTime(docHandle, pagesLoadedCountSoFar, maxPageCountToLoadAdditionally, timeoutMs) {
   const pageCount = Pdfium.wasmExports.FPDF_GetPageCount(docHandle);
-  const end =
-    maxPageCountToLoadAdditionally == null
-      ? pageCount
-      : Math.min(pageCount, pagesLoadedCountSoFar + maxPageCountToLoadAdditionally);
   const t = timeoutMs != null ? Date.now() + timeoutMs : null;
   /** @type {PdfPage[]} */
   const pages = [];
   _resetMissingFonts();
-  for (let i = pagesLoadedCountSoFar; i < end; i++) {
-    const pageHandle = Pdfium.wasmExports.FPDF_LoadPage(docHandle, i);
-    if (!pageHandle) {
-      const error = Pdfium.wasmExports.FPDF_GetLastError();
-      throw new Error(`FPDF_LoadPage failed (${_getErrorMessage(error)})`);
+  for (let i = pagesLoadedCountSoFar; i < pageCount; i++) {
+    pages.push(_loadPageMetadata(docHandle, i));
+    if (maxPageCountToLoadAdditionally != null && pages.length >= maxPageCountToLoadAdditionally) {
+      break;
     }
-
-    const rectBuffer = Pdfium.wasmExports.malloc(4 * 4); // FS_RECTF: float[4]
-    Pdfium.wasmExports.FPDF_GetPageBoundingBox(pageHandle, rectBuffer);
-    const rect = new Float32Array(Pdfium.memory.buffer, rectBuffer, 4);
-    const bbLeft = rect[0];
-    const bbBottom = rect[3];
-    Pdfium.wasmExports.free(rectBuffer);
-
-    pages.push({
-      pageIndex: i,
-      width: Pdfium.wasmExports.FPDF_GetPageWidthF(pageHandle),
-      height: Pdfium.wasmExports.FPDF_GetPageHeightF(pageHandle),
-      rotation: Pdfium.wasmExports.FPDFPage_GetRotation(pageHandle),
-      isLoaded: true,
-      bbLeft: bbLeft,
-      bbBottom: bbBottom,
-    });
-    Pdfium.wasmExports.FPDF_ClosePage(pageHandle);
     if (t != null && Date.now() > t) {
       break;
     }
@@ -1489,45 +1466,33 @@ function _loadPagesInLimitedTime(docHandle, pagesLoadedCountSoFar, maxPageCountT
 /**
  * @param {number} docHandle
  * @param {number} pagesLoadedCountSoFar
+ * @param {number[]} loadedPageIndices
  * @param {number|null} maxPageCountToLoadAdditionally
  * @param {number} timeoutMs
  * @returns {Promise<PdfPage[]>}
  */
-async function _loadPagesInLimitedTimeAsync(docHandle, pagesLoadedCountSoFar, maxPageCountToLoadAdditionally, timeoutMs) {
+async function _loadPagesInLimitedTimeAsync(
+  docHandle,
+  pagesLoadedCountSoFar,
+  loadedPageIndices,
+  maxPageCountToLoadAdditionally,
+  timeoutMs,
+) {
   const pageCount = Pdfium.wasmExports.FPDF_GetPageCount(docHandle);
-  const end =
-    maxPageCountToLoadAdditionally == null
-      ? pageCount
-      : Math.min(pageCount, pagesLoadedCountSoFar + maxPageCountToLoadAdditionally);
+  const loadedPages = new Set(loadedPageIndices);
   const t = timeoutMs != null ? Date.now() + timeoutMs : null;
   /** @type {PdfPage[]} */
   const pages = [];
   _resetMissingFonts();
-  for (let i = pagesLoadedCountSoFar; i < end; i++) {
-    await _ensurePageAvailable(docHandle, i);
-    const pageHandle = Pdfium.wasmExports.FPDF_LoadPage(docHandle, i);
-    if (!pageHandle) {
-      const error = Pdfium.wasmExports.FPDF_GetLastError();
-      throw new Error(`FPDF_LoadPage failed (${_getErrorMessage(error)})`);
+  for (let i = pagesLoadedCountSoFar; i < pageCount; i++) {
+    if (loadedPages.has(i)) {
+      continue;
     }
-
-    const rectBuffer = Pdfium.wasmExports.malloc(4 * 4); // FS_RECTF: float[4]
-    Pdfium.wasmExports.FPDF_GetPageBoundingBox(pageHandle, rectBuffer);
-    const rect = new Float32Array(Pdfium.memory.buffer, rectBuffer, 4);
-    const bbLeft = rect[0];
-    const bbBottom = rect[3];
-    Pdfium.wasmExports.free(rectBuffer);
-
-    pages.push({
-      pageIndex: i,
-      width: Pdfium.wasmExports.FPDF_GetPageWidthF(pageHandle),
-      height: Pdfium.wasmExports.FPDF_GetPageHeightF(pageHandle),
-      rotation: Pdfium.wasmExports.FPDFPage_GetRotation(pageHandle),
-      isLoaded: true,
-      bbLeft: bbLeft,
-      bbBottom: bbBottom,
-    });
-    Pdfium.wasmExports.FPDF_ClosePage(pageHandle);
+    await _ensurePageAvailable(docHandle, i);
+    pages.push(_loadPageMetadata(docHandle, i));
+    if (maxPageCountToLoadAdditionally != null && pages.length >= maxPageCountToLoadAdditionally) {
+      break;
+    }
     if (t != null && Date.now() > t) {
       break;
     }
@@ -1537,12 +1502,18 @@ async function _loadPagesInLimitedTimeAsync(docHandle, pagesLoadedCountSoFar, ma
 }
 
 /**
- * @param {{docHandle: number, loadUnitDuration: number}} params
+ * @param {{docHandle: number, firstPageIndex: number, loadedPageIndices: number[], loadUnitDuration: number}} params
  * @returns {{pages: PdfPage[], missingFonts: FontQueries}}
  */
 async function loadPagesProgressively(params) {
-  const { docHandle, firstPageIndex, loadUnitDuration } = params;
-  const pages = await _loadPagesInLimitedTimeAsync(docHandle, firstPageIndex, null, loadUnitDuration);
+  const { docHandle, firstPageIndex, loadedPageIndices, loadUnitDuration } = params;
+  const pages = await _loadPagesInLimitedTimeAsync(
+    docHandle,
+    firstPageIndex,
+    loadedPageIndices,
+    null,
+    loadUnitDuration,
+  );
   return { pages, missingFonts: missingFonts[docHandle] };
 }
 
@@ -1557,9 +1528,10 @@ async function reloadPages(params) {
   const pages = [];
   const pageCount = Pdfium.wasmExports.FPDF_GetPageCount(docHandle);
   /** @type {number[]} */
-  var indicesToLoad = [];
+  const indicesToLoad = [];
   if (pageIndices) {
-    for (const pageIndex of pageIndices) {
+    const requestedPageIndices = [...new Set(pageIndices)].sort((a, b) => a - b);
+    for (const pageIndex of requestedPageIndices) {
       if (pageIndex < 0 || pageIndex >= pageCount) {
         throw new Error(`Invalid page index ${pageIndex} (page count: ${pageCount})`);
       }
@@ -1579,29 +1551,41 @@ async function reloadPages(params) {
   _resetMissingFonts();
   for (const pageIndex of indicesToLoad) {
     await _ensurePageAvailable(docHandle, pageIndex);
-    const pageHandle = Pdfium.wasmExports.FPDF_LoadPage(docHandle, pageIndex);
-    if (!pageHandle) {
-      const error = Pdfium.wasmExports.FPDF_GetLastError();
-      throw new Error(`FPDF_LoadPage failed (${_getErrorMessage(error)})`);
-    }
-    const rectBuffer = Pdfium.wasmExports.malloc(4 * 4); // FS_RECTF: float[4]
+    pages.push(_loadPageMetadata(docHandle, pageIndex));
+  }
+  return { pages, missingFonts: missingFonts[docHandle] };
+}
+
+/**
+ * @param {number} docHandle
+ * @param {number} pageIndex
+ * @returns {PdfPage}
+ */
+function _loadPageMetadata(docHandle, pageIndex) {
+  const pageHandle = Pdfium.wasmExports.FPDF_LoadPage(docHandle, pageIndex);
+  if (!pageHandle) {
+    const error = Pdfium.wasmExports.FPDF_GetLastError();
+    throw new Error(`FPDF_LoadPage failed (${_getErrorMessage(error)})`);
+  }
+  const rectBuffer = Pdfium.wasmExports.malloc(4 * 4);
+  try {
     Pdfium.wasmExports.FPDF_GetPageBoundingBox(pageHandle, rectBuffer);
     const rect = new Float32Array(Pdfium.memory.buffer, rectBuffer, 4);
     const bbLeft = rect[0];
     const bbBottom = rect[3];
-    Pdfium.wasmExports.free(rectBuffer);
-    pages.push({
+    return {
       pageIndex: pageIndex,
       width: Pdfium.wasmExports.FPDF_GetPageWidthF(pageHandle),
       height: Pdfium.wasmExports.FPDF_GetPageHeightF(pageHandle),
       rotation: Pdfium.wasmExports.FPDFPage_GetRotation(pageHandle),
       isLoaded: true,
-      bbLeft: bbLeft,
-      bbBottom: bbBottom,
-    });
+      bbLeft,
+      bbBottom,
+    };
+  } finally {
+    Pdfium.wasmExports.free(rectBuffer);
     Pdfium.wasmExports.FPDF_ClosePage(pageHandle);
   }
-  return { pages, missingFonts: missingFonts[docHandle] };
 }
 
 /**

--- a/packages/pdfrx/lib/src/wasm/pdfrx_wasm.dart
+++ b/packages/pdfrx/lib/src/wasm/pdfrx_wasm.dart
@@ -693,7 +693,7 @@ class _PdfPageRenderCancellationTokenWasm extends PdfPageRenderCancellationToken
   bool get isCanceled => _isCanceled;
 }
 
-class _PdfPageWasm extends PdfPage {
+class _PdfPageWasm extends PdfPage with PdfPageLinkCache {
   _PdfPageWasm(
     this.document,
     int pageIndex,
@@ -715,7 +715,7 @@ class _PdfPageWasm extends PdfPage {
   final _PdfDocumentWasm document;
 
   @override
-  Future<List<PdfLink>> loadLinks({bool compact = false, bool enableAutoLinkDetection = true}) async {
+  Future<List<PdfLink>> loadLinksUncached(bool enableAutoLinkDetection) async {
     if (document.isDisposed || !isLoaded) return [];
     final result = await _sendCommand(
       'loadLinks',
@@ -725,48 +725,50 @@ class _PdfPageWasm extends PdfPage {
         'enableAutoLinkDetection': enableAutoLinkDetection,
       },
     );
-    return (result['links'] as List).map((link) {
-      if (link is! Map<Object?, dynamic>) {
-        throw FormatException('Unexpected link structure: $link');
-      }
-      final rects = (link['rects'] as List).map((r) {
-        final rect = r as List;
-        return PdfRect(
-          (rect[0] as double) - bbLeft,
-          (rect[1] as double) - bbBottom,
-          (rect[2] as double) - bbLeft,
-          (rect[3] as double) - bbBottom,
-        );
-      }).toList();
+    return List.unmodifiable(
+      (result['links'] as List).map((link) {
+        if (link is! Map<Object?, dynamic>) {
+          throw FormatException('Unexpected link structure: $link');
+        }
+        final rects = (link['rects'] as List).map((r) {
+          final rect = r as List;
+          return PdfRect(
+            (rect[0] as double) - bbLeft,
+            (rect[1] as double) - bbBottom,
+            (rect[2] as double) - bbLeft,
+            (rect[3] as double) - bbBottom,
+          );
+        }).toList();
 
-      final url = link['url'];
-      final dest = link['dest'];
+        final url = link['url'];
+        final dest = link['dest'];
 
-      final annotationData = link['annotation'] as Map<Object?, dynamic>?;
-      final annotation = annotationData != null
-          ? PdfAnnotation(
-              title: annotationData['title'] as String?,
-              content: annotationData['content'] as String?,
-              subject: annotationData['subject'] as String?,
-              modificationDate: PdfDateTime.fromPdfDateString(annotationData['modificationDate']),
-              creationDate: PdfDateTime.fromPdfDateString(annotationData['creationDate']),
-            )
-          : null;
+        final annotationData = link['annotation'] as Map<Object?, dynamic>?;
+        final annotation = annotationData != null
+            ? PdfAnnotation(
+                title: annotationData['title'] as String?,
+                content: annotationData['content'] as String?,
+                subject: annotationData['subject'] as String?,
+                modificationDate: PdfDateTime.fromPdfDateString(annotationData['modificationDate']),
+                creationDate: PdfDateTime.fromPdfDateString(annotationData['creationDate']),
+              )
+            : null;
 
-      if (url is String) {
-        return PdfLink(rects, url: Uri.tryParse(url), annotation: annotation);
-      }
+        if (url is String) {
+          return PdfLink(rects, url: Uri.tryParse(url), annotation: annotation);
+        }
 
-      if (dest != null && dest is Map<Object?, dynamic>) {
-        return PdfLink(rects, dest: _pdfDestFromMap(dest), annotation: annotation);
-      }
+        if (dest != null && dest is Map<Object?, dynamic>) {
+          return PdfLink(rects, dest: _pdfDestFromMap(dest), annotation: annotation);
+        }
 
-      if (annotation != null) {
-        return PdfLink(rects, annotation: annotation);
-      }
+        if (annotation != null) {
+          return PdfLink(rects, annotation: annotation);
+        }
 
-      return PdfLink(rects);
-    }).toList();
+        return PdfLink(rects);
+      }),
+    );
   }
 
   @override

--- a/packages/pdfrx/lib/src/wasm/pdfrx_wasm.dart
+++ b/packages/pdfrx/lib/src/wasm/pdfrx_wasm.dart
@@ -405,12 +405,16 @@ class _PdfDocumentWasm extends PdfDocument {
   }
 
   void _notifyDocumentLoadComplete() {
-    subject.add(PdfDocumentLoadCompleteEvent(this));
+    if (!isDisposed && !_documentLoadCompleteNotified) {
+      _documentLoadCompleteNotified = true;
+      subject.add(PdfDocumentLoadCompleteEvent(this));
+    }
   }
 
   final Map<Object?, dynamic> document;
   final void Function()? disposeCallback;
   bool isDisposed = false;
+  bool _documentLoadCompleteNotified = false;
   final subject = BehaviorSubject<PdfDocumentEvent>();
 
   @override
@@ -460,39 +464,47 @@ class _PdfDocumentWasm extends PdfDocument {
   }) async {
     if (isDisposed) return;
     await synchronized(() async {
-      var firstPageIndex = pages.indexWhere((page) => !page.isLoaded);
-      if (firstPageIndex < 0) return; // All pages are already loaded
-
-      final newPages = pages.toList(growable: false);
-      for (; firstPageIndex < newPages.length;) {
+      for (;;) {
         if (isDisposed) return;
+        final firstPageIndex = pages.indexWhere((page) => !page.isLoaded);
+        if (firstPageIndex < 0) {
+          _notifyDocumentLoadComplete();
+          return;
+        }
+        final newPages = pages.toList(growable: false);
+        final loadedPageIndices = <int>[
+          for (var i = firstPageIndex + 1; i < newPages.length; i++)
+            if (newPages[i].isLoaded) i,
+        ];
         final result = await _sendCommand(
           'loadPagesProgressively',
           parameters: {
             'docHandle': document['docHandle'],
             'firstPageIndex': firstPageIndex,
+            'loadedPageIndices': loadedPageIndices,
             'loadUnitDuration': loadUnitDuration.inMilliseconds,
           },
         );
         final pagesLoaded = parsePages(this, result['pages'] as List<dynamic>);
-        firstPageIndex += pagesLoaded.length;
         for (final page in pagesLoaded) {
           newPages[page.pageNumber - 1] = page; // Update the existing page
         }
         pages = newPages;
-
         updateMissingFonts(result['missingFonts']);
+        if (pagesLoaded.isEmpty) return;
+
+        final firstUnloadedPageIndex = pages.indexWhere((page) => !page.isLoaded);
+        final pageCountLoaded = firstUnloadedPageIndex < 0 ? pages.length : firstUnloadedPageIndex;
 
         if (onPageLoadProgress != null) {
-          if (!await onPageLoadProgress(firstPageIndex, pages.length, data)) {
+          if (!await onPageLoadProgress(pageCountLoaded, pages.length, data)) {
+            if (pages.every((page) => page.isLoaded)) {
+              _notifyDocumentLoadComplete();
+            }
             // If the callback returns false, stop loading more pages
-            break;
+            return;
           }
         }
-      }
-      // All pages loaded
-      if (firstPageIndex >= pages.length) {
-        _notifyDocumentLoadComplete();
       }
     });
   }
@@ -511,9 +523,14 @@ class _PdfDocumentWasm extends PdfDocument {
         },
       );
       final reloadedPages = parsePages(this, result['pages'] as List<dynamic>);
-      final newPages = pages.toList(growable: false);
+      final newPages = pages.toList();
       for (final page in reloadedPages) {
-        newPages[page.pageNumber - 1] = page; // Update the existing page
+        final pageIndex = page.pageNumber - 1;
+        if (pageIndex < newPages.length) {
+          newPages[pageIndex] = page;
+        } else {
+          newPages.add(page);
+        }
       }
       pages = newPages;
 
@@ -531,8 +548,11 @@ class _PdfDocumentWasm extends PdfDocument {
 
   @override
   set pages(Iterable<PdfPage> newPages) {
+    final previousPageCount = _pages.length;
     final pages = <PdfPage>[];
     final changes = <int, PdfPageStatusChange>{};
+    late final oldPageIndices = Map<PdfPage, int>.identity()
+      ..addEntries([for (var i = 0; i < _pages.length; i++) MapEntry(_pages[i], i)]);
 
     for (final newPage in newPages) {
       if (pages.length < _pages.length) {
@@ -551,7 +571,7 @@ class _PdfDocumentWasm extends PdfDocument {
       final updated = newPage.withPageNumber(newPageNumber);
       pages.add(updated);
 
-      final oldPageIndex = _pages.indexWhere((p) => identical(p, newPage));
+      final oldPageIndex = oldPageIndices[newPage] ?? -1;
       if (oldPageIndex != -1) {
         changes[newPageNumber] = PdfPageStatusChange.moved(page: updated, oldPageNumber: oldPageIndex + 1);
       } else {
@@ -560,7 +580,10 @@ class _PdfDocumentWasm extends PdfDocument {
     }
 
     _pages = List.unmodifiable(pages);
-    subject.add(PdfDocumentPageStatusChangedEvent(this, changes: changes));
+    if (changes.isNotEmpty || pages.length != previousPageCount) {
+      _documentLoadCompleteNotified = false;
+      subject.add(PdfDocumentPageStatusChangedEvent(this, changes: changes));
+    }
   }
 
   void updateMissingFonts(Map<dynamic, dynamic>? missingFonts) {

--- a/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
@@ -247,7 +247,9 @@ class _PdfViewerState extends State<PdfViewer>
   Size? _viewSize;
   late PdfViewerLayoutMetrics _layoutMetrics;
   int? _pageNumber;
+  int? _initialPageNumber;
   bool _initialized = false;
+  bool _documentLoadFinishedNotified = false;
   bool _usingScrollPercentageMode = false;
 
   StreamSubscription<PdfDocumentEvent>? _documentSubscription;
@@ -417,6 +419,8 @@ class _PdfViewerState extends State<PdfViewer>
     _textCache.clear();
     _clearTextSelections(invalidate: false);
     _pageNumber = null;
+    _initialPageNumber = null;
+    _documentLoadFinishedNotified = false;
     _gotoTargetPageNumber = null;
     _initialized = false;
     _txController.removeListener(_onMatrixChanged);
@@ -451,15 +455,42 @@ class _PdfViewerState extends State<PdfViewer>
     }
 
     _notifyOnDocumentChanged();
-    _loadDelayed();
+    unawaited(_loadPagesInBackground());
   }
 
-  Future<void> _loadDelayed() async {
-    // To make the page image loading more smooth, delay the loading of pages
+  /// Prefetches the initial viewport, then progressively loads the remaining pages.
+  Future<void> _loadPagesInBackground() async {
+    final document = _document;
+    if (document == null) return;
+
+    if (document.pages.isNotEmpty) {
+      await WidgetsBinding.instance.endOfFrame;
+      if (!mounted || document != _document) return;
+      final initialPageNumber = _clampInitialPageNumber(document, _initialPageNumber ?? widget.initialPageNumber);
+      final priorityPageNumbers = <int>[
+        initialPageNumber - 1,
+        initialPageNumber,
+        initialPageNumber + 1,
+      ].where((pageNumber) => pageNumber >= 1 && pageNumber <= document.pages.length);
+      final unloadedPageNumbers = priorityPageNumbers
+          .where((pageNumber) => !document.pages[pageNumber - 1].isLoaded)
+          .toList();
+      if (unloadedPageNumbers.isNotEmpty) {
+        try {
+          await document.reloadPages(pageNumbersToReload: unloadedPageNumbers);
+        } catch (error) {
+          debugPrint('PdfViewer: Priority page loading failed: $error');
+        }
+      }
+    }
+    if (!mounted || document != _document) return;
+
+    // Delay trailing pages to keep visible-page rendering smooth.
     await Future.delayed(widget.params.behaviorControlParams.trailingPageLoadingDelay);
+    if (!mounted || document != _document) return;
 
     final stopwatch = Stopwatch()..start();
-    await _document?.loadPagesProgressively(
+    await document.loadPagesProgressively(
       onPageLoadProgress: (pageNumber, totalPageCount, document) {
         if (document == _document && mounted) {
           debugPrint('PdfViewer: Loaded page $pageNumber of $totalPageCount in ${stopwatch.elapsedMilliseconds} ms');
@@ -469,6 +500,10 @@ class _PdfViewerState extends State<PdfViewer>
       },
       data: _document,
     );
+    if (!mounted || document != _document) return;
+    if (document.pages.every((page) => page.isLoaded)) {
+      await _notifyDocumentLoadFinished(succeeded: true);
+    }
   }
 
   void _notifyOnDocumentChanged() {
@@ -548,17 +583,26 @@ class _PdfViewerState extends State<PdfViewer>
   }
 
   Future<void> _notifyDocumentLoadFinished({required bool succeeded}) async {
-    if (succeeded) {
+    if (_documentLoadFinishedNotified) return;
+    _documentLoadFinishedNotified = true;
+    final document = _document;
+    final documentRef = widget.documentRef;
+    if (succeeded && document != null && document.pages.isNotEmpty) {
       // FIXME: This is a temporary workaround to wait until the initial page is loaded.
-      while (mounted) {
-        if (_imageCache.pageImages.containsKey(widget.initialPageNumber)) break;
+      while (mounted && document == _document) {
+        final initialPageNumber = _clampInitialPageNumber(document, _initialPageNumber ?? widget.initialPageNumber);
+        if (_imageCache.pageImages.containsKey(initialPageNumber)) break;
         await Future.delayed(const Duration(milliseconds: 100));
       }
+      if (!mounted || document != _document) return;
     }
 
     Future.microtask(() async {
-      if (mounted) {
-        widget.params.onDocumentLoadFinished?.call(widget.documentRef, succeeded);
+      if (!mounted) return;
+      if (succeeded && document == _document) {
+        widget.params.onDocumentLoadFinished?.call(widget.documentRef, true);
+      } else if (!succeeded && identical(widget.documentRef, documentRef)) {
+        widget.params.onDocumentLoadFinished?.call(documentRef, false);
       }
     });
   }
@@ -801,7 +845,7 @@ class _PdfViewerState extends State<PdfViewer>
 
         // Calculate initial page (using params or default)
         // We set it here so internal state is consistent before delegate runs
-        _pageNumber = _gotoTargetPageNumber = _calcInitialPageNumber();
+        _pageNumber = _gotoTargetPageNumber = _resolveInitialPageNumber();
 
         // RECALCULATE for specific initial page
         _recalculateMetrics();
@@ -874,6 +918,22 @@ class _PdfViewerState extends State<PdfViewer>
     }
     return pageNumber ?? widget.initialPageNumber;
   }
+
+  int _resolveInitialPageNumber() {
+    final initialPageNumber = _initialPageNumber;
+    if (initialPageNumber != null) return initialPageNumber;
+    int calculatedPageNumber;
+    try {
+      calculatedPageNumber = _calcInitialPageNumber();
+    } catch (error) {
+      debugPrint('PdfViewer: Initial page calculation failed: $error');
+      calculatedPageNumber = widget.initialPageNumber;
+    }
+    return _initialPageNumber = _clampInitialPageNumber(_document!, calculatedPageNumber);
+  }
+
+  int _clampInitialPageNumber(PdfDocument document, int pageNumber) =>
+      document.pages.isEmpty ? pageNumber : pageNumber.clamp(1, document.pages.length);
 
   PdfPageHitTestResult? _getClosestPageHit(int currentPageNumber, PdfPageLayout oldLayout, ui.Rect oldVisibleRect) {
     for (final pageIndex in <int>[currentPageNumber, currentPageNumber - 1, currentPageNumber + 1]) {

--- a/packages/pdfrx/test/pdf_viewer_test.dart
+++ b/packages/pdfrx/test/pdf_viewer_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/gestures.dart';
@@ -77,6 +78,307 @@ void main() {
 
     expect(tester.takeException(), isNull);
     expect(controller.isReady, isTrue);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 100));
+  });
+
+  testWidgets('initial page and neighbors load before trailing pages', (tester) async {
+    await binding.setSurfaceSize(const Size(800, 1200));
+    addTearDown(() => binding.setSurfaceSize(null));
+    final document = _TestDocument(9);
+    addTearDown(document.dispose);
+    expect(document.pages.where((page) => page.isLoaded).map((page) => page.pageNumber), [1]);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PdfViewer(
+          PdfDocumentRefDirect(document, autoDispose: false),
+          initialPageNumber: 8,
+          params: const PdfViewerParams(
+            behaviorControlParams: PdfViewerBehaviorControlParams(trailingPageLoadingDelay: Duration(seconds: 2)),
+          ),
+        ),
+      ),
+    );
+
+    for (var i = 0; i < 50 && !document.pages[7].isLoaded; i++) {
+      await tester.pump(const Duration(milliseconds: 10));
+      await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+
+    expect(document.pages.where((page) => page.isLoaded).map((page) => page.pageNumber), [1, 7, 8, 9]);
+    expect(document.reloadRequests, [
+      [7, 8, 9],
+    ]);
+
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 100));
+  });
+
+  testWidgets('calculated initial page and neighbors load first', (tester) async {
+    await binding.setSurfaceSize(const Size(800, 1200));
+    addTearDown(() => binding.setSurfaceSize(null));
+    final document = _TestDocument(9);
+    addTearDown(document.dispose);
+    var calculationCount = 0;
+    var controllerWasReady = false;
+    var loadFinishedCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PdfViewer(
+          PdfDocumentRefDirect(document, autoDispose: false),
+          initialPageNumber: 1,
+          params: PdfViewerParams(
+            calculateInitialPageNumber: (_, controller) {
+              calculationCount++;
+              controllerWasReady =
+                  controller.layout.pageLayouts.length == 9 &&
+                  controller.viewSize == const Size(800, 1200) &&
+                  controller.documentSize == controller.layout.documentSize &&
+                  controller.coverScale.isFinite &&
+                  controller.minScale.isFinite &&
+                  controller.maxScale.isFinite;
+              return 8;
+            },
+            onDocumentLoadFinished: (_, succeeded) {
+              if (succeeded) loadFinishedCount++;
+            },
+            behaviorControlParams: const PdfViewerBehaviorControlParams(trailingPageLoadingDelay: Duration(seconds: 2)),
+          ),
+        ),
+      ),
+    );
+
+    for (var i = 0; i < 50 && !document.pages[7].isLoaded; i++) {
+      await tester.pump(const Duration(milliseconds: 10));
+      await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+
+    expect(document.pages.where((page) => page.isLoaded).map((page) => page.pageNumber), [1, 7, 8, 9]);
+    expect(document.reloadRequests, [
+      [7, 8, 9],
+    ]);
+    expect(calculationCount, 1);
+    expect(controllerWasReady, isTrue);
+
+    await tester.pump(const Duration(seconds: 2));
+    for (var i = 0; i < 20 && loadFinishedCount == 0; i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(loadFinishedCount, 1);
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 100));
+  });
+
+  testWidgets('replayed completion waits for calculated initial page image', (tester) async {
+    await binding.setSurfaceSize(const Size(800, 1200));
+    addTearDown(() => binding.setSurfaceSize(null));
+    final document = _TestDocument(9, replayedEvents: const [_TestDocumentEvent.loadComplete]);
+    addTearDown(document.dispose);
+    final renderControl = (document.pages[7] as _TestPage).renderControl..block();
+    var loadFinished = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PdfViewer(
+          PdfDocumentRefDirect(document, autoDispose: false),
+          params: PdfViewerParams(
+            calculateInitialPageNumber: (_, _) => 8,
+            onDocumentLoadFinished: (_, succeeded) => loadFinished = succeeded,
+            behaviorControlParams: const PdfViewerBehaviorControlParams(trailingPageLoadingDelay: Duration(seconds: 2)),
+          ),
+        ),
+      ),
+    );
+
+    for (var i = 0; i < 30 && !renderControl.started; i++) {
+      await tester.pump(const Duration(milliseconds: 20));
+      await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+    expect(renderControl.started, isTrue);
+    expect(loadFinished, isFalse);
+
+    renderControl.release();
+    for (var i = 0; i < 30 && !loadFinished; i++) {
+      await tester.pump(const Duration(milliseconds: 20));
+      await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+    expect(loadFinished, isTrue);
+
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 100));
+  });
+
+  testWidgets('completed pages notify once without a replayed completion event', (tester) async {
+    final document = _TestDocument(
+      3,
+      replayedEvents: const [_TestDocumentEvent.missingFonts],
+      emitCompletionOnProgressive: false,
+    );
+    addTearDown(document.dispose);
+    var loadFinishedCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PdfViewer(
+          PdfDocumentRefDirect(document, autoDispose: false),
+          params: PdfViewerParams(
+            onDocumentLoadFinished: (_, succeeded) {
+              if (succeeded) loadFinishedCount++;
+            },
+            behaviorControlParams: const PdfViewerBehaviorControlParams(trailingPageLoadingDelay: Duration.zero),
+          ),
+        ),
+      ),
+    );
+
+    for (var i = 0; i < 30 && loadFinishedCount == 0; i++) {
+      await tester.pump(const Duration(milliseconds: 20));
+      await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(document.progressiveLoadingStarted, isTrue);
+    expect(loadFinishedCount, 1);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 100));
+  });
+
+  testWidgets('initial page callback failure falls back without stopping loading', (tester) async {
+    final document = _TestDocument(9);
+    addTearDown(document.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PdfViewer(
+          PdfDocumentRefDirect(document, autoDispose: false),
+          initialPageNumber: 8,
+          params: PdfViewerParams(
+            calculateInitialPageNumber: (_, _) => throw StateError('failed'),
+            behaviorControlParams: const PdfViewerBehaviorControlParams(trailingPageLoadingDelay: Duration.zero),
+          ),
+        ),
+      ),
+    );
+    for (var i = 0; i < 20 && !document.progressiveLoadingStarted; i++) {
+      await tester.pump(const Duration(milliseconds: 10));
+      await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+
+    expect(document.reloadRequests.first, [7, 8, 9]);
+    expect(document.progressiveLoadingStarted, isTrue);
+    expect(document.pages.every((page) => page.isLoaded), isTrue);
+    expect(tester.takeException(), isNull);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 100));
+  });
+
+  for (final testCase in [(calculated: 0, expected: 1), (calculated: 10, expected: 9)]) {
+    testWidgets('calculated initial page ${testCase.calculated} is clamped', (tester) async {
+      await binding.setSurfaceSize(const Size(800, 1200));
+      addTearDown(() => binding.setSurfaceSize(null));
+      final document = _TestDocument(9);
+      addTearDown(document.dispose);
+      var loadFinished = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PdfViewer(
+            PdfDocumentRefDirect(document, autoDispose: false),
+            params: PdfViewerParams(
+              calculateInitialPageNumber: (_, _) => testCase.calculated,
+              onDocumentLoadFinished: (_, succeeded) => loadFinished = succeeded,
+              behaviorControlParams: const PdfViewerBehaviorControlParams(trailingPageLoadingDelay: Duration.zero),
+            ),
+          ),
+        ),
+      );
+
+      for (var i = 0; i < 30 && !loadFinished; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+        await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+      }
+
+      expect(loadFinished, isTrue);
+      expect(document.reloadRequests.single, testCase.expected == 1 ? [2] : [8, 9]);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(milliseconds: 100));
+    });
+  }
+
+  testWidgets('replaced document does not start trailing loading', (tester) async {
+    final firstDocument = _TestDocument(3, sourceName: 'test:first');
+    final secondDocument = _TestDocument(3, sourceName: 'test:second');
+    addTearDown(firstDocument.dispose);
+    addTearDown(secondDocument.dispose);
+
+    Widget buildViewer(_TestDocument document) {
+      return MaterialApp(
+        home: PdfViewer(
+          PdfDocumentRefDirect(document, autoDispose: false),
+          initialPageNumber: 2,
+          params: const PdfViewerParams(
+            behaviorControlParams: PdfViewerBehaviorControlParams(trailingPageLoadingDelay: Duration(seconds: 1)),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildViewer(firstDocument));
+    for (var i = 0; i < 20 && firstDocument.reloadRequests.isEmpty; i++) {
+      await tester.pump(const Duration(milliseconds: 10));
+      await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+    expect(firstDocument.reloadRequests, isNotEmpty);
+
+    await tester.pumpWidget(buildViewer(secondDocument));
+    for (var i = 0; i < 20 && secondDocument.reloadRequests.isEmpty; i++) {
+      await tester.pump(const Duration(milliseconds: 10));
+      await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+    expect(secondDocument.reloadRequests, isNotEmpty);
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(firstDocument.progressiveLoadingStarted, isFalse);
+    expect(secondDocument.progressiveLoadingStarted, isTrue);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 100));
+  });
+
+  testWidgets('progressive loading continues when priority loading fails', (tester) async {
+    final document = _TestDocument(3, reloadError: UnimplementedError());
+    addTearDown(document.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PdfViewer(
+          PdfDocumentRefDirect(document, autoDispose: false),
+          initialPageNumber: 2,
+          params: const PdfViewerParams(
+            behaviorControlParams: PdfViewerBehaviorControlParams(trailingPageLoadingDelay: Duration.zero),
+          ),
+        ),
+      ),
+    );
+    for (var i = 0; i < 20 && !document.progressiveLoadingStarted; i++) {
+      await tester.pump(const Duration(milliseconds: 10));
+      await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+
+    expect(document.progressiveLoadingStarted, isTrue);
+    expect(document.pages.every((page) => page.isLoaded), isTrue);
+    expect(tester.takeException(), isNull);
 
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump(const Duration(milliseconds: 100));
@@ -291,4 +593,184 @@ void main() {
     expect(const PdfViewerParams().pageAnchor, PdfPageAnchor.top);
     expect(const PdfViewerParams().underflowAnchor, isNull);
   });
+}
+
+enum _TestDocumentEvent { loadComplete, missingFonts }
+
+class _TestDocument extends PdfDocument {
+  _TestDocument(
+    int pageCount, {
+    this.reloadError,
+    this.replayedEvents = const [],
+    this.emitCompletionOnProgressive = true,
+    super.sourceName = 'test:priority',
+  }) {
+    _pages = List.generate(pageCount, (index) => _TestPage(this, index + 1, isLoaded: index == 0));
+  }
+
+  final _events = StreamController<PdfDocumentEvent>.broadcast();
+  final Object? reloadError;
+  final List<_TestDocumentEvent> replayedEvents;
+  final bool emitCompletionOnProgressive;
+  late List<PdfPage> _pages;
+  final reloadRequests = <List<int>?>[];
+  bool progressiveLoadingStarted = false;
+
+  @override
+  Stream<PdfDocumentEvent> get events async* {
+    for (final event in replayedEvents) {
+      switch (event) {
+        case _TestDocumentEvent.loadComplete:
+          yield PdfDocumentLoadCompleteEvent(this);
+        case _TestDocumentEvent.missingFonts:
+          yield PdfDocumentMissingFontsEvent(this, const []);
+      }
+    }
+    yield* _events.stream;
+  }
+
+  @override
+  bool get isEncrypted => false;
+
+  @override
+  PdfPermissions? get permissions => null;
+
+  @override
+  List<PdfPage> get pages => List.unmodifiable(_pages);
+
+  @override
+  set pages(List<PdfPage> value) => _pages = List.of(value);
+
+  @override
+  Future<void> dispose() => _events.close();
+
+  @override
+  Future<void> loadPagesProgressively<T>({
+    PdfPageLoadingCallback<T>? onPageLoadProgress,
+    T? data,
+    Duration loadUnitDuration = const Duration(milliseconds: 250),
+  }) async {
+    progressiveLoadingStarted = true;
+    _loadPages([for (var pageNumber = 1; pageNumber <= _pages.length; pageNumber++) pageNumber]);
+    await onPageLoadProgress?.call(_pages.length, _pages.length, data);
+    if (emitCompletionOnProgressive) {
+      _events.add(PdfDocumentLoadCompleteEvent(this));
+    }
+  }
+
+  @override
+  Future<void> reloadPages({List<int>? pageNumbersToReload}) async {
+    reloadRequests.add(pageNumbersToReload?.toList());
+    if (reloadError != null) throw reloadError!;
+    final pageNumbers =
+        pageNumbersToReload ?? [for (var pageNumber = 1; pageNumber <= _pages.length; pageNumber++) pageNumber];
+    _loadPages(pageNumbers);
+  }
+
+  void _loadPages(List<int> pageNumbers) {
+    final changes = <int, PdfPageStatusChange>{};
+    for (final pageNumber in pageNumbers) {
+      if (_pages[pageNumber - 1].isLoaded) continue;
+      final previousPage = _pages[pageNumber - 1] as _TestPage;
+      final page = _TestPage(this, pageNumber, isLoaded: true, renderControl: previousPage.renderControl);
+      _pages[pageNumber - 1] = page;
+      changes[pageNumber] = PdfPageStatusChange.modified(page: page);
+    }
+    if (changes.isNotEmpty) {
+      _events.add(PdfDocumentPageStatusChangedEvent(this, changes: changes));
+    }
+  }
+
+  @override
+  Future<List<PdfOutlineNode>> loadOutline() async => const [];
+
+  @override
+  bool isIdenticalDocumentHandle(Object? other) => identical(this, other);
+
+  @override
+  Future<bool> assemble() async => true;
+
+  @override
+  Future<Uint8List> encodePdf({bool incremental = false, bool removeSecurity = false}) async => Uint8List(0);
+
+  @override
+  Future<T> useNativeDocumentHandle<T>(FutureOr<T> Function(int nativeDocumentHandle) task) async => await task(0);
+}
+
+class _TestPage implements PdfPage {
+  _TestPage(this.document, this.pageNumber, {required this.isLoaded, _TestPageRenderControl? renderControl})
+    : renderControl = renderControl ?? _TestPageRenderControl();
+
+  @override
+  final PdfDocument document;
+
+  @override
+  final int pageNumber;
+
+  @override
+  final bool isLoaded;
+
+  final _TestPageRenderControl renderControl;
+
+  @override
+  double get width => 600;
+
+  @override
+  double get height => 800;
+
+  @override
+  PdfPageRotation get rotation => PdfPageRotation.none;
+
+  @override
+  PdfPageRenderCancellationToken createCancellationToken() => _TestCancellationToken();
+
+  @override
+  Future<List<PdfLink>> loadLinks({bool compact = false, bool enableAutoLinkDetection = true}) async => const [];
+
+  @override
+  Future<PdfPageRawText?> loadText() async => null;
+
+  @override
+  Future<PdfImage?> render({
+    int x = 0,
+    int y = 0,
+    int? width,
+    int? height,
+    double? fullWidth,
+    double? fullHeight,
+    int? backgroundColor,
+    PdfPageRotation? rotationOverride,
+    PdfAnnotationRenderingMode annotationRenderingMode = PdfAnnotationRenderingMode.annotationAndForms,
+    int flags = PdfPageRenderFlags.none,
+    PdfPageRenderCancellationToken? cancellationToken,
+  }) async {
+    if (!isLoaded) return null;
+    await renderControl.beforeRender();
+    return PdfImage.createFromBgraData(Uint8List.fromList([255, 255, 255, 255]), width: 1, height: 1);
+  }
+}
+
+class _TestPageRenderControl {
+  Completer<void>? _gate;
+  bool started = false;
+
+  void block() => _gate = Completer<void>();
+
+  void release() => _gate?.complete();
+
+  Future<void> beforeRender() async {
+    started = true;
+    final gate = _gate;
+    if (gate != null) await gate.future;
+  }
+}
+
+class _TestCancellationToken implements PdfPageRenderCancellationToken {
+  bool _isCanceled = false;
+
+  @override
+  bool get isCanceled => _isCanceled;
+
+  @override
+  void cancel() => _isCanceled = true;
 }

--- a/packages/pdfrx/test/pdfium_worker_metadata_test.cjs
+++ b/packages/pdfrx/test/pdfium_worker_metadata_test.cjs
@@ -1,0 +1,91 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const workerSource = fs.readFileSync(path.join(__dirname, '..', 'assets', 'pdfium_worker.js'), 'utf8');
+
+function createContext() {
+  const context = {
+    self: { location: { href: 'test' } },
+    console: { log() {}, warn() {}, error() {} },
+    WebAssembly,
+    TextDecoder,
+    TextEncoder,
+    Uint8Array,
+    Float32Array,
+    ArrayBuffer,
+    onmessage: null,
+    postMessage() {},
+    fetch() {
+      throw new Error('Unexpected fetch');
+    },
+  };
+  vm.createContext(context);
+  vm.runInContext(workerSource, context);
+  return context;
+}
+
+test('page bounds survive WASM memory growth', () => {
+  const context = createContext();
+  const metadata = vm.runInContext(
+    `
+      Pdfium.memory = new WebAssembly.Memory({ initial: 1, maximum: 2 });
+      Pdfium.wasmExports = {
+        FPDF_LoadPage: () => 1,
+        FPDF_GetLastError: () => 0,
+        malloc: () => 32,
+        FPDF_GetPageBoundingBox: (_page, ptr) => {
+          new Float32Array(Pdfium.memory.buffer, ptr, 4).set([11, 22, 33, 44]);
+        },
+        FPDF_GetPageWidthF: () => {
+          Pdfium.memory.grow(1);
+          return 100;
+        },
+        FPDF_GetPageHeightF: () => 200,
+        FPDFPage_GetRotation: () => 0,
+        free: () => {},
+        FPDF_ClosePage: () => {},
+      };
+      _loadPageMetadata(1, 0);
+    `,
+    context,
+  );
+
+  assert.equal(metadata.bbLeft, 11);
+  assert.equal(metadata.bbBottom, 44);
+});
+
+test('page metadata resources are released after a failure', () => {
+  const context = createContext();
+
+  assert.throws(
+    () =>
+      vm.runInContext(
+        `
+          let freed = 0;
+          let closed = 0;
+          Pdfium.memory = new WebAssembly.Memory({ initial: 1 });
+          Pdfium.wasmExports = {
+            FPDF_LoadPage: () => 1,
+            FPDF_GetLastError: () => 0,
+            malloc: () => 32,
+            FPDF_GetPageBoundingBox: () => {},
+            FPDF_GetPageWidthF: () => { throw new Error('failed'); },
+            free: () => { freed++; },
+            FPDF_ClosePage: () => { closed++; },
+          };
+          try {
+            _loadPageMetadata(1, 0);
+          } finally {
+            if (freed !== 1 || closed !== 1) {
+              throw new Error('Resources were not released');
+            }
+          }
+        `,
+        context,
+      ),
+    /failed/,
+  );
+});

--- a/packages/pdfrx_coregraphics/lib/pdfrx_coregraphics.dart
+++ b/packages/pdfrx_coregraphics/lib/pdfrx_coregraphics.dart
@@ -560,7 +560,7 @@ class _CoreGraphicsPdfDocument extends PdfDocument {
   }
 }
 
-class _CoreGraphicsPdfPage extends PdfPage {
+class _CoreGraphicsPdfPage extends PdfPage with PdfPageLinkCache {
   _CoreGraphicsPdfPage({
     required _CoreGraphicsPdfDocument document,
     required this.index,
@@ -710,10 +710,7 @@ class _CoreGraphicsPdfPage extends PdfPage {
   }
 
   @override
-  Future<List<PdfLink>> loadLinks({
-    bool compact = false,
-    bool enableAutoLinkDetection = true,
-  }) async {
+  Future<List<PdfLink>> loadLinksUncached(bool enableAutoLinkDetection) async {
     try {
       final result = await _document.channel
           .invokeListMethod<Object?>('loadPageLinks', {
@@ -747,7 +744,6 @@ class _CoreGraphicsPdfPage extends PdfPage {
             final url = map['url'] as String?;
             final destMap = map['dest'] as Map<Object?, Object?>?;
 
-            // Parse annotation from Swift
             final annotationData = map['annotation'] as Map<Object?, Object?>?;
             final annotation = annotationData != null
                 ? PdfAnnotation(
@@ -763,13 +759,12 @@ class _CoreGraphicsPdfPage extends PdfPage {
                   )
                 : null;
 
-            final link = PdfLink(
+            return PdfLink(
               rects,
               url: url == null ? null : Uri.tryParse(url),
               dest: _parseDest(destMap, defaultPageNumber: pageNumber),
               annotation: annotation,
             );
-            return compact ? link.compact() : link;
           })
           .toList(growable: false);
       return List.unmodifiable(links);

--- a/packages/pdfrx_coregraphics/lib/pdfrx_coregraphics.dart
+++ b/packages/pdfrx_coregraphics/lib/pdfrx_coregraphics.dart
@@ -489,8 +489,13 @@ class _CoreGraphicsPdfDocument extends PdfDocument {
 
   @override
   set pages(List<PdfPage> newPages) {
+    final previousPageCount = _pages.length;
     final pages = <PdfPage>[];
     final changes = <int, PdfPageStatusChange>{};
+    late final oldPageIndices = Map<PdfPage, int>.identity()
+      ..addEntries([
+        for (var i = 0; i < _pages.length; i++) MapEntry(_pages[i], i),
+      ]);
     for (final newPage in newPages) {
       if (pages.length < _pages.length) {
         final old = _pages[pages.length];
@@ -511,7 +516,7 @@ class _CoreGraphicsPdfDocument extends PdfDocument {
       final updated = newPage.withPageNumber(newPageNumber);
       pages.add(updated);
 
-      final oldPageIndex = _pages.indexWhere((p) => identical(p, newPage));
+      final oldPageIndex = oldPageIndices[newPage] ?? -1;
       if (oldPageIndex != -1) {
         changes[newPageNumber] = PdfPageStatusChange.moved(
           page: updated,
@@ -523,7 +528,9 @@ class _CoreGraphicsPdfDocument extends PdfDocument {
     }
 
     _pages = pages;
-    subject.add(PdfDocumentPageStatusChangedEvent(this, changes: changes));
+    if (changes.isNotEmpty || pages.length != previousPageCount) {
+      subject.add(PdfDocumentPageStatusChangedEvent(this, changes: changes));
+    }
   }
 
   @override

--- a/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
+++ b/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
@@ -986,6 +986,7 @@ class _PdfDocumentPdfium extends PdfDocument {
   final pdfium_bindings.FPDF_FORMHANDLE formHandle;
   final Pointer<pdfium_bindings.FPDF_FORMFILLINFO> formInfo;
   bool isDisposed = false;
+  bool _documentLoadCompleteNotified = false;
   final subject = BehaviorSubject<PdfDocumentEvent>();
 
   @override
@@ -1085,14 +1086,19 @@ class _PdfDocumentPdfium extends PdfDocument {
     for (;;) {
       if (isDisposed) return;
 
-      final firstUnloadedPageIndex = _pages.indexWhere((p) => !p.isLoaded);
+      final firstUnloadedPageIndex = _pages.indexWhere((page) => !page.isLoaded);
       if (firstUnloadedPageIndex == -1) {
-        // All pages are already loaded
+        _notifyDocumentLoadComplete();
         return;
       }
-
+      final loadedPageIndicesToSkip = <int>[
+        for (var i = firstUnloadedPageIndex + 1; i < _pages.length; i++)
+          if (_pages[i].isLoaded) i,
+      ];
       final loaded = await _loadPagesInLimitedTime(
-        pagesLoadedSoFar: _pages.sublist(0, firstUnloadedPageIndex).toList(),
+        pagesLoadedCountSoFar: firstUnloadedPageIndex,
+        loadedPageIndicesToSkip: loadedPageIndicesToSkip,
+        pagesToPreserve: _pages,
         timeout: loadUnitDuration,
       );
       if (isDisposed) return;
@@ -1101,131 +1107,144 @@ class _PdfDocumentPdfium extends PdfDocument {
       if (onPageLoadProgress != null) {
         final result = await onPageLoadProgress(loaded.pageCountLoadedTotal, loaded.pages.length, data);
         if (result == false) {
+          if (_pages.every((page) => page.isLoaded)) {
+            _notifyDocumentLoadComplete();
+          }
           // If the callback returns false, stop loading pages
           return;
         }
-      }
-      if (loaded.pageCountLoadedTotal == loaded.pages.length) {
-        _notifyDocumentLoadComplete();
-        return;
-      }
-      if (isDisposed) {
-        return;
       }
     }
   }
 
   void _notifyDocumentLoadComplete() {
-    if (!isDisposed) {
+    if (!isDisposed && !_documentLoadCompleteNotified) {
+      _documentLoadCompleteNotified = true;
       subject.add(PdfDocumentLoadCompleteEvent(this));
     }
   }
 
   /// Loads pages in the document in a time-limited manner.
   Future<({List<PdfPage> pages, int pageCountLoadedTotal})> _loadPagesInLimitedTime({
-    List<PdfPage> pagesLoadedSoFar = const [],
+    int pagesLoadedCountSoFar = 0,
+    List<int> loadedPageIndicesToSkip = const [],
+    List<PdfPage> pagesToPreserve = const [],
     int? maxPageCountToLoadAdditionally,
     Duration? timeout,
   }) async {
-    try {
-      final results = await BackgroundWorker.computeWithArena(
-        (arena, params) {
-          final doc = pdfium_bindings.FPDF_DOCUMENT.fromAddress(params.docAddress);
-          final pageCount = pdfium.FPDF_GetPageCount(doc);
-          final end = maxPageCountToLoadAdditionally == null
-              ? pageCount
-              : min(pageCount, params.pagesCountLoadedSoFar + params.maxPageCountToLoadAdditionally!);
-          final t = params.timeoutUs != null ? (Stopwatch()..start()) : null;
-          final pages = <({double width, double height, int rotation, double bbLeft, double bbBottom})>[];
-          for (var i = params.pagesCountLoadedSoFar; i < end; i++) {
-            final page = pdfium.FPDF_LoadPage(doc, i);
-            try {
-              final rect = arena<pdfium_bindings.FS_RECTF>();
-              pdfium.FPDF_GetPageBoundingBox(page, rect);
-              pages.add((
-                width: pdfium.FPDF_GetPageWidthF(page),
-                height: pdfium.FPDF_GetPageHeightF(page),
-                rotation: pdfium.FPDFPage_GetRotation(page),
-                bbLeft: rect.ref.left.toDouble(),
-                bbBottom: rect.ref.bottom.toDouble(),
-              ));
-            } finally {
-              pdfium.FPDF_ClosePage(page);
-            }
-            if (t != null && t.elapsedMicroseconds > params.timeoutUs!) {
-              break;
-            }
+    final results = await BackgroundWorker.computeWithArena(
+      (arena, params) {
+        final doc = pdfium_bindings.FPDF_DOCUMENT.fromAddress(params.docAddress);
+        final pageCount = pdfium.FPDF_GetPageCount(doc);
+        final loadedPageIndicesToSkip = params.loadedPageIndicesToSkip.toSet();
+        final t = params.timeoutUs != null ? (Stopwatch()..start()) : null;
+        final pages = <({int pageIndex, double width, double height, int rotation, double bbLeft, double bbBottom})>[];
+        for (var i = params.pagesCountLoadedSoFar; i < pageCount; i++) {
+          if (loadedPageIndicesToSkip.contains(i)) continue;
+          final page = pdfium.FPDF_LoadPage(doc, i);
+          try {
+            final rect = arena<pdfium_bindings.FS_RECTF>();
+            pdfium.FPDF_GetPageBoundingBox(page, rect);
+            pages.add((
+              pageIndex: i,
+              width: pdfium.FPDF_GetPageWidthF(page),
+              height: pdfium.FPDF_GetPageHeightF(page),
+              rotation: pdfium.FPDFPage_GetRotation(page),
+              bbLeft: rect.ref.left.toDouble(),
+              bbBottom: rect.ref.bottom.toDouble(),
+            ));
+          } finally {
+            pdfium.FPDF_ClosePage(page);
           }
-          return (pages: pages, totalPageCount: pageCount);
-        },
-        (
-          docAddress: document.address,
-          pagesCountLoadedSoFar: pagesLoadedSoFar.length,
-          maxPageCountToLoadAdditionally: maxPageCountToLoadAdditionally,
-          timeoutUs: timeout?.inMicroseconds,
+          if (params.maxPageCountToLoadAdditionally != null && pages.length >= params.maxPageCountToLoadAdditionally!) {
+            break;
+          }
+          if (t != null && t.elapsedMicroseconds > params.timeoutUs!) {
+            break;
+          }
+        }
+        return (pages: pages, totalPageCount: pageCount);
+      },
+      (
+        docAddress: document.address,
+        pagesCountLoadedSoFar: pagesLoadedCountSoFar,
+        loadedPageIndicesToSkip: loadedPageIndicesToSkip,
+        maxPageCountToLoadAdditionally: maxPageCountToLoadAdditionally,
+        timeoutUs: timeout?.inMicroseconds,
+      ),
+    );
+
+    final pages = [...pagesToPreserve];
+    for (final pageData in results.pages) {
+      final page = _PdfPagePdfium._(
+        document: this,
+        pageNumber: pageData.pageIndex + 1,
+        width: pageData.width,
+        height: pageData.height,
+        rotation: PdfPageRotation.values[pageData.rotation],
+        bbLeft: pageData.bbLeft,
+        bbBottom: pageData.bbBottom,
+        isLoaded: true,
+      );
+      if (pageData.pageIndex < pages.length) {
+        pages[pageData.pageIndex] = page;
+      } else {
+        pages.add(page);
+      }
+    }
+    _resizePagesWithPlaceholders(pages, results.totalPageCount);
+    final firstUnloadedPageIndex = pages.indexWhere((page) => !page.isLoaded);
+    final pageCountLoadedTotal = firstUnloadedPageIndex < 0 ? pages.length : firstUnloadedPageIndex;
+    return (pages: pages, pageCountLoadedTotal: pageCountLoadedTotal);
+  }
+
+  /// Resizes [pages], using unloaded placeholders when the document grows.
+  void _resizePagesWithPlaceholders(List<PdfPage> pages, int pageCount) {
+    if (pages.length > pageCount) {
+      pages.removeRange(pageCount, pages.length);
+      return;
+    }
+    if (pages.isEmpty || pages.length == pageCount) return;
+
+    final templatePage = pages.lastWhere((page) => page.isLoaded, orElse: () => pages.last);
+    while (pages.length < pageCount) {
+      pages.add(
+        _PdfPagePdfium._(
+          document: this,
+          pageNumber: pages.length + 1,
+          width: templatePage.width,
+          height: templatePage.height,
+          rotation: templatePage.rotation,
+          bbLeft: 0,
+          bbBottom: 0,
+          isLoaded: false,
         ),
       );
-
-      final pages = [...pagesLoadedSoFar];
-      for (var i = 0; i < results.pages.length; i++) {
-        final pageData = results.pages[i];
-        pages.add(
-          _PdfPagePdfium._(
-            document: this,
-            pageNumber: pages.length + 1,
-            width: pageData.width,
-            height: pageData.height,
-            rotation: PdfPageRotation.values[pageData.rotation],
-            bbLeft: pageData.bbLeft,
-            bbBottom: pageData.bbBottom,
-            isLoaded: true,
-          ),
-        );
-      }
-      final pageCountLoadedTotal = pages.length;
-      if (pageCountLoadedTotal > 0) {
-        final last = pages.last;
-        for (var i = pages.length; i < results.totalPageCount; i++) {
-          pages.add(
-            _PdfPagePdfium._(
-              document: this,
-              pageNumber: pages.length + 1,
-              width: last.width,
-              height: last.height,
-              rotation: last.rotation,
-              bbLeft: 0,
-              bbBottom: 0,
-              isLoaded: false,
-            ),
-          );
-        }
-      }
-      return (pages: pages, pageCountLoadedTotal: pageCountLoadedTotal);
-    } catch (e) {
-      rethrow;
     }
   }
 
   @override
   Future<void> reloadPages({List<int>? pageNumbersToReload}) async {
-    try {
-      final results = await BackgroundWorker.computeWithArena((arena, params) {
-        final doc = pdfium_bindings.FPDF_DOCUMENT.fromAddress(params.docAddress);
-        final pageCount = pdfium.FPDF_GetPageCount(doc);
-        if (params.pageNumbersToReload != null) {
-          for (final pageNumber in params.pageNumbersToReload!) {
-            if (pageNumber < 1 || pageNumber > pageCount) {
-              throw ArgumentError('Invalid page number to reload: $pageNumber', 'pageNumbersToReload');
-            }
+    final results = await BackgroundWorker.computeWithArena((arena, params) {
+      final doc = pdfium_bindings.FPDF_DOCUMENT.fromAddress(params.docAddress);
+      final pageCount = pdfium.FPDF_GetPageCount(doc);
+      int? invalidPageNumber;
+      if (params.pageNumbersToReload != null) {
+        for (final pageNumber in params.pageNumbersToReload!) {
+          if (pageNumber < 1 || pageNumber > pageCount) {
+            invalidPageNumber = pageNumber;
+            break;
           }
         }
+      }
 
-        final pageNumbersToLoad = SplayTreeSet.from(params.pageNumbersToReload ?? []);
-        pageNumbersToLoad.addAll(
-          Iterable.generate(pageCount - params.currentPageCount, (index) => params.currentPageCount + index + 1),
-        );
+      final pageNumbersToLoad = SplayTreeSet.from(params.pageNumbersToReload ?? []);
+      pageNumbersToLoad.addAll(
+        Iterable.generate(pageCount - params.currentPageCount, (index) => params.currentPageCount + index + 1),
+      );
 
-        final pages = <({int pageIndex, double width, double height, int rotation, double bbLeft, double bbBottom})>[];
+      final pages = <({int pageIndex, double width, double height, int rotation, double bbLeft, double bbBottom})>[];
+      if (invalidPageNumber == null) {
         for (final pageNumber in pageNumbersToLoad) {
           final page = pdfium.FPDF_LoadPage(doc, pageNumber - 1);
           try {
@@ -1243,32 +1262,37 @@ class _PdfDocumentPdfium extends PdfDocument {
             pdfium.FPDF_ClosePage(page);
           }
         }
-        return (pages: pages);
-      }, (docAddress: document.address, pageNumbersToReload: pageNumbersToReload, currentPageCount: _pages.length));
-
-      final newPages = [..._pages];
-      for (var i = 0; i < results.pages.length; i++) {
-        final pageData = results.pages[i];
-        final newPage = _PdfPagePdfium._(
-          document: this,
-          pageNumber: i + 1,
-          width: pageData.width,
-          height: pageData.height,
-          rotation: PdfPageRotation.values[pageData.rotation],
-          bbLeft: pageData.bbLeft,
-          bbBottom: pageData.bbBottom,
-          isLoaded: true,
-        );
-        if (i < newPages.length) {
-          newPages[i] = newPage;
-        } else {
-          newPages.add(newPage);
-        }
       }
-      pages = newPages;
-    } catch (e) {
-      rethrow;
+      return (pages: pages, invalidPageNumber: invalidPageNumber);
+    }, (docAddress: document.address, pageNumbersToReload: pageNumbersToReload, currentPageCount: _pages.length));
+    if (results.invalidPageNumber != null) {
+      throw ArgumentError.value(
+        results.invalidPageNumber,
+        'pageNumbersToReload',
+        'Page number is outside the document',
+      );
     }
+
+    final newPages = [..._pages];
+    for (var i = 0; i < results.pages.length; i++) {
+      final pageData = results.pages[i];
+      final newPage = _PdfPagePdfium._(
+        document: this,
+        pageNumber: pageData.pageIndex + 1,
+        width: pageData.width,
+        height: pageData.height,
+        rotation: PdfPageRotation.values[pageData.rotation],
+        bbLeft: pageData.bbLeft,
+        bbBottom: pageData.bbBottom,
+        isLoaded: true,
+      );
+      if (pageData.pageIndex < newPages.length) {
+        newPages[pageData.pageIndex] = newPage;
+      } else {
+        newPages.add(newPage);
+      }
+    }
+    pages = newPages;
   }
 
   @override
@@ -1276,8 +1300,11 @@ class _PdfDocumentPdfium extends PdfDocument {
 
   @override
   set pages(Iterable<PdfPage> newPages) {
+    final previousPageCount = _pages.length;
     final pages = <PdfPage>[];
     final changes = <int, PdfPageStatusChange>{};
+    late final oldPageIndices = Map<PdfPage, int>.identity()
+      ..addEntries([for (var i = 0; i < _pages.length; i++) MapEntry(_pages[i], i)]);
     for (final newPage in newPages) {
       if (pages.length < _pages.length) {
         final old = _pages[pages.length];
@@ -1295,7 +1322,7 @@ class _PdfDocumentPdfium extends PdfDocument {
       final updated = newPage.withPageNumber(newPageNumber);
       pages.add(updated);
 
-      final oldPageIndex = _pages.indexWhere((p) => identical(p, newPage));
+      final oldPageIndex = oldPageIndices[newPage] ?? -1;
       if (oldPageIndex != -1) {
         changes[newPageNumber] = PdfPageStatusChange.moved(page: updated, oldPageNumber: oldPageIndex + 1);
       } else {
@@ -1304,7 +1331,8 @@ class _PdfDocumentPdfium extends PdfDocument {
     }
 
     _pages = List.unmodifiable(pages);
-    if (!isDisposed) {
+    if (!isDisposed && (changes.isNotEmpty || pages.length != previousPageCount)) {
+      _documentLoadCompleteNotified = false;
       subject.add(PdfDocumentPageStatusChangedEvent(this, changes: changes));
     }
   }

--- a/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
+++ b/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
@@ -1525,7 +1525,7 @@ class _DocumentPageArranger with ShuffleItemsInPlaceMixin {
   }
 }
 
-class _PdfPagePdfium extends PdfPage {
+class _PdfPagePdfium extends PdfPage with PdfPageLinkCache {
   @override
   final _PdfDocumentPdfium document;
   @override
@@ -1740,16 +1740,11 @@ class _PdfPagePdfium extends PdfPage {
   }
 
   @override
-  Future<List<PdfLink>> loadLinks({bool compact = false, bool enableAutoLinkDetection = true}) async {
+  Future<List<PdfLink>> loadLinksUncached(bool enableAutoLinkDetection) async {
     if (document.isDisposed || !isLoaded) return [];
     final links = await _loadAnnotLinks();
     if (enableAutoLinkDetection) {
       links.addAll(await _loadWebLinks());
-    }
-    if (compact) {
-      for (var i = 0; i < links.length; i++) {
-        links[i] = links[i].compact();
-      }
     }
     return List.unmodifiable(links);
   }

--- a/packages/pdfrx_engine/lib/src/pdf_page.dart
+++ b/packages/pdfrx_engine/lib/src/pdf_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
 
 import 'pdf_document.dart';
@@ -91,8 +92,10 @@ abstract class PdfPage {
 
   /// Load links.
   ///
-  /// If [compact] is true, it tries to reduce memory usage by compacting the link data.
-  /// See [PdfLink.compact] for more info.
+  /// Results may be cached for this page instance. Reload the page after modifying its annotations.
+  ///
+  /// If [compact] is true, the link data may be compacted. Cached implementations may return compact data for both
+  /// values to avoid retaining duplicate results. See [PdfLink.compact] for more info.
   ///
   /// If [enableAutoLinkDetection] is true, the function tries to detect Web links automatically.
   /// This is useful if the PDF file contains text that looks like Web links but not defined as links in the PDF.
@@ -100,6 +103,48 @@ abstract class PdfPage {
   ///
   /// If the page is not loaded yet (progressive loading case only), this function returns an empty list.
   Future<List<PdfLink>> loadLinks({bool compact = false, bool enableAutoLinkDetection = true});
+}
+
+/// Caches [loadLinksUncached] once for each auto-detection mode used by [PdfPage.loadLinks].
+///
+/// Cached links are compacted with [PdfLink.compact], made unmodifiable, and shared by raw and compact requests.
+/// Failures are not cached, and results live for the lifetime of the [PdfPage] instance.
+mixin PdfPageLinkCache on PdfPage {
+  Future<List<PdfLink>>? _linksWithAutoDetection;
+  Future<List<PdfLink>>? _linksWithoutAutoDetection;
+
+  @override
+  Future<List<PdfLink>> loadLinks({bool compact = false, bool enableAutoLinkDetection = true}) {
+    if (!isLoaded) return Future.value(const <PdfLink>[]);
+    final cached = enableAutoLinkDetection ? _linksWithAutoDetection : _linksWithoutAutoDetection;
+    if (cached != null) return cached;
+
+    final loading = _loadAndCompactLinks(enableAutoLinkDetection);
+    if (enableAutoLinkDetection) {
+      _linksWithAutoDetection = loading;
+    } else {
+      _linksWithoutAutoDetection = loading;
+    }
+    return loading;
+  }
+
+  Future<List<PdfLink>> _loadAndCompactLinks(bool enableAutoLinkDetection) async {
+    try {
+      final links = await Future<List<PdfLink>>.sync(() => loadLinksUncached(enableAutoLinkDetection));
+      return List<PdfLink>.unmodifiable([for (final link in links) link.compact()]);
+    } catch (_) {
+      if (enableAutoLinkDetection) {
+        _linksWithAutoDetection = null;
+      } else {
+        _linksWithoutAutoDetection = null;
+      }
+      rethrow;
+    }
+  }
+
+  /// Loads links for one auto-detection mode without using the page cache.
+  @protected
+  Future<List<PdfLink>> loadLinksUncached(bool enableAutoLinkDetection);
 }
 
 /// Extension methods for [PdfPage].

--- a/packages/pdfrx_engine/test/pdf_document_test.dart
+++ b/packages/pdfrx_engine/test/pdf_document_test.dart
@@ -29,6 +29,280 @@ void main() {
     final data = await testPdfFile.readAsBytes();
     await testDocument(await PdfDocument.openData(data));
   });
+  test('reloadPages loads a sparse progressive page at its original index', () async {
+    final document = await PdfDocument.openFile(testPdfFile.path, useProgressiveLoading: true);
+    addTearDown(document.dispose);
+
+    expect(document.pages.map((page) => page.isLoaded), [true, false, false]);
+
+    final eventFuture = document.events
+        .where((event) => event is PdfDocumentPageStatusChangedEvent)
+        .cast<PdfDocumentPageStatusChangedEvent>()
+        .firstWhere((event) => event.changes.containsKey(3));
+
+    await document.reloadPages(pageNumbersToReload: [3]);
+    final event = await eventFuture;
+
+    expect(document.pages.map((page) => page.pageNumber), [1, 2, 3]);
+    expect(document.pages.map((page) => page.isLoaded), [true, false, true]);
+    expect(event.changes.keys, [3]);
+    expect(event.changes[3]!.page, same(document.pages[2]));
+  });
+  test('reloadPages deduplicates and orders sparse page requests', () async {
+    final document = await PdfDocument.openFile(testPdfFile.path, useProgressiveLoading: true);
+    addTearDown(document.dispose);
+    final eventFuture = document.events
+        .where((event) => event is PdfDocumentPageStatusChangedEvent)
+        .cast<PdfDocumentPageStatusChangedEvent>()
+        .firstWhere((event) => event.changes.containsKey(2));
+
+    await document.reloadPages(pageNumbersToReload: [3, 2, 3]);
+    final event = await eventFuture;
+
+    expect(document.pages.map((page) => page.pageNumber), [1, 2, 3]);
+    expect(document.pages.every((page) => page.isLoaded), isTrue);
+    expect(event.changes.keys, [2, 3]);
+  });
+  test('reloadPages rejects invalid page numbers without mutation', () async {
+    final document = await PdfDocument.openFile(testPdfFile.path, useProgressiveLoading: true);
+    addTearDown(document.dispose);
+    final pages = document.pages.toList();
+
+    await expectLater(document.reloadPages(pageNumbersToReload: [0, 2]), throwsArgumentError);
+    await expectLater(document.reloadPages(pageNumbersToReload: [4]), throwsArgumentError);
+
+    expect(document.pages, orderedEquals(pages));
+  });
+  test('reloadPages with an empty list emits no page status event', () async {
+    final document = await PdfDocument.openFile(testPdfFile.path);
+    addTearDown(document.dispose);
+    var statusEventCount = 0;
+    final subscription = document.events
+        .where((event) => event is PdfDocumentPageStatusChangedEvent)
+        .listen((_) => statusEventCount++);
+    addTearDown(subscription.cancel);
+
+    await document.reloadPages(pageNumbersToReload: const []);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(statusEventCount, 0);
+  });
+  test('pages setter reports moved pages by identity', () async {
+    final document = await PdfDocument.openFile(testPdfFile.path);
+    addTearDown(document.dispose);
+    final originalPages = document.pages.toList();
+    final eventFuture = document.events
+        .where((event) => event is PdfDocumentPageStatusChangedEvent)
+        .cast<PdfDocumentPageStatusChangedEvent>()
+        .first;
+
+    document.pages = [originalPages[1], originalPages[0], originalPages[2]];
+    final event = await eventFuture;
+
+    expect(event.changes.keys, [1, 2]);
+    expect(event.changes[1], isA<PdfPageStatusMoved>());
+    expect(event.changes[2], isA<PdfPageStatusMoved>());
+  });
+  test('pages setter reports page removal', () async {
+    final document = await PdfDocument.openFile(testPdfFile.path);
+    addTearDown(document.dispose);
+    final events = <PdfDocumentPageStatusChangedEvent>[];
+    final subscription = document.events
+        .where((event) => event is PdfDocumentPageStatusChangedEvent)
+        .cast<PdfDocumentPageStatusChangedEvent>()
+        .listen(events.add);
+    addTearDown(subscription.cancel);
+
+    document.pages = document.pages.sublist(0, document.pages.length - 1);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(document.pages, hasLength(2));
+    expect(events, hasLength(1));
+    expect(events.single.changes, isEmpty);
+  });
+  test('pages setter resets completion after adding a page', () async {
+    final document = await PdfDocument.openFile(testPdfFile.path);
+    addTearDown(document.dispose);
+    final completionEvents = <PdfDocumentLoadCompleteEvent>[];
+    final subscription = document.events
+        .where((event) => event is PdfDocumentLoadCompleteEvent)
+        .cast<PdfDocumentLoadCompleteEvent>()
+        .listen(completionEvents.add);
+    addTearDown(subscription.cancel);
+    await Future<void>.delayed(Duration.zero);
+    completionEvents.clear();
+
+    document.pages = [...document.pages, document.pages.last];
+    await document.loadPagesProgressively();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(completionEvents, hasLength(1));
+  });
+  test('pages setter resets completion after reordering pages', () async {
+    final document = await PdfDocument.openFile(testPdfFile.path);
+    addTearDown(document.dispose);
+    final completionEvents = <PdfDocumentLoadCompleteEvent>[];
+    final subscription = document.events
+        .where((event) => event is PdfDocumentLoadCompleteEvent)
+        .cast<PdfDocumentLoadCompleteEvent>()
+        .listen(completionEvents.add);
+    addTearDown(subscription.cancel);
+    await Future<void>.delayed(Duration.zero);
+    completionEvents.clear();
+
+    document.pages = [document.pages[1], document.pages[0], document.pages[2]];
+    await document.loadPagesProgressively();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(completionEvents, hasLength(1));
+  });
+  test('consecutive completed loads do not duplicate completion', () async {
+    final document = await PdfDocument.openFile(testPdfFile.path);
+    addTearDown(document.dispose);
+    final completionEvents = <PdfDocumentLoadCompleteEvent>[];
+    final subscription = document.events
+        .where((event) => event is PdfDocumentLoadCompleteEvent)
+        .cast<PdfDocumentLoadCompleteEvent>()
+        .listen(completionEvents.add);
+    addTearDown(subscription.cancel);
+    await Future<void>.delayed(Duration.zero);
+    completionEvents.clear();
+
+    await document.loadPagesProgressively();
+    await document.loadPagesProgressively();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(completionEvents, isEmpty);
+  });
+  test('missing-font events do not duplicate completion', () async {
+    final document = await PdfDocument.openFile(testPdfFile.path);
+    addTearDown(document.dispose);
+    final events = <PdfDocumentEvent>[];
+    final subscription = document.events.listen(events.add);
+    addTearDown(subscription.cancel);
+    await Future<void>.delayed(Duration.zero);
+    expect(events.whereType<PdfDocumentLoadCompleteEvent>(), hasLength(1));
+    final missingFontEvent = document.events.where((event) => event is PdfDocumentMissingFontsEvent).first;
+
+    final image = await document.pages.first.render();
+    image?.dispose();
+    await missingFontEvent.timeout(const Duration(seconds: 1));
+    expect(events.whereType<PdfDocumentMissingFontsEvent>(), isNotEmpty);
+    final completionCount = events.whereType<PdfDocumentLoadCompleteEvent>().length;
+
+    await document.loadPagesProgressively();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(events.whereType<PdfDocumentLoadCompleteEvent>(), hasLength(completionCount));
+  });
+  test('progressive loading preserves pages loaded out of order', () async {
+    final document = await PdfDocument.openFile(testPdfFile.path, useProgressiveLoading: true);
+    addTearDown(document.dispose);
+    await document.reloadPages(pageNumbersToReload: [3]);
+
+    final eventFuture = document.events
+        .where((event) => event is PdfDocumentPageStatusChangedEvent)
+        .cast<PdfDocumentPageStatusChangedEvent>()
+        .firstWhere((event) => event.changes.containsKey(2));
+    await document.loadPagesProgressively(loadUnitDuration: Duration.zero, onPageLoadProgress: (_, _, _) => false);
+    final event = await eventFuture;
+
+    expect(document.pages.map((page) => page.isLoaded), [true, true, true]);
+    expect(event.changes.keys, [2]);
+  });
+  test('progressive loading skips pages loaded out of order', () async {
+    final document = await PdfDocument.openFile(testPdfFile.path, useProgressiveLoading: true);
+    addTearDown(document.dispose);
+    await document.reloadPages(pageNumbersToReload: [3]);
+    final prefetchedPage = document.pages[2];
+
+    await document.loadPagesProgressively(loadUnitDuration: const Duration(seconds: 1));
+
+    expect(document.pages.every((page) => page.isLoaded), isTrue);
+    expect(document.pages[2], same(prefetchedPage));
+  });
+  test('progressive loading resynchronizes after callback changes pages', () async {
+    final document = await PdfDocument.openFile(testPdfFile.path, useProgressiveLoading: true);
+    addTearDown(document.dispose);
+    var rearranged = false;
+
+    await document.loadPagesProgressively(
+      loadUnitDuration: Duration.zero,
+      onPageLoadProgress: (_, _, _) {
+        if (!rearranged) {
+          rearranged = true;
+          document.pages = [document.pages[0], document.pages[2], document.pages[1]];
+        }
+        return true;
+      },
+    );
+
+    expect(rearranged, isTrue);
+    expect(document.pages.every((page) => page.isLoaded), isTrue);
+  });
+  test('progressive loading notifies completion after prefetch loads every page', () async {
+    final document = await PdfDocument.openFile(testPdfFile.path, useProgressiveLoading: true);
+    addTearDown(document.dispose);
+    await document.reloadPages(pageNumbersToReload: [2, 3]);
+    final completionEvent = document.events.where((event) => event is PdfDocumentLoadCompleteEvent).first;
+
+    await document.loadPagesProgressively();
+
+    await expectLater(completionEvent.timeout(const Duration(seconds: 1)), completes);
+  });
+  test('progressive loading notifies completion when final callback stops', () async {
+    final document = await PdfDocument.openFile(testPdfFile.path, useProgressiveLoading: true);
+    addTearDown(document.dispose);
+    final completionEvent = document.events.where((event) => event is PdfDocumentLoadCompleteEvent).first;
+
+    await document.loadPagesProgressively(
+      loadUnitDuration: const Duration(seconds: 1),
+      onPageLoadProgress: (_, _, _) => false,
+    );
+
+    expect(document.pages.every((page) => page.isLoaded), isTrue);
+    await expectLater(completionEvent.timeout(const Duration(seconds: 1)), completes);
+  });
+  test('loadLinks reuses raw and compact results', () async {
+    final document = await PdfDocument.openFile(testPdfFile.path);
+    addTearDown(document.dispose);
+    final page = document.pages.first;
+
+    final raw = await page.loadLinks(enableAutoLinkDetection: false);
+    final rawAgain = await page.loadLinks(enableAutoLinkDetection: false);
+    final compact = await page.loadLinks(compact: true, enableAutoLinkDetection: false);
+    final compactAgain = await page.loadLinks(compact: true, enableAutoLinkDetection: false);
+
+    expect(raw, isNotEmpty);
+    expect(rawAgain, same(raw));
+    expect(compact, same(raw));
+    expect(compactAgain, same(compact));
+    expect(() => compact.first.rects.add(const PdfRect(0, 1, 1, 0)), throwsUnsupportedError);
+  });
+  test('loadLinks coalesces concurrent requests', () async {
+    final document = await PdfDocument.openFile(testPdfFile.path);
+    addTearDown(document.dispose);
+    final page = document.pages.first;
+
+    final results = await Future.wait([for (var i = 0; i < 8; i++) page.loadLinks()]);
+
+    expect(results.first, isNotEmpty);
+    expect(results.skip(1).every((links) => identical(links, results.first)), isTrue);
+  });
+  test('reloadPages replaces the page link cache', () async {
+    final document = await PdfDocument.openFile(testPdfFile.path);
+    addTearDown(document.dispose);
+    final oldPage = document.pages.first;
+    final oldLinks = await oldPage.loadLinks(enableAutoLinkDetection: false);
+
+    await document.reloadPages(pageNumbersToReload: [1]);
+    final newPage = document.pages.first;
+    final newLinks = await newPage.loadLinks(enableAutoLinkDetection: false);
+
+    expect(newPage, isNot(same(oldPage)));
+    expect(newLinks, oldLinks);
+    expect(newLinks, isNot(same(oldLinks)));
+  });
   test('PdfDocument.openUri', () async {
     Pdfrx.createHttpClient = () =>
         MockClient((request) async => http.Response.bytes(await testPdfFile.readAsBytes(), 200));

--- a/packages/pdfrx_engine/test/pdf_page_link_cache_test.dart
+++ b/packages/pdfrx_engine/test/pdf_page_link_cache_test.dart
@@ -1,0 +1,165 @@
+import 'package:pdfrx_engine/pdfrx_engine.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('raw and compact requests share one immutable result', () async {
+    final page = _TestPage();
+
+    final raw = await page.loadLinks(compact: false);
+    final compact = await page.loadLinks(compact: true);
+
+    expect(compact, same(raw));
+    expect(page.loadCount, 1);
+    expect(() => raw.first.rects.add(const PdfRect(0, 1, 1, 0)), throwsUnsupportedError);
+  });
+
+  test('compact result is reused by a later raw request', () async {
+    final page = _TestPage();
+
+    final compact = await page.loadLinks(compact: true);
+    final raw = await page.loadLinks(compact: false);
+
+    expect(raw, same(compact));
+    expect(page.loadCount, 1);
+  });
+
+  test('concurrent requests share one extraction', () async {
+    final page = _TestPage();
+
+    final results = await Future.wait([for (var i = 0; i < 8; i++) page.loadLinks(compact: i.isEven)]);
+
+    expect(page.loadCount, 1);
+    expect(results.skip(1).every((links) => identical(links, results.first)), isTrue);
+  });
+
+  test('auto detection modes use separate cache entries', () async {
+    final page = _TestPage();
+
+    final annotations = await page.loadLinks(enableAutoLinkDetection: false);
+    final detected = await page.loadLinks(enableAutoLinkDetection: true);
+
+    expect(annotations, isNot(same(detected)));
+    expect(page.loadCount, 2);
+    expect(await page.loadLinks(enableAutoLinkDetection: false), same(annotations));
+    expect(await page.loadLinks(enableAutoLinkDetection: true), same(detected));
+    expect(page.loadCount, 2);
+  });
+
+  test('failed extraction can be retried', () async {
+    final page = _TestPage(failuresRemaining: 1);
+
+    await expectLater(page.loadLinks(), throwsStateError);
+    final links = await page.loadLinks();
+
+    expect(links, isNotEmpty);
+    expect(page.loadCount, 2);
+    expect(await page.loadLinks(), same(links));
+    expect(page.loadCount, 2);
+  });
+
+  for (final enableAutoLinkDetection in [false, true]) {
+    test('synchronously failed extraction can be retried with auto detection $enableAutoLinkDetection', () async {
+      final page = _TestPage(synchronousFailuresRemaining: 1);
+
+      await expectLater(
+        Future<List<PdfLink>>.sync(() => page.loadLinks(enableAutoLinkDetection: enableAutoLinkDetection)),
+        throwsStateError,
+      );
+      final links = await page.loadLinks(enableAutoLinkDetection: enableAutoLinkDetection);
+
+      expect(links, isNotEmpty);
+      expect(page.loadCount, 2);
+      expect(await page.loadLinks(enableAutoLinkDetection: enableAutoLinkDetection), same(links));
+      expect(page.loadCount, 2);
+    });
+  }
+
+  test('unloaded page does not cache an empty result', () async {
+    final page = _TestPage(isLoaded: false);
+
+    expect(await page.loadLinks(), isEmpty);
+    expect(page.loadCount, 0);
+
+    page.isLoaded = true;
+    expect(await page.loadLinks(), isNotEmpty);
+    expect(page.loadCount, 1);
+  });
+}
+
+class _TestPage extends PdfPage with PdfPageLinkCache {
+  _TestPage({this.isLoaded = true, this.failuresRemaining = 0, this.synchronousFailuresRemaining = 0});
+
+  int loadCount = 0;
+  int failuresRemaining;
+  int synchronousFailuresRemaining;
+
+  @override
+  bool isLoaded;
+
+  @override
+  Future<List<PdfLink>> loadLinksUncached(bool enableAutoLinkDetection) {
+    loadCount++;
+    if (synchronousFailuresRemaining > 0) {
+      synchronousFailuresRemaining--;
+      throw StateError('load failed synchronously');
+    }
+    return _loadLinks(enableAutoLinkDetection);
+  }
+
+  Future<List<PdfLink>> _loadLinks(bool enableAutoLinkDetection) async {
+    await Future<void>.delayed(Duration.zero);
+    if (failuresRemaining > 0) {
+      failuresRemaining--;
+      throw StateError('load failed');
+    }
+    return [
+      PdfLink([
+        const PdfRect(0, 1, 1, 0),
+      ], url: Uri.parse(enableAutoLinkDetection ? 'https://example.com/auto' : 'https://example.com/annotation')),
+    ];
+  }
+
+  @override
+  PdfDocument get document => throw UnimplementedError();
+
+  @override
+  double get height => 1;
+
+  @override
+  int get pageNumber => 1;
+
+  @override
+  PdfPageRotation get rotation => PdfPageRotation.none;
+
+  @override
+  double get width => 1;
+
+  @override
+  PdfPageRenderCancellationToken createCancellationToken() => _TestCancellationToken();
+
+  @override
+  Future<PdfPageRawText?> loadText() async => null;
+
+  @override
+  Future<PdfImage?> render({
+    int x = 0,
+    int y = 0,
+    int? width,
+    int? height,
+    double? fullWidth,
+    double? fullHeight,
+    int? backgroundColor,
+    PdfPageRotation? rotationOverride,
+    PdfAnnotationRenderingMode annotationRenderingMode = PdfAnnotationRenderingMode.annotationAndForms,
+    int flags = PdfPageRenderFlags.none,
+    PdfPageRenderCancellationToken? cancellationToken,
+  }) async => null;
+}
+
+class _TestCancellationToken implements PdfPageRenderCancellationToken {
+  @override
+  bool get isCanceled => false;
+
+  @override
+  void cancel() {}
+}

--- a/packages/pdfrx_engine/tool/PDF_OPEN_BENCHMARK.md
+++ b/packages/pdfrx_engine/tool/PDF_OPEN_BENCHMARK.md
@@ -1,0 +1,18 @@
+# PDF open benchmark
+
+Run the benchmark from `packages/pdfrx_engine`:
+
+```console
+dart run tool/pdf_open_benchmark.dart /path/to/document.pdf
+```
+
+Pass an optional page number as the second argument. The output separates document opening, priority-page metadata,
+link extraction, repeated link access, and trailing-page loading.
+
+To scan a document for embedded annotation links:
+
+```console
+dart run tool/pdf_open_benchmark.dart /path/to/document.pdf --scan-links
+```
+
+This is a manual performance probe. Timing thresholds are intentionally not part of the test suite because they depend on the PDF, platform, build mode, filesystem cache, and hardware.

--- a/packages/pdfrx_engine/tool/pdf_open_benchmark.dart
+++ b/packages/pdfrx_engine/tool/pdf_open_benchmark.dart
@@ -1,0 +1,97 @@
+import 'dart:io';
+
+import 'package:pdfrx_engine/pdfrx_engine.dart';
+
+Future<void> main(List<String> args) async {
+  if (args.isEmpty) {
+    stderr.writeln('Usage: dart run tool/pdf_open_benchmark.dart <pdf-path> [page-number]');
+    exitCode = 64;
+    return;
+  }
+
+  final file = File(args.first);
+  if (!file.existsSync()) {
+    stderr.writeln('PDF not found: ${file.path}');
+    exitCode = 66;
+    return;
+  }
+
+  await pdfrxInitialize();
+  if (args.length > 1 && args[1] == '--scan-links') {
+    await _scanLinks(file);
+    return;
+  }
+
+  final requestedPage = args.length > 1 ? int.tryParse(args[1]) : 1;
+  if (requestedPage == null) {
+    stderr.writeln('Invalid page number: ${args[1]}');
+    exitCode = 64;
+    return;
+  }
+  final documentWatch = Stopwatch()..start();
+  final document = await PdfDocument.openFile(file.path, useProgressiveLoading: true);
+  final pageNumber = requestedPage.clamp(1, document.pages.length);
+  _printMeasurement('document-open', documentWatch, {'pages': document.pages.length, 'targetPage': pageNumber});
+
+  final targetWatch = Stopwatch()..start();
+  final priorityPageNumbers = <int>[pageNumber - 1, pageNumber, pageNumber + 1].where(
+    (pageNumber) => pageNumber >= 1 && pageNumber <= document.pages.length && !document.pages[pageNumber - 1].isLoaded,
+  );
+  await document.reloadPages(pageNumbersToReload: priorityPageNumbers.toList());
+  _printMeasurement('target-page-loaded', targetWatch, {
+    'loadedPages': document.pages.where((page) => page.isLoaded).length,
+  });
+
+  final page = document.pages[pageNumber - 1];
+  final annotationWatch = Stopwatch()..start();
+  final annotationLinks = await page.loadLinks(enableAutoLinkDetection: false);
+  _printMeasurement('annotation-links', annotationWatch, {'links': annotationLinks.length});
+  final repeatedAnnotationWatch = Stopwatch()..start();
+  final repeatedAnnotationLinks = await page.loadLinks(enableAutoLinkDetection: false);
+  _printMeasurement('annotation-links-repeated', repeatedAnnotationWatch, {'links': repeatedAnnotationLinks.length});
+
+  final allLinksWatch = Stopwatch()..start();
+  final allLinks = await page.loadLinks();
+  _printMeasurement('all-links', allLinksWatch, {'links': allLinks.length});
+  final repeatedAllLinksWatch = Stopwatch()..start();
+  final repeatedAllLinks = await page.loadLinks();
+  _printMeasurement('all-links-repeated', repeatedAllLinksWatch, {'links': repeatedAllLinks.length});
+
+  final trailingWatch = Stopwatch()..start();
+  await document.loadPagesProgressively(loadUnitDuration: const Duration(milliseconds: 100));
+  _printMeasurement('trailing-pages-loaded', trailingWatch, {
+    'loadedPages': document.pages.where((page) => page.isLoaded).length,
+    'targetPagePreserved': identical(page, document.pages[pageNumber - 1]),
+  });
+  final postTrailingLinksWatch = Stopwatch()..start();
+  final postTrailingLinks = await document.pages[pageNumber - 1].loadLinks();
+  _printMeasurement('all-links-after-trailing', postTrailingLinksWatch, {'links': postTrailingLinks.length});
+
+  await document.dispose();
+  await PdfrxEntryFunctions.instance.stopBackgroundWorker();
+}
+
+Future<void> _scanLinks(File file) async {
+  final openWatch = Stopwatch()..start();
+  final document = await PdfDocument.openFile(file.path);
+  _printMeasurement('document-open-all-pages', openWatch, {'pages': document.pages.length});
+
+  final scanWatch = Stopwatch()..start();
+  var totalLinks = 0;
+  for (final page in document.pages) {
+    final links = await page.loadLinks(enableAutoLinkDetection: false);
+    if (links.isNotEmpty) {
+      stdout.writeln({'page': page.pageNumber, 'annotationLinks': links.length});
+      totalLinks += links.length;
+    }
+  }
+  _printMeasurement('scan-annotation-links', scanWatch, {'links': totalLinks});
+
+  await document.dispose();
+  await PdfrxEntryFunctions.instance.stopBackgroundWorker();
+}
+
+void _printMeasurement(String name, Stopwatch watch, Map<String, Object> values) {
+  watch.stop();
+  stdout.writeln({'benchmark': name, 'elapsedMicros': watch.elapsedMicroseconds, ...values});
+}


### PR DESCRIPTION
Hello!

After my message yesterday in [issue #586](https://github.com/espresso3389/pdfrx/issues/586#issuecomment-5108549065), I decided to contribute the code myself. I hope you like it!

The code was written by AI (GPT-5.6 Sol, Extra High reasoning) and thoroughly reviewed by Claude Code (Opus, High reasoning).

This contribution includes 5 commits:

- `Cache page links per page instance`: adds a documented, retry-safe cache for compact immutable page links.
- `Use page link cache across backends`: enables the cache for PDFium, WASM, and CoreGraphics.
- `Preserve sparse pages during progressive loading`: keeps prefetched pages alive, improves progressive loading, and makes completion events consistent.
- `Prioritize initial viewer pages`: loads the initial page and its neighbors before the trailing pages.
- `Add PDF open performance probe`: adds a reusable benchmark for document opening, target pages, links, and trailing loading.

The loading improvement is significant. On my machine, using `זבחים.pdf` with 238 pages and opening page 201:

- The target page and its neighbors loaded in about 62 ms median.
- Trailing-page loading fell from about 6.01 seconds to 2.83 seconds median, an improvement of about 53%.
- Repeated cached link access took about 25–30 microseconds.

The changes were validated with 41 engine tests, 19 viewer tests, 2 worker tests, static analysis, and Web, WebAssembly, and Windows builds.

If you need any additional details, I will be happy to provide them.

Thank you for the package. I do not know what I would do without it!!!