### PR TITLE
Auds/lazy loading: Added support for the lazy loading for the range-served / linearized PDFs, fixed caching bug on 2.2.24

### DIFF
--- a/packages/pdfrx/lib/src/pdf_document_ref.dart
+++ b/packages/pdfrx/lib/src/pdf_document_ref.dart
@@ -463,6 +463,12 @@ class PdfDocumentListenable extends Listenable {
 
   void _releaseIfNoRefs() {
     if (_listeners.isEmpty && _additionalRefs == 0) {
+      if (Pdfrx.debugLazyLoading) {
+        pdfrxLazyLog(
+          'RELEASE last listener gone for ${ref.key} -- disposing the document and '
+          'evicting the listenable; the next resolve will re-download it',
+        );
+      }
       PdfDocumentRef._listenables.remove(ref);
       _release();
     }

--- a/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
@@ -467,8 +467,8 @@ class _PdfViewerState extends State<PdfViewer>
     if (event is PdfDocumentPageStatusChangedEvent) {
       // FIXME: We can handle the event more efficiently by only updating the affected pages.
       for (final change in event.changes.entries) {
-        _imageCache.makeCacheImageForPageDirty(change.key);
-        _magnifierImageCache.makeCacheImageForPageDirty(change.key);
+        _imageCache.makeCacheImageForPageDirty(change.key, page: change.value.page);
+        _magnifierImageCache.makeCacheImageForPageDirty(change.key, page: change.value.page);
         _canvasLinkPainter.releaseLinksForPage(change.key);
         _textCache.remove(change.key);
       }
@@ -719,25 +719,6 @@ class _PdfViewerState extends State<PdfViewer>
         callOnViewerSizeChanged();
       });
     } else if (isLayoutChanged || isViewSizeChanged) {
-      if (Pdfrx.debugLazyLoading && isLayoutChanged) {
-        pdfrxLazyLog(
-          'LAYOUT changed: docSize ${oldLayout?.documentSize} -> ${_layout?.documentSize}  '
-          'currentPage=$currentPageNumber  visibleTop=${oldVisibleRect.top.toStringAsFixed(1)}  '
-          'interacting=$_isInteractionGoingOn',
-        );
-      }
-      // A layout change while the user is mid-drag or mid-fling must not move
-      // the viewport: _goToPosition below overwrites the transform matrix and
-      // drops partial images, which cancels the gesture. Upstream never hits
-      // this because every page is measured before the first paint; with
-      // loadPageDimensionsOnDemand the layout can change on any scroll, so the
-      // same guard the other transform paths already use applies here too.
-      if (isLayoutChanged && _isInteractionGoingOn) {
-        if (Pdfrx.debugLazyLoading) {
-          pdfrxLazyLog('LAYOUT reposition skipped -- interaction in progress');
-        }
-        return;
-      }
       Future.microtask(() async {
         if (mounted) {
           // preserve the current zoom whilst respecting the new minScale
@@ -1356,6 +1337,10 @@ class _PdfViewerState extends State<PdfViewer>
   }) {
     final unusedPageList = <int>[];
     final unmeasuredPageList = <int>[];
+    // Pages inside the extent that are painting as a blank white rectangle
+    // because no preview image has landed for them yet. This is the white-page
+    // symptom itself, so trace it rather than inferring it from measurement.
+    final whitePageList = <int>[];
     // Bounds of what this paint considers on-screen, so the trace can show
     // whether measurement is following the viewport or running away from it.
     int? firstInExtent, lastInExtent;
@@ -1417,6 +1402,10 @@ class _PdfViewerState extends State<PdfViewer>
         }
       }
 
+      if (enableLowResolutionPagePreview && previewImage == null) {
+        whitePageList.add(page.pageNumber);
+      }
+
       if (enableLowResolutionPagePreview && previewImage != null) {
         canvas.drawImageRect(
           previewImage.image,
@@ -1449,7 +1438,11 @@ class _PdfViewerState extends State<PdfViewer>
 
       final selectionColor =
           Theme.of(context).textSelectionTheme.selectionColor ?? DefaultSelectionStyle.of(context).selectionColor!;
-      final text = _getCachedTextOrDelayLoadText(page.pageNumber);
+      // Guarded on the selection flag. Without this, paint loads structured text
+      // for every page in the cache extent even when nothing can select it --
+      // and on a scanned document that means parsing the entire content stream,
+      // on the same worker isolate the render needs, to return zero fragments.
+      final text = isTextSelectionEnabled ? _getCachedTextOrDelayLoadText(page.pageNumber) : null;
       if (text != null) {
         final selectionInPage = _loadTextSelectionForPageNumber(page.pageNumber);
         if (selectionInPage != null) {
@@ -1490,17 +1483,27 @@ class _PdfViewerState extends State<PdfViewer>
       }
     }
 
-    if (unmeasuredPageList.isNotEmpty) {
-      if (Pdfrx.debugLazyLoading) {
+    if (Pdfrx.debugLazyLoading && (unmeasuredPageList.isNotEmpty || whitePageList.isNotEmpty)) {
+      // Paint runs on every frame, so log only when the picture actually
+      // changes -- otherwise a single scroll buries the trace.
+      final signature = '$firstInExtent-$lastInExtent/$unmeasuredPageList/$whitePageList';
+      if (signature != _lastExtentSignature) {
+        _lastExtentSignature = signature;
         pdfrxLazyLog(
           '#$_viewerInstanceId EXTENT pages $firstInExtent-$lastInExtent on screen '
           '(${lastInExtent! - firstInExtent! + 1} of ${_document!.pages.length}), '
-          'unmeasured $unmeasuredPageList',
+          'unmeasured $unmeasuredPageList, white $whitePageList',
         );
       }
+    }
+
+    if (unmeasuredPageList.isNotEmpty) {
       _ensureVisiblePagesMeasured(unmeasuredPageList);
     }
   }
+
+  /// Last logged extent/unmeasured/white tuple, to keep the trace to changes.
+  String? _lastExtentSignature;
 
   /// Pages whose real dimensions have been requested but not yet applied.
   final _pagesBeingMeasured = <int>{};
@@ -1615,7 +1618,20 @@ class _PdfViewerState extends State<PdfViewer>
       if (_textCache.containsKey(pageNumber)) return _textCache[pageNumber]!;
       final page = _document!.pages[pageNumber - 1];
       if (!page.isLoaded) return null;
+      // Paint asks for this for every measured page in the cache extent. On a
+      // scanned document it parses the whole content stream -- the same bytes
+      // and the same worker isolate the render needs -- so trace what it costs.
+      final sw = Pdfrx.debugLazyLoading ? (Stopwatch()..start()) : null;
+      final bytesAtStart = Pdfrx.debugBytesFetched;
       final text = await page.loadStructuredText();
+      if (sw != null) {
+        final fetched = Pdfrx.debugBytesFetched - bytesAtStart;
+        pdfrxLazyLog(
+          '#$_viewerInstanceId TEXT p$pageNumber loaded ${text.fragments.length} fragment(s) '
+          'in ${sw.elapsedMilliseconds}ms  '
+          '${fetched > 0 ? 'NETWORK ${(fetched / 1024).toStringAsFixed(0)}KB' : 'cache hit'}',
+        );
+      }
       _textCache[pageNumber] = text;
       if (onTextLoaded != null) {
         onTextLoaded();
@@ -1695,8 +1711,24 @@ class _PdfViewerState extends State<PdfViewer>
     final cancellationToken = page.createCancellationToken();
 
     cache.addCancellationToken(page.pageNumber, cancellationToken);
+
+    // Every preview render in this viewer queues on one lock (the extension is
+    // keyed on the cache object), so a page can sit here for as long as all the
+    // pages ahead of it take. Time the wait separately from the render to tell
+    // "slow to draw" apart from "stuck in the queue".
+    final sw = Pdfrx.debugLazyLoading ? (Stopwatch()..start()) : null;
+    final bytesAtRequest = Pdfrx.debugBytesFetched;
     await cache.synchronized(() async {
-      if (!mounted || cancellationToken.isCanceled) return;
+      final waitedMs = sw?.elapsedMilliseconds ?? 0;
+      if (!mounted || cancellationToken.isCanceled) {
+        if (sw != null) {
+          pdfrxLazyLog(
+            '#$_viewerInstanceId RENDER p${page.pageNumber} abandoned after ${waitedMs}ms in queue '
+            '(${!mounted ? 'viewer gone' : 'cancelled -- page left the cache extent'})',
+          );
+        }
+        return;
+      }
       final prev = cache.pageImages[page.pageNumber];
       if (prev != null && !prev.isDirty && prev.scale == scale) return;
       PdfImage? img;
@@ -1709,13 +1741,39 @@ class _PdfViewerState extends State<PdfViewer>
           flags: widget.params.limitRenderingCache ? PdfPageRenderFlags.limitedImageCache : PdfPageRenderFlags.none,
           cancellationToken: cancellationToken,
         );
-        if (img == null || !mounted || cancellationToken.isCanceled) return;
+        if (img == null || !mounted || cancellationToken.isCanceled) {
+          if (sw != null) {
+            // A null here is a silent failure that leaves the page white --
+            // pdfium declined to produce a bitmap and nothing upstream records
+            // it. Note render does not require the page to be measured: it
+            // happily renders at the estimated size.
+            final why = img == null
+                ? 'pdfium returned no image'
+                : (!mounted ? 'viewer gone' : 'cancelled mid-render');
+            pdfrxLazyLog(
+              '#$_viewerInstanceId RENDER p${page.pageNumber} FAILED -- $why '
+              '(queued ${waitedMs}ms, total ${sw.elapsedMilliseconds}ms)',
+            );
+          }
+          return;
+        }
 
-        final newImage = _PdfImageWithScale(await img.createImage(), scale);
+        final newImage = _PdfImageWithScale(await img.createImage(), scale, pageGeometry: _pageGeometryOf(page));
         cache.pageImages[page.pageNumber]?.dispose();
         cache.pageImages[page.pageNumber] = newImage;
+        if (sw != null) {
+          final fetched = Pdfrx.debugBytesFetched - bytesAtRequest;
+          pdfrxLazyLog(
+            '#$_viewerInstanceId RENDER p${page.pageNumber} ok ${width.round()}x${height.round()} '
+            'in ${sw.elapsedMilliseconds - waitedMs}ms (queued ${waitedMs}ms)  '
+            '${fetched > 0 ? 'NETWORK ${(fetched / 1024).toStringAsFixed(0)}KB' : 'cache hit'}',
+          );
+        }
         _invalidate();
       } catch (e) {
+        if (sw != null) {
+          pdfrxLazyLog('#$_viewerInstanceId RENDER p${page.pageNumber} THREW after ${sw.elapsedMilliseconds}ms: $e');
+        }
         return; // ignore error
       } finally {
         img?.dispose();
@@ -1786,7 +1844,14 @@ class _PdfViewerState extends State<PdfViewer>
         cancellationToken: cancellationToken,
       );
       if (img == null || !mounted || cancellationToken.isCanceled) return null;
-      return _PdfImageWithScaleAndRect(await img.createImage(), scale, rect, x, y);
+      return _PdfImageWithScaleAndRect(
+        await img.createImage(),
+        scale,
+        rect,
+        x,
+        y,
+        pageGeometry: _pageGeometryOf(page),
+      );
     } catch (e) {
       return null; // ignore error
     } finally {
@@ -2067,12 +2132,6 @@ class _PdfViewerState extends State<PdfViewer>
     PdfPageAnchor? anchor,
     Duration duration = const Duration(milliseconds: 200),
   }) async {
-    if (Pdfrx.debugLazyLoading) {
-      pdfrxLazyLog(
-        '#$_viewerInstanceId GOTO page $pageNumber (currently page $_pageNumber, '
-        'visibleTop=${_visibleRect.top.toStringAsFixed(1)})',
-      );
-    }
     final pageCount = _document!.pages.length;
     final int targetPageNumber;
     if (pageNumber < 1) {
@@ -2107,12 +2166,6 @@ class _PdfViewerState extends State<PdfViewer>
     _imageCache.releasePartialImages();
 
     zoom = zoom ?? _currentZoom;
-    if (Pdfrx.debugLazyLoading) {
-      pdfrxLazyLog(
-        '#$_viewerInstanceId GOTO position visibleTop=${_visibleRect.top.toStringAsFixed(1)} '
-        '-> documentOffset=${documentOffset.dy.toStringAsFixed(1)} zoom=${zoom.toStringAsFixed(3)}',
-      );
-    }
     final tx = -documentOffset.dx * zoom;
     final ty = -documentOffset.dy * zoom;
 
@@ -3567,13 +3620,23 @@ class _PdfPageImageCache {
     cancellationTokens.clear();
   }
 
-  void makeCacheImageForPageDirty(int pageNumber) {
+  /// Marks the cached bitmaps for [pageNumber] as needing a re-render.
+  ///
+  /// When [page] is given, bitmaps already rendered from that same geometry are
+  /// left alone: re-rendering them would burn a full page render on the worker
+  /// isolate to produce a pixel-identical image. This matters under on-demand
+  /// measurement, where every page raises a status change as its estimated size
+  /// is replaced -- usually by the very same size.
+  void makeCacheImageForPageDirty(int pageNumber, {PdfPage? page}) {
+    final geometry = page == null ? null : _pageGeometryOf(page);
+    bool stillValid(_PdfImageWithScale image) => geometry != null && image.pageGeometry == geometry;
+
     final image = pageImages[pageNumber];
-    if (image != null) {
+    if (image != null && !stillValid(image)) {
       image.isDirty = true;
     }
     final imagePartial = pageImagesPartial[pageNumber];
-    if (imagePartial != null) {
+    if (imagePartial != null && !stillValid(imagePartial)) {
       imagePartial.isDirty = true;
     }
   }
@@ -3626,10 +3689,22 @@ class _PdfPartialImageRenderingRequest {
   }
 }
 
+/// Identifies the page geometry a cached bitmap was rendered from.
+///
+/// Used to tell a page-status change that actually moved something apart from
+/// one that did not. With on-demand measurement every page raises a change event
+/// when its estimate is replaced by real dimensions, and for a document of
+/// uniformly sized pages -- a scanned book -- the two are identical.
+String _pageGeometryOf(PdfPage page) => '${page.width}x${page.height}/${page.rotation.index}';
+
 class _PdfImageWithScale {
-  _PdfImageWithScale(this.image, this.scale);
+  _PdfImageWithScale(this.image, this.scale, {this.pageGeometry});
   final ui.Image image;
   final double scale;
+
+  /// Geometry of the page at the time this bitmap was rendered, or null when it
+  /// was not recorded -- in which case any change is treated as invalidating.
+  final String? pageGeometry;
 
   int get width => image.width;
   int get height => image.height;
@@ -3642,7 +3717,7 @@ class _PdfImageWithScale {
 }
 
 class _PdfImageWithScaleAndRect extends _PdfImageWithScale {
-  _PdfImageWithScaleAndRect(super.image, super.scale, this.rect, this.left, this.top);
+  _PdfImageWithScaleAndRect(super.image, super.scale, this.rect, this.left, this.top, {super.pageGeometry});
   final Rect rect;
   final int left;
   final int top;

--- a/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
@@ -368,7 +368,7 @@ class _PdfViewerState extends State<PdfViewer>
     _textCache.clear();
     _clearTextSelections(invalidate: false);
     _pagesBeingMeasured.clear();
-    _pagesFailedMeasurement.clear();
+    _measurementFailures.clear();
     _pageNumber = null;
     _gotoTargetPageNumber = null;
     _initialized = false;
@@ -1493,19 +1493,17 @@ class _PdfViewerState extends State<PdfViewer>
   /// Pages whose real dimensions have been requested but not yet applied.
   final _pagesBeingMeasured = <int>{};
 
-  /// Pages whose measurement threw. Not retried, so that a persistently failing
-  /// page cannot drive a measure/repaint/measure loop.
-  final _pagesFailedMeasurement = <int>{};
-
-  /// Serialises measurement so that only one [PdfDocument.reloadPages] call is
-  /// ever in flight.
+  /// How many times measuring each page has thrown.
   ///
-  /// reloadPages snapshots the page list, awaits pdfium (which can block for
-  /// seconds on a range fetch), then writes the whole list back. Two overlapping
-  /// calls therefore clobber each other: the one that finishes last restores the
-  /// pages the other had just measured, they repaint as unmeasured, and get
-  /// requested all over again.
-  Future<void> _measureQueue = Future.value();
+  /// A page is given up on only after [_maxMeasurementAttempts] failures, rather
+  /// than on the first one. Measurement can fail for reasons that have nothing to
+  /// do with the page -- the document being disposed while the reader navigates
+  /// away, a range request timing out -- and blacklisting on those leaves a page
+  /// permanently blank. The cap still stops a genuinely unreadable page from
+  /// driving a measure/repaint/measure loop out of paint.
+  final _measurementFailures = <int, int>{};
+
+  static const _maxMeasurementAttempts = 3;
 
   /// Replaces the estimated dimensions of [pageNumbers] with real ones.
   ///
@@ -1518,18 +1516,21 @@ class _PdfViewerState extends State<PdfViewer>
 
     final toMeasure = <int>[];
     for (final pageNumber in pageNumbers) {
-      if (_pagesFailedMeasurement.contains(pageNumber)) continue;
+      if ((_measurementFailures[pageNumber] ?? 0) >= _maxMeasurementAttempts) continue;
       if (_pagesBeingMeasured.add(pageNumber)) toMeasure.add(pageNumber);
     }
     if (toMeasure.isEmpty) return;
 
-    _measureQueue = _measureQueue.then((_) async {
+    // Deliberately not serialised. reloadPages reads the page list *after* its
+    // await and writes it back synchronously, so concurrent calls cannot clobber
+    // one another. Queueing them would mean one slow page -- a measurement that
+    // faults a block and waits on the network -- holding up every other visible
+    // page behind it, which shows up as a screen of blank pages instead of one.
+    Future.microtask(() async {
       if (!mounted || _document != document) {
         _pagesBeingMeasured.removeAll(toMeasure);
         return;
       }
-      // An earlier queued batch may already have covered some of these while
-      // this one waited its turn.
       final pending = toMeasure.where((n) => !document.pages[n - 1].isLoaded).toList();
       if (pending.isEmpty) {
         _pagesBeingMeasured.removeAll(toMeasure);
@@ -1559,16 +1560,22 @@ class _PdfViewerState extends State<PdfViewer>
           );
         }
       } catch (e) {
-        debugPrint('PdfViewer: failed to measure pages $pending: $e');
-        _pagesFailedMeasurement.addAll(pending);
+        // Only hold this against the page if the viewer and document are still
+        // the ones that asked. A throw during teardown says nothing about
+        // whether the page is readable, and counting it would leave the page
+        // blank for the rest of the session.
+        if (mounted && _document == document) {
+          for (final n in pending) {
+            _measurementFailures[n] = (_measurementFailures[n] ?? 0) + 1;
+          }
+          debugPrint(
+            'PdfViewer: failed to measure pages $pending '
+            '(attempt ${_measurementFailures[pending.first]} of $_maxMeasurementAttempts): $e',
+          );
+        }
       } finally {
         _pagesBeingMeasured.removeAll(toMeasure);
       }
-      // Keep the queue alive: an unhandled throw here would leave _measureQueue
-      // in the error state and every later measurement would be dropped.
-    }).catchError((Object e) {
-      debugPrint('PdfViewer: measurement queue error: $e');
-      _pagesBeingMeasured.removeAll(toMeasure);
     });
   }
 

--- a/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
@@ -1356,6 +1356,9 @@ class _PdfViewerState extends State<PdfViewer>
   }) {
     final unusedPageList = <int>[];
     final unmeasuredPageList = <int>[];
+    // Bounds of what this paint considers on-screen, so the trace can show
+    // whether measurement is following the viewport or running away from it.
+    int? firstInExtent, lastInExtent;
     final dropShadowPaint = widget.params.pageDropShadow?.toPaint()?..style = PaintingStyle.fill;
     cacheTargetRect ??= targetRect;
 
@@ -1372,6 +1375,8 @@ class _PdfViewerState extends State<PdfViewer>
       }
 
       final page = _document!.pages[i];
+      firstInExtent ??= page.pageNumber;
+      lastInExtent = page.pageNumber;
       // A page that has never been measured cannot render -- PdfPage.render
       // returns null while isLoaded is false -- so collect it and measure it
       // after this paint. Only reachable when loadPageDimensionsOnDemand is on;
@@ -1486,6 +1491,13 @@ class _PdfViewerState extends State<PdfViewer>
     }
 
     if (unmeasuredPageList.isNotEmpty) {
+      if (Pdfrx.debugLazyLoading) {
+        pdfrxLazyLog(
+          '#$_viewerInstanceId EXTENT pages $firstInExtent-$lastInExtent on screen '
+          '(${lastInExtent! - firstInExtent! + 1} of ${_document!.pages.length}), '
+          'unmeasured $unmeasuredPageList',
+        );
+      }
       _ensureVisiblePagesMeasured(unmeasuredPageList);
     }
   }

--- a/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
@@ -286,10 +286,19 @@ class _PdfViewerState extends State<PdfViewer>
   @override
   void initState() {
     super.initState();
+    _viewerInstanceId = ++_viewerInstanceCounter;
+    if (Pdfrx.debugLazyLoading) {
+      pdfrxLazyLog('#$_viewerInstanceId STATE created (initState)');
+    }
     pdfrxFlutterInitialize();
     _animController = AnimationController(vsync: this, duration: const Duration(milliseconds: 200));
     _widgetUpdated(null);
   }
+
+  /// Distinguishes viewer instances in [Pdfrx.debugLazyLoading] traces; several
+  /// live at once when the viewer sits inside a PageView or an IndexedStack.
+  late final int _viewerInstanceId;
+  static int _viewerInstanceCounter = 0;
 
   @override
   void didUpdateWidget(covariant PdfViewer oldWidget) {
@@ -311,6 +320,12 @@ class _PdfViewerState extends State<PdfViewer>
       }
       return;
     } else {
+      if (Pdfrx.debugLazyLoading) {
+        pdfrxLazyLog(
+          '#$_viewerInstanceId REF key changed ${oldWidget?.documentRef.key} -> ${widget.documentRef.key} '
+          '-- dropping the old listener (which disposes the document) and reloading',
+        );
+      }
       oldWidget?.documentRef.resolveListenable().removeListener(_onDocumentChanged);
       widget.documentRef.resolveListenable()
         ..addListener(_onDocumentChanged)
@@ -321,6 +336,27 @@ class _PdfViewerState extends State<PdfViewer>
   }
 
   void _onDocumentChanged() async {
+    // PdfDocumentListenable notifies for download progress as well as for a real
+    // document change. Under range access those progress ticks never stop -- every
+    // block faulted in while scrolling fires one -- and reconfiguring here would
+    // clear _initialized and send the viewer back to the initial page. So ignore
+    // notifications that arrive while the document instance is unchanged.
+    //
+    // The document is still null during the initial load, and that case must fall
+    // through so the loading banner keeps updating.
+    final currentDocument = widget.documentRef.resolveListenable().document;
+    if (_document != null && identical(currentDocument, _document)) {
+      return;
+    }
+
+    if (Pdfrx.debugLazyLoading) {
+      final listenable = widget.documentRef.resolveListenable();
+      pdfrxLazyLog(
+        '#$_viewerInstanceId DOCUMENT changed ${_document == null ? "(none)" : "#${identityHashCode(_document)}"} '
+        '-> ${currentDocument == null ? "(none)" : "#${identityHashCode(currentDocument)}"}  '
+        'error=${listenable.error}  -- resetting _initialized/_pageNumber',
+      );
+    }
     _layout = null;
     _documentSubscription?.cancel();
     _documentSubscription = null;
@@ -331,6 +367,8 @@ class _PdfViewerState extends State<PdfViewer>
     _canvasLinkPainter.resetAll();
     _textCache.clear();
     _clearTextSelections(invalidate: false);
+    _pagesBeingMeasured.clear();
+    _pagesFailedMeasurement.clear();
     _pageNumber = null;
     _gotoTargetPageNumber = null;
     _initialized = false;
@@ -369,6 +407,21 @@ class _PdfViewerState extends State<PdfViewer>
   Future<void> _loadDelayed() async {
     // To make the page image loading more smooth, delay the loading of pages
     await Future.delayed(widget.params.behaviorControlParams.trailingPageLoadingDelay);
+
+    // With on-demand measurement the pages keep the estimated sizes they were
+    // given at open time; _ensureVisiblePagesMeasured replaces those with real
+    // ones as pages scroll into the cache extent. Walking every page here would
+    // defeat that, so skip it entirely.
+    if (widget.params.behaviorControlParams.loadPageDimensionsOnDemand) {
+      _invalidate();
+      // loadPagesProgressively is what normally emits
+      // PdfDocumentLoadCompleteEvent, and only once every page has been
+      // measured; that event is what drives onDocumentLoadFinished. Since this
+      // mode never makes that pass, report completion here instead -- the
+      // document is as loaded as it is going to get up front.
+      _notifyDocumentLoadFinished(succeeded: true);
+      return;
+    }
 
     final stopwatch = Stopwatch()..start();
     await _document?.loadPagesProgressively(
@@ -637,6 +690,12 @@ class _PdfViewerState extends State<PdfViewer>
 
     if (!_initialized && _layout != null && _coverScale != null) {
       _initialized = true;
+      if (Pdfrx.debugLazyLoading) {
+        pdfrxLazyLog(
+          '#$_viewerInstanceId INIT first layout -- will jump to the initial page. '
+          'If this appears mid-session, something reset the viewer.',
+        );
+      }
       Future.microtask(() async {
         // forcibly calculate fit scale for the initial page
         _pageNumber = _gotoTargetPageNumber = _calcInitialPageNumber();
@@ -660,6 +719,25 @@ class _PdfViewerState extends State<PdfViewer>
         callOnViewerSizeChanged();
       });
     } else if (isLayoutChanged || isViewSizeChanged) {
+      if (Pdfrx.debugLazyLoading && isLayoutChanged) {
+        pdfrxLazyLog(
+          'LAYOUT changed: docSize ${oldLayout?.documentSize} -> ${_layout?.documentSize}  '
+          'currentPage=$currentPageNumber  visibleTop=${oldVisibleRect.top.toStringAsFixed(1)}  '
+          'interacting=$_isInteractionGoingOn',
+        );
+      }
+      // A layout change while the user is mid-drag or mid-fling must not move
+      // the viewport: _goToPosition below overwrites the transform matrix and
+      // drops partial images, which cancels the gesture. Upstream never hits
+      // this because every page is measured before the first paint; with
+      // loadPageDimensionsOnDemand the layout can change on any scroll, so the
+      // same guard the other transform paths already use applies here too.
+      if (isLayoutChanged && _isInteractionGoingOn) {
+        if (Pdfrx.debugLazyLoading) {
+          pdfrxLazyLog('LAYOUT reposition skipped -- interaction in progress');
+        }
+        return;
+      }
       Future.microtask(() async {
         if (mounted) {
           // preserve the current zoom whilst respecting the new minScale
@@ -1277,6 +1355,7 @@ class _PdfViewerState extends State<PdfViewer>
     FilterQuality filterQuality = FilterQuality.high,
   }) {
     final unusedPageList = <int>[];
+    final unmeasuredPageList = <int>[];
     final dropShadowPaint = widget.params.pageDropShadow?.toPaint()?..style = PaintingStyle.fill;
     cacheTargetRect ??= targetRect;
 
@@ -1293,6 +1372,13 @@ class _PdfViewerState extends State<PdfViewer>
       }
 
       final page = _document!.pages[i];
+      // A page that has never been measured cannot render -- PdfPage.render
+      // returns null while isLoaded is false -- so collect it and measure it
+      // after this paint. Only reachable when loadPageDimensionsOnDemand is on;
+      // otherwise every page was measured at open time.
+      if (!page.isLoaded) {
+        unmeasuredPageList.add(page.pageNumber);
+      }
       final previewImage = cache.pageImages[page.pageNumber];
       final partial = cache.pageImagesPartial[page.pageNumber];
 
@@ -1398,6 +1484,92 @@ class _PdfViewerState extends State<PdfViewer>
         }
       }
     }
+
+    if (unmeasuredPageList.isNotEmpty) {
+      _ensureVisiblePagesMeasured(unmeasuredPageList);
+    }
+  }
+
+  /// Pages whose real dimensions have been requested but not yet applied.
+  final _pagesBeingMeasured = <int>{};
+
+  /// Pages whose measurement threw. Not retried, so that a persistently failing
+  /// page cannot drive a measure/repaint/measure loop.
+  final _pagesFailedMeasurement = <int>{};
+
+  /// Serialises measurement so that only one [PdfDocument.reloadPages] call is
+  /// ever in flight.
+  ///
+  /// reloadPages snapshots the page list, awaits pdfium (which can block for
+  /// seconds on a range fetch), then writes the whole list back. Two overlapping
+  /// calls therefore clobber each other: the one that finishes last restores the
+  /// pages the other had just measured, they repaint as unmeasured, and get
+  /// requested all over again.
+  Future<void> _measureQueue = Future.value();
+
+  /// Replaces the estimated dimensions of [pageNumbers] with real ones.
+  ///
+  /// Called from paint, so it has to be cheap and re-entrant: pages already in
+  /// flight are skipped, and the resulting [PdfDocumentPageStatusChangedEvent]
+  /// invalidates the viewer, which re-runs layout and picks the new sizes up.
+  void _ensureVisiblePagesMeasured(List<int> pageNumbers) {
+    final document = _document;
+    if (document == null) return;
+
+    final toMeasure = <int>[];
+    for (final pageNumber in pageNumbers) {
+      if (_pagesFailedMeasurement.contains(pageNumber)) continue;
+      if (_pagesBeingMeasured.add(pageNumber)) toMeasure.add(pageNumber);
+    }
+    if (toMeasure.isEmpty) return;
+
+    _measureQueue = _measureQueue.then((_) async {
+      if (!mounted || _document != document) {
+        _pagesBeingMeasured.removeAll(toMeasure);
+        return;
+      }
+      // An earlier queued batch may already have covered some of these while
+      // this one waited its turn.
+      final pending = toMeasure.where((n) => !document.pages[n - 1].isLoaded).toList();
+      if (pending.isEmpty) {
+        _pagesBeingMeasured.removeAll(toMeasure);
+        return;
+      }
+      if (Pdfrx.debugLazyLoading) {
+        pdfrxLazyLog('#$_viewerInstanceId MEASURE requesting pages $pending');
+      }
+      final sw = Pdfrx.debugLazyLoading ? (Stopwatch()..start()) : null;
+      final bytesAtStart = Pdfrx.debugBytesFetched;
+      try {
+        final before = Pdfrx.debugLazyLoading
+            ? {for (final n in pending) n: _fmtPageSize(document.pages[n - 1])}
+            : null;
+        await document.reloadPages(pageNumbersToReload: pending);
+        if (Pdfrx.debugLazyLoading && mounted && _document == document) {
+          final changed = <String>[];
+          for (final n in pending) {
+            final after = _fmtPageSize(document.pages[n - 1]);
+            if (before![n] != after) changed.add('p$n ${before[n]} -> $after');
+          }
+          final fetched = Pdfrx.debugBytesFetched - bytesAtStart;
+          pdfrxLazyLog(
+            '#$_viewerInstanceId MEASURE done ${pending.length} page(s) in ${sw!.elapsedMilliseconds}ms  '
+            '${fetched > 0 ? 'NETWORK ${(fetched / 1024).toStringAsFixed(0)}KB fetched' : 'cache hit, no network'}'
+            '${changed.isEmpty ? '' : '; size changed: ${changed.join(", ")}'}',
+          );
+        }
+      } catch (e) {
+        debugPrint('PdfViewer: failed to measure pages $pending: $e');
+        _pagesFailedMeasurement.addAll(pending);
+      } finally {
+        _pagesBeingMeasured.removeAll(toMeasure);
+      }
+      // Keep the queue alive: an unhandled throw here would leave _measureQueue
+      // in the error state and every later measurement would be dropped.
+    }).catchError((Object e) {
+      debugPrint('PdfViewer: measurement queue error: $e');
+      _pagesBeingMeasured.removeAll(toMeasure);
+    });
   }
 
   /// Loads text for the specified page number.
@@ -1876,6 +2048,12 @@ class _PdfViewerState extends State<PdfViewer>
     PdfPageAnchor? anchor,
     Duration duration = const Duration(milliseconds: 200),
   }) async {
+    if (Pdfrx.debugLazyLoading) {
+      pdfrxLazyLog(
+        '#$_viewerInstanceId GOTO page $pageNumber (currently page $_pageNumber, '
+        'visibleTop=${_visibleRect.top.toStringAsFixed(1)})',
+      );
+    }
     final pageCount = _document!.pages.length;
     final int targetPageNumber;
     if (pageNumber < 1) {
@@ -1910,6 +2088,12 @@ class _PdfViewerState extends State<PdfViewer>
     _imageCache.releasePartialImages();
 
     zoom = zoom ?? _currentZoom;
+    if (Pdfrx.debugLazyLoading) {
+      pdfrxLazyLog(
+        '#$_viewerInstanceId GOTO position visibleTop=${_visibleRect.top.toStringAsFixed(1)} '
+        '-> documentOffset=${documentOffset.dy.toStringAsFixed(1)} zoom=${zoom.toStringAsFixed(3)}',
+      );
+    }
     final tx = -documentOffset.dx * zoom;
     final ty = -documentOffset.dy * zoom;
 
@@ -3638,6 +3822,9 @@ class PdfTextSelectionAnchor {
 enum PdfTextSelectionAnchorType { a, b }
 
 /// Defines page layout.
+String _fmtPageSize(PdfPage page) =>
+    '${page.width.toStringAsFixed(0)}x${page.height.toStringAsFixed(0)}';
+
 class PdfPageLayout {
   PdfPageLayout({required this.pageLayouts, required this.documentSize});
   final List<Rect> pageLayouts;

--- a/packages/pdfrx/lib/src/widgets/pdf_viewer_params.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer_params.dart
@@ -1673,12 +1673,40 @@ class PdfViewerBehaviorControlParams {
     this.enableLowResolutionPagePreview = true,
     this.pageImageCachingDelay = const Duration(milliseconds: kIsWeb ? 20 : 20),
     this.partialImageLoadingDelay = const Duration(milliseconds: kIsWeb ? 100 : 0),
+    this.loadPageDimensionsOnDemand = false,
   });
 
   /// How long to wait before loading the trailing pages after the initial page load.
   ///
   /// This is to ensure that the initial page is displayed quickly, and the trailing pages are loaded in the background.
   final Duration trailingPageLoadingDelay;
+
+  /// Measure only the pages the user can actually see, instead of walking the
+  /// whole document at open time.
+  ///
+  /// The default (false) calls [PdfDocument.loadPagesProgressively], which runs
+  /// `FPDF_LoadPage` over every page to obtain its size. For a network document
+  /// served by range requests, that measurement pass faults in whichever blocks
+  /// the page objects happen to live in; when page objects are spread through
+  /// the file, that is the whole file, before the first page can be painted.
+  ///
+  /// When true, off-screen pages keep the estimated size assigned at open time
+  /// (the last known page's dimensions) and are measured for real only once
+  /// they enter the render cache extent. Cold-open cost then scales with what
+  /// is on screen rather than with the page count.
+  ///
+  /// The trade-offs:
+  ///
+  /// - The layout of unvisited pages is an estimate, so in a document with
+  ///   varying page sizes the scroll extent settles as the user moves through
+  ///   it. Where page sizes are uniform -- scanned books, generated reports --
+  ///   the estimate is exact and nothing shifts.
+  /// - Anything that reads a page without displaying it sees an unmeasured
+  ///   page and gets nothing back: `PdfPage.loadText` returns an empty list
+  ///   while `isLoaded` is false, so whole-document text search and text
+  ///   extraction only cover pages the user has already visited. Leave this
+  ///   off if you rely on [PdfTextSearcher] or document-wide text extraction.
+  final bool loadPageDimensionsOnDemand;
 
   /// Whether to enable low resolution page preview.
   final bool enableLowResolutionPagePreview;
@@ -1697,7 +1725,8 @@ class PdfViewerBehaviorControlParams {
         other.trailingPageLoadingDelay == trailingPageLoadingDelay &&
         other.enableLowResolutionPagePreview == enableLowResolutionPagePreview &&
         other.pageImageCachingDelay == pageImageCachingDelay &&
-        other.partialImageLoadingDelay == partialImageLoadingDelay;
+        other.partialImageLoadingDelay == partialImageLoadingDelay &&
+        other.loadPageDimensionsOnDemand == loadPageDimensionsOnDemand;
   }
 
   @override
@@ -1705,5 +1734,6 @@ class PdfViewerBehaviorControlParams {
       trailingPageLoadingDelay.hashCode ^
       enableLowResolutionPagePreview.hashCode ^
       pageImageCachingDelay.hashCode ^
-      partialImageLoadingDelay.hashCode;
+      partialImageLoadingDelay.hashCode ^
+      loadPageDimensionsOnDemand.hashCode;
 }

--- a/packages/pdfrx/pubspec.yaml
+++ b/packages/pdfrx/pubspec.yaml
@@ -11,7 +11,7 @@ screenshots:
 environment:
   sdk: '>=3.9.0 <4.0.0'
   flutter: '>=3.35.1'
-resolution: workspace
+# resolution: workspace
 
 dependencies:
   pdfrx_engine: ^0.3.9

--- a/packages/pdfrx/test/assets/multipage40.pdf
+++ b/packages/pdfrx/test/assets/multipage40.pdf
@@ -1,0 +1,1224 @@
+%PDF-1.7
+%¿÷¢þ
+1 0 obj
+<< /Pages 2 0 R /Type /Catalog >>
+endobj
+2 0 obj
+<< /Count 40 /Kids [ 3 0 R 4 0 R 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 13 0 R 14 0 R 15 0 R 16 0 R 17 0 R 18 0 R 19 0 R 20 0 R 21 0 R 22 0 R 23 0 R 24 0 R 25 0 R 26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 34 0 R 35 0 R 36 0 R 37 0 R 38 0 R 39 0 R 40 0 R 41 0 R 42 0 R ] /Type /Pages >>
+endobj
+3 0 obj
+<< /Annots [ 43 0 R 44 0 R 45 0 R 46 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+4 0 obj
+<< /Annots [ 54 0 R 55 0 R 56 0 R 57 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+5 0 obj
+<< /Annots [ 58 0 R 59 0 R 60 0 R 61 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+6 0 obj
+<< /Annots [ 62 0 R 63 0 R 64 0 R 65 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+7 0 obj
+<< /Annots [ 66 0 R 67 0 R 68 0 R 69 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+8 0 obj
+<< /Annots [ 70 0 R 71 0 R 72 0 R 73 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+9 0 obj
+<< /Annots [ 74 0 R 75 0 R 76 0 R 77 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+10 0 obj
+<< /Annots [ 78 0 R 79 0 R 80 0 R 81 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+11 0 obj
+<< /Annots [ 82 0 R 83 0 R 84 0 R 85 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+12 0 obj
+<< /Annots [ 86 0 R 87 0 R 88 0 R 89 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+13 0 obj
+<< /Annots [ 90 0 R 91 0 R 92 0 R 93 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+14 0 obj
+<< /Annots [ 94 0 R 95 0 R 96 0 R 97 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+15 0 obj
+<< /Annots [ 98 0 R 99 0 R 100 0 R 101 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+16 0 obj
+<< /Annots [ 102 0 R 103 0 R 104 0 R 105 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+17 0 obj
+<< /Annots [ 106 0 R 107 0 R 108 0 R 109 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+18 0 obj
+<< /Annots [ 110 0 R 111 0 R 112 0 R 113 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+19 0 obj
+<< /Annots [ 114 0 R 115 0 R 116 0 R 117 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+20 0 obj
+<< /Annots [ 118 0 R 119 0 R 120 0 R 121 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+21 0 obj
+<< /Annots [ 122 0 R 123 0 R 124 0 R 125 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+22 0 obj
+<< /Annots [ 126 0 R 127 0 R 128 0 R 129 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+23 0 obj
+<< /Annots [ 130 0 R 131 0 R 132 0 R 133 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+24 0 obj
+<< /Annots [ 134 0 R 135 0 R 136 0 R 137 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+25 0 obj
+<< /Annots [ 138 0 R 139 0 R 140 0 R 141 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+26 0 obj
+<< /Annots [ 142 0 R 143 0 R 144 0 R 145 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+27 0 obj
+<< /Annots [ 146 0 R 147 0 R 148 0 R 149 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+28 0 obj
+<< /Annots [ 150 0 R 151 0 R 152 0 R 153 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+29 0 obj
+<< /Annots [ 154 0 R 155 0 R 156 0 R 157 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+30 0 obj
+<< /Annots [ 158 0 R 159 0 R 160 0 R 161 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+31 0 obj
+<< /Annots [ 162 0 R 163 0 R 164 0 R 165 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+32 0 obj
+<< /Annots [ 166 0 R 167 0 R 168 0 R 169 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+33 0 obj
+<< /Annots [ 170 0 R 171 0 R 172 0 R 173 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+34 0 obj
+<< /Annots [ 174 0 R 175 0 R 176 0 R 177 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+35 0 obj
+<< /Annots [ 178 0 R 179 0 R 180 0 R 181 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+36 0 obj
+<< /Annots [ 182 0 R 183 0 R 184 0 R 185 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+37 0 obj
+<< /Annots [ 186 0 R 187 0 R 188 0 R 189 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+38 0 obj
+<< /Annots [ 190 0 R 191 0 R 192 0 R 193 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+39 0 obj
+<< /Annots [ 194 0 R 195 0 R 196 0 R 197 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+40 0 obj
+<< /Annots [ 198 0 R 199 0 R 200 0 R 201 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+41 0 obj
+<< /Annots [ 202 0 R 203 0 R 204 0 R 205 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+42 0 obj
+<< /Annots [ 206 0 R 207 0 R 208 0 R 209 0 R ] /Contents 47 0 R /Group << /CS /DeviceRGB /S /Transparency /Type /Group >> /MediaBox [ 0 0 595.32 841.92 ] /Parent 2 0 R /Resources << /ExtGState << /GS10 48 0 R /GS11 49 0 R >> /Font << /F1 50 0 R /F2 51 0 R /F3 52 0 R /F4 53 0 R >> /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /StructParents 0 /Tabs /S /Type /Page >>
+endobj
+43 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+44 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+45 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+46 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+47 0 obj
+<< /Filter /FlateDecode /Length 772 >>
+stream
+xœµ—]kÛ0†ïþºlUtŽ¾!–¤)+lmÇ.Æ.zÑæjaëþ?L²ä$öäD	rÁUìçÑùx_‰Ìž~¿lÉ|>{X~\6ûü²Ý«×íí·§ë¦!‹Õ’ü©+F™ÿ3FaDZI9#€Z$ï¯uõý†lëjñ\W³5äù­®üTF€I	¢¤¦Æ}óËMºF6Ý‹É&ÜB¼½¯«sÆ$gLhwY÷YºkÑü$ÏŸêêÎýÆ×º"wKBúðP ‡ðèæ?„o‘è¹>I…EB
+‚º¦¢
+–Ú!— .áaÜµnnù¼ý#‰á–­O‡”OŽZ›QxÆO£‰©ÐS†£h\ŸF“S¡q r<å"¦|ò+UÌ3o ÒÏO®DMµ%(ôòO™AAåZ¹ÿÈû&õôq§±¦umcæùR¡§Z—TÙñº^·ao³$Zàœ$˜‰`€¢W»—i‚tÄh»±ñœEØ©!‘‚oWç#hýzrH¡Œ	&PPÎGQ¥íµoÜƒ8·_+?™ôÀz?‹ù1´ôs%ö;!ÀTè„ìå|Ç³î•@7ÛÍ
+³yg.ƒwžŽw	ß>æŒQÁ£ÊHcvr"l™ÁÃÇtíìÂÖ­˜e¬m*÷ŽT÷×Ö+&€¸îŽI8Ea„-gË%¼=+Bjgñú"²ÖÎqé].‘Ïœb+áÖ"gU8—¶Éü–qWi‡`µômì_H¥³·ÐâÃ§]cOìU¶ÓÑCµâ¦ún˜““æì1mü¹ä¬œ|ÙcÙH’ŽWVN‘-Ý~ØoÂ4X«[¸·›‘³N	ë<ÒÂÚËÛKøÌ‘öHÃe's‰6‡`£ðßFÉÕ)8¸N Þ]AžìÄ¨4˜·–¬j˜ìü¨‘²Ì ƒ‚«6ð Ã÷uT2Î3XÂ—R2ƒÀ¨±çÕö^fPE’®µ`Úþ³¥„qÙ	åäS^Ô³S	;¢õÂ~Ù?/31endstream
+endobj
+48 0 obj
+<< /BM /Normal /Type /ExtGState /ca 1 >>
+endobj
+49 0 obj
+<< /BM /Normal /CA 1 /Type /ExtGState >>
+endobj
+50 0 obj
+<< /BaseFont /TimesNewRomanPSMT /DescendantFonts 211 0 R /Encoding /Identity-H /Subtype /Type0 /ToUnicode 212 0 R /Type /Font >>
+endobj
+51 0 obj
+<< /BaseFont /TimesNewRomanPSMT /Encoding /WinAnsiEncoding /FirstChar 32 /FontDescriptor 213 0 R /LastChar 32 /Name /F2 /Subtype /TrueType /Type /Font /Widths 214 0 R >>
+endobj
+52 0 obj
+<< /BaseFont /BCDEEE+YuMincho-Regular /DescendantFonts 215 0 R /Encoding /Identity-H /Subtype /Type0 /ToUnicode 216 0 R /Type /Font >>
+endobj
+53 0 obj
+<< /BaseFont /ArialMT /Encoding /WinAnsiEncoding /FirstChar 32 /FontDescriptor 217 0 R /LastChar 32 /Name /F4 /Subtype /TrueType /Type /Font /Widths 218 0 R >>
+endobj
+54 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+55 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+56 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+57 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+58 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+59 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+60 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+61 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+62 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+63 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+64 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+65 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+66 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+67 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+68 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+69 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+70 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+71 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+72 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+73 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+74 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+75 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+76 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+77 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+78 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+79 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+80 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+81 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+82 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+83 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+84 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+85 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+86 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+87 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+88 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+89 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+90 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+91 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+92 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+93 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+94 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+95 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+96 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+97 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+98 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+99 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+100 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+101 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+102 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+103 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+104 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+105 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+106 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+107 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+108 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+109 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+110 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+111 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+112 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+113 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+114 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+115 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+116 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+117 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+118 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+119 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+120 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+121 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+122 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+123 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+124 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+125 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+126 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+127 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+128 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+129 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+130 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+131 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+132 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+133 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+134 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+135 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+136 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+137 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+138 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+139 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+140 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+141 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+142 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+143 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+144 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+145 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+146 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+147 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+148 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+149 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+150 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+151 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+152 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+153 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+154 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+155 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+156 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+157 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+158 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+159 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+160 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+161 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+162 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+163 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+164 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+165 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+166 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+167 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+168 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+169 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+170 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+171 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+172 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+173 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+174 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+175 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+176 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+177 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+178 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+179 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+180 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+181 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+182 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+183 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+184 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+185 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+186 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+187 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+188 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+189 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+190 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+191 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+192 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+193 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+194 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+195 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+196 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+197 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+198 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+199 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+200 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+201 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+202 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+203 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+204 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+205 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+206 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pub.dev/packages/pdfrx) >> /BS << /W 0 >> /F 4 /Rect [ 161.88 615.25 196.7 634.67 ] /StructParent 1 /Subtype /Link >>
+endobj
+207 0 obj
+<< /A << /S /URI /Type /Action /URI (https://pdfium.googlesource.com/pdfium/) >> /BS << /W 0 >> /F 4 /Rect [ 82.8 587.82 134.76 615.25 ] /StructParent 2 /Subtype /Link >>
+endobj
+208 0 obj
+<< /BS << /W 0 >> /Dest [ 210 0 R /XYZ 82 742 0 ] /F 4 /Rect [ 100.8 524.4 180.34 560.4 ] /StructParent 3 /Subtype /Link >>
+endobj
+209 0 obj
+<< /A << /S /URI /Type /Action /URI (https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) >> /BS << /W 0 >> /F 4 /Rect [ 100.8 480.4 213.03 524.4 ] /StructParent 4 /Subtype /Link >>
+endobj
+210 0 obj
+null
+endobj
+211 0 obj
+[ 219 0 R ]
+endobj
+212 0 obj
+<< /Filter /FlateDecode /Length 339 >>
+stream
+xœeRËnƒ0¼û+|LØÚJ)!ŠÄ¡•öˆ½¤HÅX†øû/yb	¬ÙÙÝ‘7È‹]¡›Ÿ¶“%´n´²Ðw'+àØhÂbª9ÌÈÿe[8q9ö´…®;’¦4ørÉ~°#]mTw€'|X¶ÑGºúÉK‡Ë“1Ð‚hH²Œ*¨]¡·Ê¼W-ÐÀËÖ…rùf×Nse|(÷˜á0²SÐ›J‚­ôHº“ÑtïNF@«‡ü¬:Ôò·²ž-;yèÙsœŸY×¢{OcÙy6jYâ/q."ñØ‰m‘ö‚Ú¢G<ò(b·S°Å;ñgd‹»†küiÉmÑdYt{öäÙ8G¿ýFèW _ÃÆ!g÷Ø,>Í~ÐdÂ0ˆ5cì—äwÓOO5mÔeäÉZ·~íüÛO¯Þh¸l¦éÌ¤š¾¿4ËÑendstream
+endobj
+213 0 obj
+<< /Ascent 891 /AvgWidth 401 /CapHeight 693 /Descent -216 /Flags 32 /FontBBox [ -568 -216 2046 693 ] /FontName /TimesNewRomanPSMT /FontWeight 400 /ItalicAngle 0 /Leading 42 /MaxWidth 2614 /StemV 40 /Type /FontDescriptor /XHeight 250 >>
+endobj
+214 0 obj
+[ 250 ]
+endobj
+215 0 obj
+[ 220 0 R ]
+endobj
+216 0 obj
+<< /Filter /FlateDecode /Length 222 >>
+stream
+xœ]MjÄ0…÷>…–ÓÅ`gÖ!Pf(dÑšö Ž­¤†F6Š³Èí+»a
+Ø ¿÷‰gékë)dÐoÝ€¦@žq;„ç@ª1àƒËGWo·Ø¤´ÀÃ¾f\zš¢j[Ðï"®™w8=ú8âƒÒ¯ì‘Ípú¼Ò[Jß¸ e0ªëÀã$ƒžmz±‚®Ø¹÷¢‡¼Ÿ…ùs|ì	áRûæ7Œ‹×d²¥Uk¤:hŸ¤:…äÿé5NîËrq7ÅmÌåVÝÇ{áÊ÷î¡ÜÆ,yêj!Þ×”b*T9?!o)endstream
+endobj
+217 0 obj
+<< /Ascent 905 /AvgWidth 441 /CapHeight 728 /Descent -210 /Flags 32 /FontBBox [ -665 -210 2000 728 ] /FontName /ArialMT /FontWeight 400 /ItalicAngle 0 /Leading 33 /MaxWidth 2665 /StemV 44 /Type /FontDescriptor /XHeight 250 >>
+endobj
+218 0 obj
+[ 278 ]
+endobj
+219 0 obj
+<< /BaseFont /TimesNewRomanPSMT /CIDSystemInfo 221 0 R /CIDToGIDMap /Identity /DW 1000 /FontDescriptor 222 0 R /Subtype /CIDFontType2 /Type /Font /W 223 0 R >>
+endobj
+220 0 obj
+<< /BaseFont /BCDEEE+YuMincho-Regular /CIDSystemInfo 224 0 R /CIDToGIDMap /Identity /DW 1000 /FontDescriptor 225 0 R /Subtype /CIDFontType2 /Type /Font /W 226 0 R >>
+endobj
+221 0 obj
+<< /Ordering (Identity) /Registry (Adobe) /Supplement 0 >>
+endobj
+222 0 obj
+<< /Ascent 891 /AvgWidth 401 /CapHeight 693 /Descent -216 /Flags 32 /FontBBox [ -568 -216 2046 693 ] /FontFile2 227 0 R /FontName /TimesNewRomanPSMT /FontWeight 400 /ItalicAngle 0 /Leading 42 /MaxWidth 2614 /StemV 40 /Type /FontDescriptor /XHeight 250 >>
+endobj
+223 0 obj
+[ 0 [ 778 ] 3 [ 250 ] 15 [ 250 333 250 ] 19 [ 500 500 500 500 ] 27 [ 500 ] 29 [ 278 ] 36 [ 722 ] 38 [ 667 722 ] 41 [ 556 ] 43 [ 722 333 ] 47 [ 611 889 722 ] 51 [ 556 722 ] 54 [ 556 611 722 722 ] 68 [ 444 500 444 500 444 333 500 500 278 278 ] 79 [ 278 778 500 500 500 500 333 389 278 500 500 722 500 ] ]
+endobj
+224 0 obj
+<< /Ordering (Identity) /Registry (Adobe) /Supplement 0 >>
+endobj
+225 0 obj
+<< /Ascent 880 /AvgWidth 969 /CapHeight 880 /Descent -120 /Flags 32 /FontBBox [ -1000 -120 1243 880 ] /FontFile2 228 0 R /FontName /BCDEEE+YuMincho-Regular /FontWeight 400 /ItalicAngle 0 /Leading 315 /MaxWidth 2243 /StemV 96 /Type /FontDescriptor /XHeight 250 >>
+endobj
+226 0 obj
+[ 0 [ 1000 ] 16 [ 393 ] ]
+endobj
+227 0 obj
+<< /Filter /FlateDecode /Length1 95948 /Length 43403 >>
+stream
+xœì}	|ÔÕµÿ¹÷þ~³$™d²/ÌL&“ a$¿¬,	„%ƒb&	»@\6±JµA-nÕ
+Ö¢T°L&,øJôiÝÚ‚µÖµ‚[µ¥¥Öõ	™÷½¿	­ï½öóiÿíÿÿŸó›sÎ½çœ{ï¹ç.¿{'!#¢x…ºg4§w4­'bK!õ·­lé˜¾÷÷{ˆª»‰¸Ò¶~­cèBþ
+QóZ"ë‹;–¬\é³5ÕÞHã[²âšÅ¿éüÁ¢öÏˆöœ\º¨eáçÚ>7êúpìR’§§]‹úsÏYºríÕÏL!ÿ,Qåþím-g®rbö7¡þheËÕ™ñÖÇ Ÿ{ÇÊEk[Ävµ…Xg¾ôoUËÊEw-^&VsŒhTyG{çÚp-„>NÚw¬YÔÑW|ÇíD3N%|‹d_	—þå™ýÍ	ÞM™&’ðÝw†>)ù;¾Kò¿X{öë¦™Èšu{	àFç@-Í³Òk?ÿ™õŠóšAˆo•’¤khYi	âà}ƒH}írhQÊ¶J&õÛêTéŽp±ó$¦rnª¢r¡œ Qá~ºú2ÝÀìéÕÔåŸQo¨ccŒNvX#‡Qz«:Mö”Relˆ´æçðQ:)jh#ý ûU°o¿]æ¢©ÀÓÀ|`ãŸÛC¶A/WFÿ®NõD@ò¹4i—^®“œƒ:Ús¾¾w(Ï8”²ÕgÂïÚ!M“ÓÝÐOD>˜ô×ôG‚¸•¦(þ¼þÖ€OC›3¾hï^^nìÇ%†2J„<X‹rŸË2°·ˆ¡´úE. ¢Dø`·ýµ~Dá˜#™Àô¿w½rŽü…ìQzÿïÝN¢…(D!
+QøÿØÎð¡¶-¨¶ÿ{|B¢…&0
+2­Ý7£…(D!
+QˆB¢…(D!
+QˆB¢…(D!
+QˆB¢ð÷å	ZüUòs¿…(Dá/}ûŸíA¢…(Dá_ÄÛTÅß UâIª×Sñ_è_¡å’+e´„?AòßV‰]úçvüÛ*¯ò2åžî¤<e1¹ƒgSŒxžÒ”I4Eùe‰­T*š‘ïÓó<•†óÍ¤ÿ[0ñ"W³(òd¥›¦ˆ£\BÃ•a”Æ?¢éð©P¹‘LJ<Å)º!ÿà0ýKŒÕ?Û‡(üŸ>—Ò× “€ã¾B?îo±“`2ÒÄ¬×QˆB¢…(Dáÿ!ƒ8dð¯J Çô¼B¿/&RI”M£h§rª¤ª£)¸=Ì¤¹¸W\MÛé16šã¯4‡ÙQèþñŠüû(™OEƒeªQf2M£j¤Zñe(¿ó?<mx¾gzu€	üö§¿Ýùî%Dþ—0þW|a¡~ËzËU(nø²
+ÆyäW\P
+E=ŸM°&RrJjšLÛhhD˜C¹Ã)<ùD…E£iL	7¾ìË:jjë&Mž2µ~ÚtšÑ0sVãì9sç5ùæ_ö7ºþ¿ƒø
+Ù‘þ¯4}Y’×õ¤6oãÚÎ5«;ÚW­\qåòeK—,^Ôº`Îì—j/ñN(/?nliÉ˜âÑE…£
+ò=#óFÏuç¸²û°¡ClY™éi)ÉI‰Ö„xK\lŒÙd4¨ŠàŒòk]u~G ×Pr]“'È¼«‚–þ€¢º‹m¿næ¸ØRƒåâ?³Ô"–ÚyKfuxÉ[ï¨u9?©q9BlþÌ&¤o­qùSzzºžÞ¢§-H;(à¨ÍXZã0¿£6P·~iO­¿ÕõÆÆT»ªÅäSoL,’±HÒ]½,}"Ó<½¶¼—“É§Y®šÚ@¦«FzîÚ–…†™Mµ56§ÓW`Õm®Ö ¹ª	Ý„ªõf†ê€QoÆ±Lö†69zóû{n	Y©Õï‰[èZØryS@´ød‰´[H¿ödÆ—YTžTÝtÓ…Z›è©ÍXæÙžž›í3›.Ô:%õùPG€»ëü=uhø„°¾Ñ¶øF_S€mDƒÙÙ§Hï¹j¥Ä¿Ü0»ª\K{–û10Y=šu3˜•¥Ÿ ¬ZGÏì&—3PasùZj†ô¦PÏ¬kú25GæÅš‚ü^kb$¬½ñ	ƒ‰8Ë…‰EçuzJ7—©úYçãÊ¤G®)˜G›ž4¹Ð§ñ’,O=mãað1”
+,Äx,˜«ý=ÖrÈ­²|@u[]Žž	ãï:õ»‹%-ƒƒÛú1É¤œ%ç'ôçÒ'0r¤œ ÆjŒ(|œ¨çKò×‡xÀÕau€!|Ô€Ø¶øÊ|§Sï¦F­Èºg6EòjµI+ôøÜ/5ýç4©s¤¦ûœæ|q¿óx¯¾£¥L¹ç?	Ö´äÚ¥å–ö?¨Eôõ®ú™ó›µ=þÁØÖÏ¾(Ñ?¯L±ˆ(nDjŠSoÖü&)ÀGu×¹j—ù'c©ÁÇ@ru“°q_$ÅmB¯
+ó÷òó5ËLSœ¬Kqôù¿0d4aëæ¨Xý“#Ôãtþ•…BáÓ²”Î¾,6Ø§@¹çâü„‹ò¹×#à°’ËëgÏïé‰¹HW‡Íª§§Îå¨ëñ÷´„ÂÝ­.‡ÕÕsP4‰¦žŽZÿ¹á…m²ênñ¡KYyA¾Kjzzö’pÏn
+h¶^¦'ÆUoòfx|®@«Çåt5-B#½åçœí¯FŠSU¯‹Ý<³Wc77Îo:hÅ›÷æÙMAÎxµ¿Ê×›]ÓA¶z]Ê¥T
+eÆ!3TÏ°–‚Ü¤ÛÛjDÝºVÑz¾-ÄH—™ÎÉµ…xDf4”«7¤á-ÚR"íœµ™)"ëŽX´6Ac•šC„·éÊô"3»I‹§•k´‰¼‚#"R„äl'0ê›È*˜­uÎÒÅ!ÖÝ;A³Ôkš5hÙK)ë>/ƒçÒì‚ŠÐ^¤ãs¾ìÁœùM}	õëUä~	'.\	úö"W¾—¶á¶\.a¿«Ú5µ—_êÑ9ÓyÏTWíBXHÄ¢^9}ÒÊ%g‡áÿÖˆ]`$÷=½òë„s96˜CŸžÀ’‹³KÏgë$â…êY ˜ÏúÜt–Û+|žó&-îVG&q¹œÉåzáIýXØ“Ým-rcÑ·¹ ˜
+£©Õæô¡Bù^é‘¯ù¶SrÏ·Xå¹¨JL~6Ms·ìN »Áá÷9üX,lfª# ‚;ã]ïj‘¤!ÒŸìU`-=(KŸ-`ÄŽµ¸e‘K.ï€ØHô#{ÓÔ 56ÈÖÓãê	0¸è®ƒ1ªÏr§H†O‡ÇÕ²HCËSÈ¢ÈîêÑ‘µÙj]NL¸[%‡Õ*I[<ä,ð{‰Äž¤GYfö,J%·m®ØauÔ9ô¡n±!‡ L‘9*ŠšÝÒåõOn`¥§wÑý¥Dÿ´{"Æ&½Výh8gbÔ?H¬öxúx(eç™Ü#»³žêž‚ðj˜U6YÚà³wÊHù)²¨íÜ€EŠA¢/MýuŠ½ÇÍnn¸pÉ_H®Ÿu™-Àk¦2†f‹?ðÇpT¶‹ß‹Sä?4µ‡ÄïúÄH{Eeª8I~ñ>mïÒq BVH¬HU ;Õp¿x»¯¶¶X{Fé<8"¯ø T³†ÿ»x›ï¦ád‡àx0Í¦kÞ
+VU&ÆŽ$úF¯ŒoÑ€\¼%ŽÓˆH©¾£ŠOWZ `âk”ÀÙi»ø%€œ4ñz_Nnñ¶#âÇÐ?/ž£…z±ç‚–ÄbTøŒ8€k’]ìû5ûúâ‹©²SÜŠ½²ôðð4P¡vñu7÷ J µ3¤Dì»àç”O -¶7DöQÈ¯”TìËqC³‹[ÄVJß$¾¥óïgòaà"/ù¶Áü}àRÿíAù½È§ß3Èï†Ü~ò’ß9˜_/ÖéåÖòí¢38Ìn­½XHmEj+B·U^N@™¸A¬Ð[ê/_á×uA§K£ëúÒ3‹·#¤×!ô×!r×!r×‘Õ†s6"6bl6Àfl6 *E¢íuÊ›¨è 
+Ä½q—ò h?ð˜.¿tp»Ì‰«Ç<xõM±<8ÂŽI¶¤¯L+®8,#ÔšXÜ—9´xó—9sŒœˆàñƒ<AÚ.Òµ‹úÌqRº¨/kh„ÃêÊÊxÑFÿä”š,Ö ÑÌ)´—ÒJiñö.Þ%º”.U)ªaIGD15˜S2I×DûíÍ^6nãöÊBÿû V`pPAo›!wˆ+€ÍˆK3œºBÞ€A	9+ðÒ'ÀUä`— »H M€”@¥¦èvjç5çÊHûÓRm<¤ñèå	ÐÓ2œŠœ9rXãgà¡Ôl 
+]v(/ãgÎëŠõ~ A×ŸÖmÎé4Y–ŸÑò‡÷ç±@ÛžÇ¶ä1Í[QY¬eƒ$%%mÜ<mÏ´#ÓŽNSš§µOëš&Æ…Âý}AOQ±Î³Ý’ïffK¨œÀ÷À³fÐmÀã@AvÐB`°¨ð= vìn…À
+à`3PE‰Çäšµê¤|›®“)©çéú°;X>fFåtìcÍÀm@ºwC¿[·Ž¤öèò è	]>cÐ~».·ƒž+#ô2rï˜?HíÀ
+`3°¨ÒQ1ûî<Y?¨ØÜTÄ|<óÄ<þžÝ|·È×,£Sí”&¿ÿHJ4Y+­<ƒja;uzN¿©Ó
+æhñS-ŸLµüpªåS-Ã‘à#¨Š­:uj±•–½•–•–¼JjK''YxªN’²ßêôRæk)NËçNËŸœ–?:-ßqZV;-—8e¹!Xž¢ÓXIÙ]:ªÓ\-Önù‘Ý2Ïng·TZØ­S•N‡éÔ&)ûpoBM™³©5± 7ÏŽ7ºÎX8è­z'z ûÏ ÷[öÇÙçL[°O‚9'í•©ì#6E‘ù?ò?²)´ü4øð‡ÉËÜàßz¯—ö¡ü·‘ÿ.e›¤ýƒÔ —ÛÆ¦èòï–»?˜ßŠVïæ_ƒV¿Mùz«wóOBú­`þ7Áîæ¯ ÛtK—½#í•‰l	åpiÛFn.=™6ØâdÔ¼|R¤pm0_–ª‘„XuÐ5l¸ôòqæ¢½9{Ð¥wr(¹ô*†KwÚFnÇ³ÝyeëÜt]Z{Ý'íŸzËŽÓÇ,!ø€ýÇÑ¿¹ÈþŠM	î²¿xP†+h?šbîýöŸºÛŸÎ	±¹A{~ÈÅ‘ügûì½r ¶œí·ïÉ_bÌ¥kw¸ ÅPoóØïsÍ·ßëF>h¿>ÿqé­DçBíËŸhŸæÝe¯s‡Ôši1ör×{ÄãClJß.ûèœt¥uìÚo‰s]pe¯½tÎœq‡x)Ù:-ß¸ÖØjœkœiœ`c,0:ŒCCŒ)¦$“ÕoŠ3Å˜L&ƒI1q™RBášG~£˜b°JfP$Uô´•K*¿|”×fâX=dQÏë«X ©žêgWÆyêCÆð¬ÀxO}ÀÔpYS/c·ùð›q7›Ý„)*Emò{ ƒÄXáÆ[m’oØx«ÏÇêýmTßê|ÒˆžÄà>«ºª2(m}EFEÒÄÄ²ºš¯ þAêù2<BÆÐªÀ]õMÁÒGZåëépéúÀ$ùEÒA¾š·×Öä’ùš²kùêÚYRÎ®­ñ7£lÞ3òJ&Íú([šQ6ëÓÍ¦éf˜¯Ùµ5½ÙÙ£'Ùi„yô¤n´$RWš@]’ÁŒ£½®>LšabD*K¸°²8b	ze	q¤W6DõºÝ0ÉwK“ÞqnôºÇéê]_ª]îˆ;>rëí¸™Oo‡±/mFDl0m¸	6ž¿',ªúŒY_Ë›Ûä×y~Wí" ?°iýÒyÕsô.|sð{¾\kÛRÉqÙyÓµ¨&°ÐUãèmiû
+u›T·¸jz©­vvSo›¶¨&Ø¢µÔºZj|}wU×_ÔÖ7Ï·UÝõ•uÉÊªe[×…º^ª–mÕË¶êe[këmÕÏªbõM½&ªòU_á}<6ËÂûaUšµc¢¾F&83¾f;¤Þ_±_ ÎU° ¥ª ² Rª°H¥*^~a;¨ÊøÚ§íÛ9¨²Bœèª"eÔ.«9ÿéìì\Û)ÉºuÐµë2táZ,^gc} N~¿äxkš¿ÆÇäxÀ°IÛìjv7hÞ¡´»ÚÝí#Úw(3\3Ü3FÌØ¡T¸*Ü#*v(…®BwáˆÂŠÝewÛGØw(ëtðU7iÖ#Þ£^ÞîíònönóîñªqÒ‘ì£Ù¼9»=»+{sö¶ì=Ù©¸¼i¿æÝ–ý‡l±3‘­ÔÖèî®ÇGf×®“é„w9~s‡¹Û,¬f‡¹È¬™Ìj»è›…°‹BQ!fˆf¡â4–Óêåc¶ÄnÄöÇ‹U†~Ã1Ã	Ãiƒê04CƒÁoè0t¶¶Ì[[ŒÜÛÛ+¬±ŽØ¢X-¶!Vµ¡o@£uëlšÕh¨±ÇÆÔØ¯±›M5v>Ÿg§º©2›Úp>f8ËP2Ðlªô /ßþ	¨Ð ß>ì“Q 
+j3–ÕÈø<r'ÍÅ}E¥ÅãCà-‹#¼q~„×^áÞÊâð`Å˜˜ÊÕ}ø:ðàUQ,ŠõÊ×EÖ ¯“:=Ý"dÖJÒéYË<H09wÖvz<$Q.WÌ'˜zØÅ«˜Xç:êì$Ì.0éÒNYläç 
+ÒíÕÛˆÔidÑou~xøÞÀÔðõJr,ŸÉx=6ˆDnº‹¶Qf£éIêÇêaœáh+M¢£´‡âéöâéÂÑi'ö?;^gu”ÎTº—^£Ëi½K'pÓ®§·Xê©¥Ü0ËÂïƒÖÓÍáƒ°Š¡júb+X#"=™ç#nÚî§tþIøUä¾Cï²œp/MFê×”ˆ{DÝŽ«÷rz>|†äÏãZé¶½C£Ÿ6)%JOøJš@ûèeVÔtºF}Õ¼ÇžÛé!–ÎúÃÇÃ¿¡â°5}n†ÇAêç£Dµº”K—Ð¥Ôí¿Ñk,™Zxx¸*|/¤Ð‡ÜÃ$ŒðÃCS¨™n¥_ÐIœqbY)Žn»ð¼È~¯¾
+ßêi]KÝðüa”ÝMÙh6š§ãàËÑÃ<šÝfÚöûè«g>ÖÏž;Ô¢ŠpJ85ü›p˜FR<ÜFO XlÐ‚Èk•aÊZµøìõèáBºŸŽÑ‹ðã-ÄýcúŒÄó6ÿï
+ÏïÔÿÒ½	‡¢ñ4“æS;­§«è»Õ'é)ú#û‚›ayTyZ½V=¾±Í¥*ø>Ö¨{F)H!<¿@/™½Ï.e³Ø¶™ÝÅBì5ö7p'^ýˆ€xA¼©ŒUÕp9jJ“·Ì’y´#ð5Dûôw'=MÏ±T–Ë
+Ð£_ ü'|¯Áó?ÊßÅfåŒú¿ø"ÜCFÌ²IˆÃ:zQøKƒyl9ëdïÀó-|¯ˆVá¥¢RÌ>q³Ø*ž?UÖ(»”×Õ)j‹ºËØ2°jàÅp}øFýØe€_Ã)ŸJhæÏbÌ¦+á_ž5´®§ºóåÚŽƒ|ˆŽÐsô2ý’~‡ æ„ÏËÐúJÌºì6<÷²Ýì	ö4{Ž½Í>‘ÏÆ3‚å¼š×ñ%|#ž­üÿOmØE»ñ< ö‹×ðÖQ”°ZŒg²ºI}Äð‚q„q²±Õôã3§ÎŽ<ë;ûÖ d\6p×À¿	Ï_ÿÝT@£àéMðò^ÌÁxÅLÜO?¢Ó+º¯2ÎTÌøæÂlÈÇ¨U°I8:MaÓÙL<sðÌcóñ´°V¶Oëf_g7°Ù­ìNý¹}ÛÁ¾Ïöã9Àáy™g¿f°9&1˜Ín>œò2ô´šOâ3ø,<Kx;ž¾†¯Ç=ÂûøAþ‘,ÜØo[Äjq¯øxRü\|®p%_)T¼Ê\e‰rƒrTyQyUùBµ«µêRõõIƒÍPb˜cXn¸Ç°ÇðžáŒÑ`lÀ)|ƒñçÆ°ÉÝêô{ßE?í.4ejŠr5?Žu‘!:Ô›ØDÌÀg‹â6ñ3u1;-ìuÖ#–‰+Ã‰:þ™hgsù–-ìj¹XL·P˜íâoóøo”T6›¿ÏF(·³¼]Tãª
+P_RR•Ô÷p€…Êùu¬Ÿ?-n7„ÿÊÕØqõþ"9”<™ŽcUßÄïF¡Ÿòe|5)%ê´qÿ¾z5â=‘ßÌFŠŸ+Ð»ÂÅÿ„kã]Ø5~Â¦*9ü
+^ÆvaÇ=Ë†Ñ)¶š:Ø¤±Ãì—,„£þNñ›Æã0Znaãp›ø‰p²Ÿ‹òIY.Oeü4Ÿ#7¥¸Ï£ŸÑµL°¢Èo~ë0@«°¶òáØÓj±›¼ÄŠ)ƒîÆ~ÿÑÀãrÇV_U7až=(òiÑþ•cm¼‹§‰¾AÅtsðf*â÷Ð†p7[ˆ}:öON¸R!‹Ån™ßºð¾HãÙØ›ÑêgØÿŸÇ®_Ï~OW1VV?P¤æ¥;“ûï&<ir÷Ó†}êK4ƒ¥)Ž0Ëß¤+ðÎyíg‘þÍ§•|xíÀÎ¼%î˜Lšþ?£¼À8]Ÿ'b7(“±óÞ^Ž.Ã;jÞ‰ÏÑ²ðÝT±›¾!¼‰šÃ†/Ç¼1¼ûïúpÆÒMªÏU=J	öØçØSx½Á6aßžL¯c?r³ú ÏàÿDõ0õ(¯`ï¬ß~™RlD¨oÑ“´’~¸Mý4fàRÞ®xC§™áGÂvCKÃ+°ó>N;Œ*öžn¦îÀÜÝ¤,æEð7ÒX!¤—«ÛÄ+âJÇWÿnH¢…(D!
+Qø—†4<é8oeàcÃ6'Ž‘¸™Èó}!Î6%8{ŒÃÍ­ç—	8ç\‚SLÎ=u8MLÃ9kžF<spÇòáæ}9ÎKp2jÆv!NaKpóZ†çJœòÚq.Z¯ßþ®Âyèk8‘uã®óuœnÂÓƒÛìm¸÷ß…“ÑÝ8?mÇñ!œÖvã”Ó‡›EˆÒqzB¿7>›Æ38Á=O/à,öcú)îŸ?£—p÷xÞÀÙì-:ŽÓÕ	œÏ~M\þqêùFÜåV6zšz9;Ìˆ{˜‘	’ª„ø÷
+Š1ÊÄ>F™&ƒzzN‚å‘™]É® õïYï¥Ö¼ÓÏz©iëÑE¶^RBÆWúV3‚÷®`”Qè)ôö9‰n6D¡3ÑFSéÌûåoÿžŸd?R¯¤8DÿFéÕaþ(e’9Ü¯™ÇŽ/!M«,1Éo¶R†9Kb²>‹_2–´‘¥%Ðô)$¦°…EKŽEºT³Å(V-­$FS>Ë´~rê£S‰Ie…§¨âT…õ×£‹Øjý««±ifK2cÆd³QPFEÌÇÀ[æ¹¥%cÇ§¥¦…¤W¶”°¥¹M†êÂÂJeÕ¨ÊÊQ@¶DŒ,Íª˜6­>Ãs¦¨²@Š*e¯6âñ8zeÁŒ
+Ê^e>›ùiœˆ…?ës¹Kt^PTÂBá÷úÐ
+…ŸÕ†"‘™’5äÓ8fŒKã1C6¢Óœäg÷EV<x0Eº»×b‰Qâe¿Ó²²ÒcV*ÿ‘¾’YâFÛ­Îå×fx<Ÿ,8ûI$ƒq8ë­Ãåa«~)½Æ¶â5cŠŒÂ˜¬ŸËˆáÄÀya@¸66å)K.h—VZ_ž5V¸XÎ5™™åå£ç´¼ÁF\›¯•O=ü¶×äMÕÀ.v=‹5¶RÆBîã¾ô§Ò„9ÝŸy,S˜%Á”Dû“´¸X¥<!ÕžÚ*RCl¤kOhNà	™÷/Ãƒy·`úÙr8O&•±Ä¤ô2Œé¶Úv —›¸¤¤¸XÙ	d¡ÊäÒ±cKK†çº²ƒc¨wÂ°jÉj³ÑëNJ]^?¶jÉæ]ùÙ›’-æsù˜ÑuÍKz¥ß¬›7ñt¬˜Ùºß®v]8¶KeLÿ­AÜÊ˜ŸmaÛÙ1f`!V²º•Ùóå:9»ÀkõRá)Pé¤+D„LY½+H®éž3ÕÙÈÕ³_ðô»ÑÚíX	íX×±4Aomi†X¡™µòR³VQÚlfÛÌ{ÌÜ¼1NŽ¬õ“Õk<	¬½ ôŽ£R÷…3–
+5}¢>©ÓQ…šœ›SÃï‰êR²R½![
+¶˜!fªjªdKVˆ%hIæ,ÊÕr¹–ëÏÝž{"WÉM”âøfla]´[“J™îCl‚182§.µ.XýÉt}µÁ­êk´i,Ç•“Ã^n0º‡Ø†Ú†Ù„!97Á››‘™žÉN%±•ì†¬V–TZR9ÌÑÊl&$kj+eÆ€è³U’‘:Žy½­Wu„Œì]¡ª–Ôñýà
+‹qðTèá-I‡OOKLáÈðÜqÖô´1ÅcÇMÄœˆÌ
+>õ–µóý÷o¸ïæ—ZŸ¼~åSµe«Ç®6ª(§,¯¼¦tr	à=6cVå¶§öün`ÿï>ñéÀ{½w¶¬ÙÍÊÞ»¯³ÈyIãÀýr¦œÆ¶j@LÓ"«]KÑ2üÛ3Nd(”¡eðõØÞy|e2[Æ*±“nÇ]TèiÒ.Tð%°e¸Wbó`jñ,!›9SÍ¦8.èûæS´¤øø-±´(¡+aKÂö%!3ýÏa'ÃïñN·ž:i•»r…7Q.2úøÔö±Ç3ºˆ°HØö2ÕhŽ	‰_W˜ãd Š+d ÜcSÒÒÒS¥y©ŽŒÍi6Õ™ì½|€ûÇ§ÅÝYî*å™¿¸iÍøaÜíæCG_ËßÜ:Ò1ÌŽÞç£÷»ÐûaìN½÷_7fÄ–¥g¹¤$CÉ”$aXZZžÑkœbü¾Ñ 9.Sæ›.KŸŸq¥imâÚ¤ûc¿oâîØÝñÏ©Ï¥?›ñZúk'Ÿ+Ÿ§§¦²¡J¦jKÍLËLša4§ÇfÄ-Éœ”ùÍôÍcF&çéY™q™‹Èäª!#]nRÉŠ%Ä–jf³–WÑmfæ£ÅYÕ¬Í™l[æžLžyHŒAHoíc<nXˆÝŠ÷†áW3’›“Û“»’•ä3jÉò×m³È¡9ºÂïØîàŽÌÃìsì¦i)Í¼wñÍü?Êó?pÏ´b·}¹Nz#«aÁôœ²bIxO]°›ïê^ƒü]Ö›Íìˆù¨™Ó‚Õ>ÏI¹•éc–TVÆ­“½×eÞš	½/Þ{“U½î©ø§älÎL‰ÙX,ÖaÃ¸ÕŒmeï
+«Ê3‘®àq‘5 ßhe…úvî,%*-Á°Œ®±ƒ[¹ÁÈÎâ±cÇ‰]ÍgN°æx`ÕÂm¹îÌ£÷íøeÑÔ‡?ŸÈZWÌ«ËbêÀnVÅîùþõ¯[}ðG?ß²dÉw÷œo] ï’ØOæbô‹Y—ýƒ>Œ+3Ë—¶7®¬Ò\S[Ÿ­5³¼¼ñyZ‰¿ähÉ‰’OcŒTÂ*Í]®kG=šs0çÐ¨çFww¿1êƒì÷ÝqSLy!vKßˆV
+ñ“}ÇŠXQH”ìª5¥…Ø¶}C5OaÉÐ«î³ZòFfK)…Ìü-¶#Æ·è#†qïÄ±¸ÛyAwßR°½€@¾¯ÙØ… „ø»ZŒVÂ¶—ô—p¼…ÙÄZò‘džœ9FnmïN},O-Xý‘$'qþÁ&ç9µ¦âÔ‚SòÅªïvcGËIPÙÿE×—À·QœoÏÌîjW÷ju­´’vWòê°lI¶¬$rœxCç›’‡¨1GC
+¦±MH	4Å@À$´MZÊÝ†PŽB›–$Ä‰h1ÿ-…|M[¾–B)áÿ”ËmÚ¦”6±ýÍŒìÚ¯Nvf´Ú•¥yŸ÷yŸ÷Q¢'ô:ÝÐYg¸’I¦±<Ûx	Œ¹ñH·§.6kÎR¸ªÎ(á5±mr‘©þFüC}u `©¢<ieÒì¯Ã½x"˜BUðîïÅS­òß×+:ÏØÄ‘§Q¾Ã¶Pë“1/ˆ›0_‰ò^2‘ ~NÐÀ¯kÝ»å¡•çÞ<Ø÷ñ¶^š×CaÏµA£~íÝ‰°š½ë<­ó…7öÜ¿Ž]¼õÎ+:W}sgÓë÷ÜøØ¼T´AàÚ-ö½KfDÓsb¶Ïné¼ü†G±|	ãaÆC$A>Láp7„Ö¢Z¬O­/^´:ÃƒÊMÆ`r[ñqù‘ðw'ûÃ“O¥ž·=oÿ­3À´8QØš
+8ƒaÃi¸–À¯À›·¸®™ .Kà¢ôxQjuñ
+pü<º<yEj]ñzø¥ÔÆ†/·³Û¹A~P¸És“´Ý·=p{—ðMÏ]ÒýG“?Hý XeïÙßw¼çz/õ^s†wZS­ g4sóà§XÚˆA-\#é¼Îè+tc7éQÀc®5EP2KÈ,õ”v•Ž•ØRâiügƒz0m… Üd‚¡–ÃðOð½3Áòä(ÁÔèñ“µxI =ƒÔœÍÇâž +øKààÈG/¾úK@NÂ¨‰³F1³ÆK@Þƒ›³Ñ1K0„ðßå`ØR¬×‚ãäÛû{-œ·±Ê¿µ¯×;… LžG| XSTDAÞðûA¯…t“@‚[¬¼üøÃ?ëýþžòÒ×ö>Û»blºÖÜ¸ví`©iÚ]_½ª÷¦dúþ–]+¶<³o`éÎ+o;omÿö—6]|õª½¿éÝÜùù/nìlY—ÿã‚Gzn¼ÿº•ËWU…UÐfVAApÍR˜Ù/u^>mGh–&à¦dw›~,ŽZvøwù‘ÿihàüáWXeT9I—Š"¼:$ì8ïÁ:ßS¬ÉüOè$ï'5“>)îòsÎ!=³§&žrsÆ¼çÔFçÐÿïp{°Â -«eSô«Tc(‘XDU‹ ß™ÿA|ðø°1ÿk‰1n!ˆµB¡àFÈ“$¤räè‘|ž AýÓ‡0_û7=÷œˆ,÷LEp¹ÝNÑ³ª]ºÅïöŠaOXQ"rÔ¢“Í F‰tO.l¡}6Gû}™Úi-Y;ŽÕNéé}~Ú™w‹Þ§ÛŽ_¼ì^ì^ .ŠuêÝî•ârß…±+Ü—‹ëbÅAvÈµÍ=$I[c·©÷»ïïõÜ;ä>$þ(|(ö’ûçâÏ¢?½î~UüÀý®ønìŸîÅFÿk°º—(HÅ’OˆÆb«Ë¦X‘ ¯~Oñ_s‹š‹DâÑçéÃùŒèv¹ªèEÓƒb>„bjô jW…Ã¦CÝŒ?«©Â™V7¾=â2=UTx²3cUô¡éÒLW—ë„‹q}W»rÅI(Œ“	9,bO$ZÄp{÷±¶!W.ËmŸª¸rrvÇß¬ÄQ(Žüg;$n~®oÃI„®œÝð3PéVÆÜÑ¨Õ­Â*?j:zUÕêfø ¡BìÉÞ€U Ò=l&ÖÏzhÔ& ÕyêtX•aÉ:aM¢Ñ”ÆŽ˜ÇÇþ¶:>ó’ñåËCÅÙð|µ\¹`ì½óËé/¼ó!|á7)5Ï†[.ÜÁ®>uÏmçs†Áæô†5Ð‰êÆ~O"÷â‰·87Æp¬eçXcy˜Gy&¯Þå¾7öû!é€û db0„›™ëý×¾Êl|›¹+¼›yŠ±:‹¢™n†Ë¢§NÁ”F
+„‡q~ºä€v—Ž0°ŠÞöd÷ˆP¬2s†·;p"g•É›yŸ•ì–…°YÜý„ªžvò„Í$LZÛ4ºeUF²ÃéDËåEÆe—RâÌVhžñÑ@?¦Ð~’Ñâ˜|òöÑObSV}‘r¨æW,¬[“ödÀ°(ÖFàðãFqÐt6ÆœÜÙQ£Ë,1H´ˆ(FòEê˜Wå?Øßa|Np}Öi¶×Œ4¥®¼	"˜-Èï“h~´°	°§TGbo±›ý¥ªÎ~çÁ¡×6o½gËÏ7©kÇO<5þÄ¡m`ûîØ^/)¾°»r¼ø‹[Ç_y³:þ×ýù†û×áÓ/ÁeO-x•fœ+p›¸¥8ÏÐá<j³n»bÞ*Þ)þ_‘Û(nô‰÷xïõ¿¨¼}Edä‹ÆÞ‡Â·ÅPZ°¨
+Ðã¼ª8õDP©i—Ë‰Bé@ ‘¶N	I”4© ™'U'þp€Ì½´(Axav{ÉL@-û»ÇLBZ¼^´<èÀÉ
+nÉ¥AœR9D-·Ð“–09iÙ¿xÒvYœ£ŒÑ‡¾ìGÔ˜ÄñFÉá)—Iª‚m	ÇÜ~Ñð%cîÈ
+öã&êQW@ÅZ1e6¢“ú±ƒõ+{zU@8÷S«üŸpçÀ~µ¿×‰@°Êíë¡*ÿ!î Í{ ñ6|;9°ñŠ%bšô`Y¤k¬ä±pJa«°DJWÔ"©s‹(pÖ³»Ÿ¿æõV¼›ÇÿÏ‰UWÓõ«™Þ´cÛø=þö_¹$À ÁyQìc: ,ÙùÓ¯¥Q"¯Â˜9Ý¸lš•µÚöä™{²‡³/dÇü:ûûží{Êfíãú,7ð7ƒÜ e;¿]x›µ‹u²IÓ)(|TU‚zÜ¢#DÎd8ÅâR•€žˆ©JROdÒ6ÁÁrÁ¶K°$’ -¦QºŠ~m©T‚B*›Þ2d
+3Ó—a3;,•‡<|†‡<!ÖpQ»¨5]ÔÄ®x,JM¥'£ÔÄÑ¹ÿ0ñIlá6Ì±ýcÇiF*þ©‚Y;NÛÉN'“lLqôC ŽMõ8Uí¯ÀJV1™L’ã’‚LBì€î…0˜˜F÷õ&ªŠ“È”©]ƒB-ŸÍfÏ²è”ƒzˆW=‰J$<¾ ÃEÌ¤g,_³½—<úÇòN§aÀÔüyÿpÚ´†BÓØáÂ²¤ì´©›Ì_œ‰ðüÏ]Á¡±–¬/u.6ÆW\®‡$Ù0š´ë˜ÞÚxü7kºÓ„a‰¿~[><|V#ì0É¤£:ñÑ0™_£¥:qÚ”È°…ÎgÛ/¾Àô’Ó^w>Nm¯N¼kR#Äé…ñðk‹(>ð‘ÇG8pkÅG;>Ú°ê°Ïuu¹Y(±!Ðž§Zã–~H˜'N5r$Kú7²#Mlþ¾Ž]G;Žu°ÞŽsZ"IUìz<®*=Þ¢*9=>_Ufëq¤*6=áUEOªÒ¨'Jª2KOàYHÔÕ)³gÍ²Ûm(×Ø‰(‚ä#3ßŒC-^ˆ÷ÅwÅÆÅ-ñ*ÒÌ°ØÑÓ1ÒÁh°c¾/uáŒµì\pñïåì¹âÉRzû(Àhz2nã?5xM…_ªþ ÁÃí8TÍnÃ@9ÐmÈ3J˜b¦Ž`Étöâwg›l¨QPÐŽ|²8"ã¿4Ÿ‰ŸT,þÿ@‘þßq5y|mÄ€Ê
+h^¡Õ‚Q…ÂØÓ…’¡±mô©¦±§&±†ŸAó±pü-Ü²®†° 8ç²Ówž…üöø¥Ÿ ß•Ÿ¸c¯ º–ì;ïÐH±^7	dt
+>ÝL—BúÅžË¦	ª‚ô¸¬*’©
+ÔVUñè	ÉƒéCCˆà.$œ…Xrk(ní…c3!À‚Ð%ôÌaD8*0K.(†…êÄÇûÉ½x0nFÉ¯.ÖúôAý˜Îô.½GgFô£:"f=Û’’G¶Òß?0É ”6jv$­²Ïç©×{ŠjA4åõÄNÆ™û)k¡kÿmzñÄÓi7>å¼d|ú›tŒg1ƒùû žE¼EgQqÊ§šñ•èrôE´M»W{\;¤9`¼
+¿f]—M[ŽVÇžEF¦+žYq›ªˆzBS5P &N‘ÿñˆ(’@Œ vÃ^TEÏ™ùÀÿ/œZ­6êç6zÖF'Ö¶S¿¸r–lÅÛž¤%&ìÇ+$Œì`ì+Ã 0’è¦!QDL¤ÊŸÜ×Ë°tö˜Z,Ä³'Õˆ2ÈèŸŽ‡þä$Ø1²›§McïÒ7œz§¸ÂðÓ€¸¶w¥&:šo¾ô[_^¿Èï0fh˜+I04`½¹éôîT¿/waÂ8 –¿ây, –Îã»nº€t…œiwÆ]Ïxiœ•ï–×ÃuòUùMòÝð¾üKòkò»ðÙé”±h³˜iò´B‡Ì
+)9Y`,2W™,ÈàG3Ak°,—B¥B{sgó:pØ(o
+m(l[å[
+÷‚»ƒG»š÷4¿|Qiþ}ðwòÑæÑàûòû¡cÍÿQ0ÂEÁùU°;¸"EðÚÐòó…ßÈ¿)¼-¿]p¹UÅªÇ5U	ëñœª¤)ë	zB¤ÑWW•ÖU²Ðä€!Y&yËìBÞWƒ…¼Œõ5~ïÁp(DVA  PH¥…ÂEØWCù\\Óô]úøÅ1Ý¢ï4›a3Dä%œ¢[s{Ðr÷Î&ê0Øú„±ú¨Bm8ÖcPœ¢Ã )	“‰Œ€ó2Ï²#ö¶þ~pç®ÆÈÎ‹>G;¬5bY–=eY”Ê@ËÁêÄÑá`9Xð•k¥GztÃ
+À’Ùå<cÖÖŒ+ÓÚ‹³t#3•à¤Ï&8YB­´â C‚ªOÓeÂOøì'ž†Ì‚±“ŠÑUO°ó¹–\€ó¿áq8˜_‰õ™Ñ•)¬LÆþÎ^szãfµÞ0Z´fãªt4eœz¥Oo;óÄ¶S·8ñöÄûÜ÷0*Sð•K¶IPÚ!2;KÛ”¢¦P£w†÷Zï=èM4xo<.‰$ÒÅuéâADÂG‘$D(.Å}’ÇlðÓÚmV+DJX¬µ¤CºÀãÑÄ‚hŠŒX8¶ßƒÍŠ'÷'*»Å"»E,»3P#_°<–A¯¼„_×q8Çª€ª ‘ª€êÄ	ÓFõA(}ñw¦¢ÒO8âŒâÆ'ðø7Ûk(ª`IV¦ààÉ’¨Ì½ÐL[¥”í ,u‚ÅÒ°JZ®®“î‡Ã§à°ôü”þŒ Àª­ôgaÿ\ò} 4ñØ“1©‘BCÀÙŽ³‰w`8š‘2î›ìÚ•q¤!ÃWM·T–R‰~|„ÊX½ºÏ^Æ/s´Ö}<ì+#ÓSS)öÔ®|ŒGŠF/R¬ IÖ”Ã*ÐhaE²¡|§œ‰Í4Æ 2‰-Ÿ
+‰‡f’ö1³Ìà«€u§oR’}3gÍŒÎä–žæ×¾NmeçþÑ´=1¿Á‹ßaA6KcrÜ[«–ç°‘ïh-ås×È”‘/¥ûrwFøMòÁºÃé×•×#¯ÕYB)1—N–rjfº[•ú|ª/7˜³¿ `8’‰,‰ü6ôºÂ=–†?¯û]ðµºß¥^MPg‰˜‰hZpzŠCUáõ&/¿ž Q­¡>šnOt&°æýõ8ûó#$Ã…°îsáE¹Éœä ™Û“CäFrGsL®Ò0i@‚4LÁ¸ÛEq8™'Ð(åÚÙ˜«Â/>©“Ä {Þæ~•sÉ7=’Lã{
+íF»ki]¨&Eõ²T‹c$¬Ë#²‘Nf‚É"¬‹à&ª/BCI?‘.Z¶ÉcØ13ÙxL›	tM!†G­$: P³ÊÞh¢Ê¿?Ü
+þú*ÿ—}½~…‹q‚•ÂEøTJA‰ÿà,‚›æÀdù0¨Géú|8’<·eì)-}
+Ž–ð/~µãõŸ5Ì)}&ºîî…[–»Ðõã×ª8ZÎP70½d´dßuuuØl^x÷/Y¯]8¾çüW?HÂÊR™ùðBþNÈX\p%­…á­p¸Kø©ûm`eÝ&82+æn¶ŠŽšy!Û-DôAÀ‚Ï‚“ÉÆÛToÞ‹€WôjÞ‚×ôrÞEibøp{IK›8a·‰NÍ‰ÜNÕ‰œ‹R“E’¶Ÿ+öc#âÁq²þQí£mí£âÉÚJˆiMjF$iwØÈ"u	#,ª?Þ£Öp#ºq“ôà‡º/Öˆ?™âÀU¹0!á†®‰L-‹Ô“ßÉ’¶²—eªüo÷÷² Äªü±á^XÅ@•ÿó¾^‘¡õ™bV|Ž˜‹#³d]ƒ¨$b4 @ìä±V–¡Q‡¹uíèÝÛÆ_ÿãÚË®‚Û Öð–ñÆ¯;°þ+_ûÂðÓW-.ÿÈ½çQ‡Æ}îÉÏµÎ¹*ÏÂüÆøUãGþ9~ûþMï?¸oëÖïÀ¶¿=:H¾08ñËa«Í@÷R›…¤; º‘n62\¶v"«§µ
+˜G§Í˜fv¼&´&¼F±pNÎêGZÙöÎ®î¾XŸÚ—ï+lnµ9‡\[ÜCÙÇØÇŠ¢ä,:[œ¥h1Ú-‘ò]#«Å45“i,Î†³Q;[bµ Ïj™UZè\X¿Ì¾Â¹R\‘Y‘ªPEJQ-)Ó–ÉËBËÂÝÍ«‹«[V—VO[5ÝÅØí¯]É$ìZëÌL¡u@ðn­»‡¿'oá±üHúÙú²#­'Z}ç	3°)OÀ_@o€“Õ?ÓYº¯)¢D×«J,v8JÎ´„îóaS¶9\>‡Ã•uÔ»Ø¤•v–Ã
+1ÝÄ$Ò¤*ÍX¼B5	“U˜0Å¼çzÓ5Ïž7=Œ§Š†ª»cY‘¬îâÔrð™ÜŸs˜¢ÌŽ’™û~À€œ–+`âbsOÃ @yrù¥’íÇÐ8IeÆ°×(ÿk[KHØEô§j‹tTbÿè$Ð§Õxo:io°AÆMÈÉ‹¾€ÚE`w4dS"¦*·+SoH˜®„¼¥éšEø™¥¿oÄrj ‚C®õRûZçåâ¥Y¶Ò]˜+A? 
+Ía—Ýe¶à.ñA`·bzK¥¦P¨	¡¦XÌ×4ƒ‰Z›,˜Îö÷61¾õŠ3UËO”-§
+#¤äAÖvp~C“«>µUbO1†jd–JÖ%§ÖI!…ù¾!Uv¯^w[vö{?¾}ÉŸŸžÙ¢þ$Šò†¾p¸wó×§·¦Æ¾cé±ônšë6îÊñìÐ®ÏÞpþìâ’Ík¯úæù÷½iåÚcyøËo|½gËªæµ±ŸløÊ²oüºRó$W˜£ä%aŒúNë*¸
+­Š®Š]	¯DWF¯Œ	y½]ïÔïáîVãUx£± É±â8ërë	^N ‰nA¯¢Ók…Y`]í’Þ.ðæ¿*J›aÁJc™•†-+eÖx0 fc„]äckb»blì0JƒÀÄ‡¦Dº qüêOj—UÈZB6{²BZlbdŸ½D^`ŸÝÝB¾$y\l›,ˆÛÓ^ÂÇÔSïÐ GJP|‘T®©¦>€b1QPeœ¬÷ªÈ)zh@ÏèlÈâdé™.èþ[`¢>áet'í^õòeÏ`±’{–(—‡Ö¤[óI‘[:þ?ËêZ§Ÿ:9¥RX‡ËÛ»ÎÆ°OãöbäàîšJ)`WŸo)Ðõ£:Ú›Ë‘–´¥Õ²Ô²ÉÍ	#ÕœhNÍOÌO=’â3©r
+u6Ø¯wß—z&õqÒÒæªUTU	éñzZiðªŠ¬'p’„DFÚi­Çš÷/ûÉãÁ;TÓ™íQ¾¢Õ*˜Ž²`â %$`¹lz|>´\ 2ÁBDD×JôÎk/‰ØWØUØS8V`ªF¯QÃkÔðZ\’nðÂõ^è¥ZÆë"Ïycä9o(ò¬ž®LåÜdUÔÙÊÙDœ°Í½j)Ö’ó7í.`¢Hêi›‡ì@·‘2ê\Z#=IG¦Úmºh4‚´74ðÑ½ °‚=ô‚P†Y0rj(#§A3y§u2äÕ*Ug+*H’X¤|ªBzRº0¿„ÇŠ]Yÿù£/ÿá‚6gô‹[–Õ…¢K·¯»åWçâŸKÆ\µìµ—ßzð¾›ºÿŽ¤ÍçF©n`loçË‹7¿ŠœíŸ•&Þâ~H|M'ˆÙos[TT«wîÀ˜èÄoü KEÞ…xºÒÙ.Ž=:ódAÓ!‰:öòãH#åÚRe±T[ªlÈÓÞ¼YK´üM:¥žÐ™ÃÁCòSá=ú?yîñÐîðÓÜË!'sßµ<ÎÏÿÝ w?¿Ã½Cº/°Cç>ï¿,¸ÝdÔ¹U•Á.ýs–ÏóÜE|·p‘í³®n?gê]`³’»ÀÂiz;Ã¿ ,rq†%Ã§…´?à°xÐzÎË¹Úæ3\ºf„õ&À;ÉGT\ò‚êBÄ«+âØóÏ?9·Bwõ(¦pPn¿¨¸]¾XÆµ:1dz¼Ex>Žu$Ö’œÅB ^
+É®,Õív¹ â-ÖSAüc!`vNØÀ»¿éïòïñŸðsš¿Çßçô³þ*úà€¦ß¥“NLI•ÐÉÊñ
+ÆÈdE`ˆ«Å4ÜËtðß5»éZæÙšeU²p€„"«M–ÊnS*³$Ë‚à-ó8W;à-ÛÒ^röÕ½îòTrÖÝ+ÊÁ /Æ ãrRãIâ	v)téîè·ðxþPZ
+C–ì6BX‹A©÷Ã…F)3ž2ÆÙ”Z4ÕvFvC3ß:ŸspK§Þô¹S_f¿¾Ê§&8Ã°æêš¯8ý6ãÙÐ-Ù1¿`-½hb”ÙÊ<šÁ,æöO¬Úkí´*ÚnZð+|Îìv´Ü Ô` G‘äÖvIBË‹r	~üJSEÂ?~BEzm±ÌÓžo¤	”fÅ·äŠ Æf
+-ÓŠ_ÔaF£¤õà§Õ‰WÌ¹Èá`o¡LÏÊô
+Y4b|[òX—<‡I†¥³Ù#ù1‚§W²G`? <2òF6ûœøÊR*UÌõöÈ¶"’.˜%M-¶?f=`c¤¬´l.Þ
+n·ß^²D¥@«Ø>ØÎZ#K¹¥–ùÚüøÒV³}kT°¹xÄÁ%¶EöE¥%Óç¶.šµÒ~¹ýëÛ»{Yàæ RÛ×´£¡ZÚr™Æ–§0®À11rÀZv¤íeÍ!ZK¢£ËLÜô8v¬£M&‰~Æ^î”×Èëe&/ß #ùËªÉ'.´™mì>²]«±„ç­Ê,0=¬=7Ò{Pt:--xâOcX–Ÿ"ÿÔ0Èot•¡ƒÆƒ54 !’‹Œ§Ð\À?fµì¯ÂËÍ˜’/7ñ¦«¬ñ]ü Ïˆ<<ÁÃ.ì¿sgÏýBM$ödÉ>,¦v’³â8>Y^?ª`¦?9v¼"Žö·`™õ”É5Ùl¾Fû•îÑÚZWm_OGif$Áy§Ï˜6Y¬‚M@=®Å‘¥d/ãä$ê ÉëVOÌäÊ0ChÑ`©Å.EÄtÅqÓji‹éWŽ“±¢¾žlƒ°‹~œáÎ½p_»+Øí²€øëþ&üI1"íiwÀUž®áÏNj0Ò3íö²¬ÙËA|DÚÃvìÉöòô4ém¸·áÞŠ{ë™ÚËÔO7 k,²ÌÆ-UþÝá^‡£ñh/¶g¦*8÷÷ìl[U°îëeí“rôÌB)Ý[&whOŸ6mzmkšÅôÙµMê÷~²I•.¦ûilóXøÉýH¨ã«uÓf­¹>–yéÃ•´I”Où=\wÞÌˆdºE‡¿­omS+¼»¡sÞŠK·\å	ÝtÅÜ¦y×®¨Ûº6ohÍ5·4®Ø‘QÏÉÞ2þâÍ3}¼³mÆ]óî€•¶PCOyáœ‡Oœš8Îâ¾ ~t–;öÆ8Â"aÎç 2-ÁÉ"[U8PÉ): Lá ×;Éõ‡,²zIÙÔã3­ø2Î†«]ïÆa’d$íodk)	õô7²#âØíÉ.jq(‰_‚Á/ï#÷{c—4 Ù9aY.#‚òv>ÞOãÁŸ’SGÒ¨­saê!£#“¿ïHm_½bn“ðaËË0ÿ¾ÊrÉ¹ÎÊ4-y³‘½•be¾/ð<l|)çoÌ7O: « ågÞI“ÊíàP7È=Á1ÜŽ  rÃ!:»œ}ÎNv7{œp’2CGœG¼óÇÁ¶’³ÇøŸ%“»>Èª8F\o¬2PËÕÚ=Á2ÝáL+Ò;ŸÔ˜˜Ã69B²Ýð#•Õ5²+µ(Ý*³“íÆ±Ë`/©ÀînåI?@zUîïÅÑI¡+ÍÖ)¼’5µu–â¯VçIEgªðCpgÞrßWõÛ¿ßõÈ
+·&Gê]ÐÛX¼ª|Ñ·¿}Y©”FúË/OÞ9ØÚÊkaXLô¥Ç~ß\üÙ3{~¤ø°’Z€q¶Ç(Åéî|…SQ
+…?µ½‚FKÀp[ù½OGD"Ñe=ŠãÊ~/VÅxðó$nE›HpÈVÚŸ¥`:Bö’í•èîŽ«ë[@‚X8è\É¡ˆw{VCËø•#üåÜFnêû•çµ£Ú1ð6g;à
+yydM¢Gî‰l”"Û¤¯ywxvÈÂ‡Ñ‰'á³ð§üOCï	Ç#ïk'¡lA‹¥•ÒíêíÚ`âD‚÷hðé‰c@Ã‡Ši	D¡ùÆN>¨# ‹Xq‘EÂ>}Ç'ÖDNèN}môM7tÿ4`Xù()ûÊ¤3gHeü!íúËªv:¶;#/Òõ¶Ðv€=`Vrï]¾9ŒºÂð0W¡Ã”NX °ˆ–Ú¿’ÃYæÆçB_¯ÈN£Ê@ÿXåx?…^6Û>:ÚOÄqiÒmD/^eîˆB²£ûÏŒ3àR´ÂÐ80¢\V0»b™Ä‰b©+þÙ+–'·pb±Ô¯t»­ºÎXôëVž‰V…È¾^Æþï[»‰ÎG¥PlžÚµ9ùÕÊŒ˜,™ÅÆ«7ë]÷ý°©afÌcO$f_6ëü·^rÞô¸zø'Ðòæ«ÐµýÜd>éß¨Æ_òàÃ§ææ6‘Úã¼‰ã,‡9Ohàz)™§kÉ‹L!(ÔàH¡	´h€R`À®ÑäŒ O£É™F¯Æg?6k™—LîÐ"‡Éæ"È¶U"d(zM«g^>€…ßÐÀPD¸08©zÞÀšg„B™lW˜´Äg$|ÐìCnôE¡í‰¢¨jÇ/cPV°„ñ;ô‘^cÝnÜ"òŒ¦åszýp–åK>GyòH¶F—d“D–Ð•Ê‘öQÌ•˜2±'yœ©tt´ä‰C“Íµôä¿Ä~‰ÛÆæŸÈäy3?˜G ¨÷g—sË…eÙ»x~!µüt[‡m…íö»õ»òüHþDiÐôÃØ7p"nÎoÓ:µÏjkm½ÚuÚàí{ü!þ…z{Rð¦s¤˜wž?š
+Ì‰Ä¢óT|›mðÓYS`CƒÊØU`×=’¿'0x"À¨8‡@2]’]¥s-¤?ØQ²ÌÍÍ½a2Ó=wtl Ò6ÖF~ÈÚò þÈ˜pEÊ¸@<K¼ád–RFRÈh Ëâ&Í¬ç´©=vd¯Öâ¤„ÿc_GuçY¯ª»ªºúª®¾ªª¯ju·ú–ZR·¤–]Â‡lHàK²Ø9 g-‹p°Ä	kÈA2È“„“|3!Ûm2%q$xf&a—ÀÌç%PâÉxØ$ yßÿU·,³»ßÙUïÕ«»ûüþÇû÷$dHba{ÜCE¬lÇ¾E(<WåÍ)¼R!°À@ F ¥‹âÖÀ~s¬äÿUÖé¯ŸêûòëüáCXìªY;råQ_ o]9×ÄvïmÙ¸{vÿîlºì½ýõþÝ_éûÞ«ÓtÅ¾€~¹a¢<ôÑçò¯@ùX
+oef)bæ×P~Š÷aMksbR¥¤©åEy:…ÀÁNS”…7.,	Ý1>Š².ŽâD˜x€wÃÙ‘Ùø8ÛL/“3pç''kL-V+7€þ+K„ú°!FÈæÅ…‹0 ä¢Ža!ÇÔsÈCwäá&zH]ä4n–c(nƒÞcœ‰{ÈôuÓœ‰[qøÕ€cì=žH¿'tñÛbö€·ÅÃCG$|)xÈ.žü0vŠ­äYñ“[èŠ´GSÆ©qÏËŒYÑ‚bË>=XŽÀS	ëûŠ|O„bªH†·fšŠV±Œ¸¯õíñï’w«b,,gámfïö0ý û€í³â}¡oÐß‘»NÿÊùŠxžþOÆ-sãü~»Ã–ïsÏ;ÏqXröOÓŒø‰ÅüÔ×nÙD÷Z†"Ûèm–ëéIú°û°rÔýMË7…*Ü2+ü˜þýºí¼àáÏpˆâÎpôAhá³›ÆÚ,6Sï6y¨‚Ïê–ÊÒï!ïŒ÷5l{ÿbB&Wzˆm<gÃúfl*ãÏøš ‚o„ûïKÊN:à;ä;âc|ç=ž)H§™æé„gD^çñ›ð³üë<ËÛá5Q‡®˜œ.ËÌPÑ¡9˜sä€'±àÏÒ±>¼¾†™°ù2¸| ÓÁ1Ü,a…¤ÅOIe'±;á€Û	Y˜È{~+42¡’êì„,¼õ#ó,üJÏÁQbØÀ$‰îrønÖXÙ¦çËv¼ÀÝ¹8  Y20¶Æ¾Ú–`l	Æ–…léKÙ+*eEs•í	ì¢ì%Æ(È
+Ž³º¼T•û_Ç÷{½VW€dæº8«©ÊGæö[/êÅºIáfýµl\CCJ !ÑFÃÁý
+Ú·ï]÷å#ÞŸ|å±·ÿãÄWŸ[~ =n•½í[ï¥×ýìãß{»çð¿!ô«·÷ÓowÄ;õO‚Ÿkˆ¢˜;ÍRYºgTHä‰>Ìë ÖòÄ—È"ÑÁ"Þ‘F<‰’Jø;ú­.c;$"2Œp)û´‘©§|<öS”3í¬¢ÀœÄÂŒ€¥q¡²¸$.Jo€Óâsðï4É‹ª	€S”“œCáSõPšã+ñiD±À¹ˆXä1~©[	“q¼ý
+±Ž|®®â^…¾ýâ¢1" _þ9í¨÷h#³Ù`Û¬ÜÇÜg3Õ„šó‡¢PFp†Ÿ±<*>êšÍ[DË·=™=Y:È;æÃüCh>ÌU^ÄÂ3ágÃtØOøQvü…LZr±<'ˆ˜1ªèê§Ž`#¿J¿;‡2Ù*u{*$§K|ÈéDq ò§ÆÇ‹¤íê2ÚJÅhã-¤Õ}ÁhqÚ€5ö8&Ž3Ö¡äžfX†«b\Â$O¬ùnÜ¼1vv’øâ»»—'»+ËØšo®EŸ¥DÒãkLx¾TJzâATÓj Ê oè“þx•{G·ì‡]ø;taó÷íûÓ.v5š,Îû¶¬‘èÿx28ec¥6líÖæpæ#P¹Þ6/úV0qùÖåWÓ©+”¹¹‘ãoé*†ým}‘Hc“|‡XþÖTC.Om¸žÞµ¹ûð÷nÙï—¢s»[>òò›±J¸leó?°e±ŽÚB2ËÆ\MÉ7üpãÑv†Ê‹»é[3·n¥©ÛÄ^ý9ÍTéÚ} ã–Æ‰Ý0›ê^ÿ§å#¥Ï^~ïÆ#ý÷}Éÿ%ùèPÕtÊ<ïŸ—_(¾Ð¿°ûÌî×wŸÛP5o›Xò´Gv›ÿ–ïk¯(ÓíPÊú‹?Zeq»=~*¤øÒ$¬÷ð5zlhu«d­Ì$žH<›`Uôèñ‘ìT\Ã¿Öíp¬4}"úl”‰ÖÎ!->%ŠÕåé>Ôs?ût<Ô—–ëö Oñºû ñ¸ã‚ A‰=º­¯2-ºMéš4¬L)´òýÏ‹™rêÆ»–S®BWårÎÁï1¬_Ãx]¦™‚è@áHa¦ÀdÐç°R¡Tnb¦¶¡mðnvÌå¸ó“yÑC:¿&~«mFºfÀm‰H
+‘°»Ï¯¤ÐPj"µ:“2¥pdªž„;¿Ó%4©[´Ý…Ýúîcø37ï†SƒV[q·ãÈ—7¡MÄãµ©Eó!§oÂ÷V.ÕÐ]$ne â#Ïè«ÒÏèî£Ti)0Ã=Ì ŠšR	I‹¯ÊÀí¾Cç$¼#sÃ®ÝO£Û©(ž<EŒÄÍÉ¥ÉeÒYÊNž³I²ÑÁì$h›ìAñ,Æ”Øt—jJhùPIq	2?1ª™áx|0ÖJó/E_‹ÒX/Mž_Ç3Œ$^Kà‘I`ØÚlÙÕ³uÿÚý;»6ÆKÁ_FæÆDkK[K±…a{‡›™Æ‰mA\Rý¥AºU4ê2s%HçƒÔÕÙmÚ o
+¢íÉA´cg¨+€¬£Zú4ÔßWj×éõÄ'MÝAteóUAjkú*Úè_4æßÕ#ºµÕ¥•C3dbÈc@‰*Õ…&ÓhI”À/wîI©×}’÷T¹wõÄ~Lª˜`÷ðhˆG5ó(Â#'$†gõö¾PÖW¹×ŽïW”>¶›ôXîªœRî}H>U\Üsíª'Í”??V‹dÊ(V“±š	IÜj~ò¯æíH×þGÎBFÈ¸>]»…·KÛv-»wüYÃšgö¶ÎÓmèÍE¢…àÄ‹—¸ñkï}ÿ¾~««Äí)fËÈÛ·oCqxàúm+l.tí{fþ;mÅ¯þº2ý…ÑÏœÖÍ¬Å¯
+fvóÄÔ	OcÙãÒ8c¶Ø'®>¸÷¡­í²œ¸Â²7Ò‰]K?pëî¼bòÎ™]W¼ÿÉ¶‘D!~ù¡ÍEŸÏ„aeÇšû?±-ÛN?³Fs‡:u¢àˆšä8lË$À+ƒ×8O)±oe°‚Üº<Ñb)™GQ“ÍFo’kDó2\#_½ðçyÅw‰0_çdÜyGwÈ@®—GØí0ð’ÀK
+/Iªˆa³Dü‚¥v*é
+åLàlnK˜äíãï¶f(.ž~®U<5F±y|ze<R”€ñKdï˜,â‹Â%]I€ €¡æ9$C5_¢ÜÙ¢d8J†£d8Šßæ‘i¸ó‡yØ;ïŸ„}ù|gGSHQë/”Äoax{Ä-š;õLIèÇÖ€3álœêœî4Ív.tžéd²,îïœ€!½i¼œ»ªŒSw5äÓád_ƒ‹}±h:ÜXezS¬”lê)†K–l§È[bäçr‰‚"Ç-ÓšS˜f„—“ ¢0‘§¢ñ¦H~8?žŸÈ›¦òÓyz6°^Ì/äÏäMùñŽo"Ó‰€«×N@Xªt»ÊåZÅ…tð¨A3Ï&A³D¯r! 5Ï#qÕÃ\bãïW0…ª¼€A„‰s&RŒK"ÈÁEƒ‘>KP™ÁOâ˜mÀ’fänû¶v´×±ÙŒ|ªçÊ‰€Û!ô•Ë½z«ÀD6Znìó–7­t]óÈÎˆêmv ÉüùåëïÜ¸ãýÛ+ÿ¸S“ƒB%^‰6|ùÚæâÐJðÚ¦H<î:w0—&4ØËÝxÅaî²Rô‹üuŠŠcå"óÈì„9ìQâõ‰ÊÀQ·ÌX°V#úÅÉ°$	,a’“Q½ðâ	8Úb—ëZwþ}¾Æœ¯×™óåã„75pù‡¢¢‡04h8€¹~œE,AåÄÃ`X7F¶/cE³8&¾:Vó&‘´EÌ@XŽg¡ÔÂ*ßØ5Â1Q²†ëÌ÷÷×:==FGW::Øí:8±4Ü”¢´hç†×{WÂ™K<f'Üc§Iì„{àÍî‘ALnÃ#'†‹ÇÖpŒagãgu±²h›jŒ£LÇÑx|">??7kñá8­Ã*J¼µµHÚÎ.£ÍŒ6– ­Þ¤¨EÌNî¾{:,a&J*=Z8ºÁ¦ØÜÓøUÊÕ`ãÜ’0mA–2à‚¹õ%htg¥ÄÜd³Ù{\Ö³e™ÄýÚ»ŠÓ2–Ñ¸<!OËÇäs²Yž‹Í}ƒ0)[ƒáÀ’¹1À¯&®+1Ô&fÃ)Šbù–“:~Îåö–p×ÀtE]úà\îUêoo_­e‚©?Y·.“é^wÒÒ³²~}SÀÂ…Õ`Ê<æÏÃŽîLfÝJtYÛQÆä®voG×})§)ÎøE_Ø»²	1Á´FçÖèkÊMÌ>w¾åóó ôI§FÄ¯×‰ø—ºÛ bƒ¶GªVÈ)¸ó9wþ'9%§Xà”Å¦“@Õ¶”îÑTÚxQ¤š—Á*¾¼X#Þl¶N¾Ùç°µvâk*b”…ï£ÒQ²gç°HÕ³ÃÙéìãŽÇCÇ²¬†7¦²ŒˆGÎd•O%µžd8µAWb·»UKF	hiç«"‡n)ÊÆá;;gÜÈ®ÄîŒAzo‰iÊúý*¦ƒ¶‰3Þ¯ã‘È´†œ‚
+*ç4FÓˆ¿µzá¿°ÞÖ¹LöŸ¢@$E¸å1’k6~hÃƒç1ˆ$»´R1¸q–]Ìª\š…‰£eR¶Vî†^1v8C‰ 3DaG ðª[lXõ`“-0ïó‰i¶Ê·œÐ)”æÄ@•;7·_tO&¬šáÄµ&$ékû ¥²ÝÝYLJSÏÛ=ÒU®ë¢r“ï"¥!»3Ùîíý¿}öŠX¬ÕÎíLìü+úÁ‡³QBmˆºKR'–¤^#÷ª.GýXŒ9ê±±ˆ«ùÈ|+ÄÈ@6P¾µˆão	î°ÕE¥*	8bëã8‰AšŸÁ ƒ‡ª”fºW£ój¶uÕå`ÈžÓàuXƒ%’n"=ÄÁGŠâjÞÃÏ@È Ên6úŽ!Ül6¿ï8P!~tg'§ýþs~ÆOüMEhõ®òº"òÏÙ÷µû‘îöû'üÓþcø@Î–s}(f“±z8?Ç
+ŠÛmµËi	¥uÅi¶¡qÛ„mÚvÌvÎf¶ÍùÖˆ'C©Wº/
+$×‰ÍOäÑ¼—2s<‘Cœ°ZE	]*xê4ñ	¥Ø»R©4©Žˆ¬¦\Èeþü{=;:CDÈ0ú#½D"ÊEQlÛæ;Mü	ã%èt”x”ü.ò¥»¶ê8² _5|±0¢;áÛ/dÉQÙ–ŽMõ£6Õ‚=
+Gmêéí!Çõê!$Ô3à»ÔÏ¨ãÖúpçÏºÇp™,9=KNÏv,èá´Èn!ù’A¸pÍphMö“¹….r¹†RŒkh…Z´èÆ5´‰$U/¼¢[áP®íS/D—|JsëÆÍ ,µÞmÛu8¦y;Ú~`û¡íÌölo‹œÈY¹îœÙˆ¬7ŒÆÖÐ¢¸¼ u½*M/éÖ˜ ¬¼Ób–´Ïœ°ê‚Ó»ñåñÕ­œ™Û¶}'·ôº/¸4nÒ²4gÉX¶£‡lõ­žü¿=i F:Àì€áÃþ ?½#€—`p Î[¸óG²w``t¤ÆR®ÕµˆŸœ,ø(òÎ‹•
+Xá˜®gíýÛFž¥6]x“Úˆ—f¼.¼y\•ƒ}ão4 ‹Ü™Ñßû˜)Lå£€Î³v4=ŠA¸–ËUúýù†Žt¸wtkÃ@:ÜÛ×àJ‡ý‡ÏÇ²ép¡ÊØçc=éð&ÜÑ/mOöloßÀ§;õr:ÅS\¢wÇNøb9›`åX“™ëÝÔRýÂ(Ö,¢+-hhB›…’N¨¤;;ÒMÙxg¡MtÌvÐ0æÜÙˆÒSƒÓƒ45(Òƒ˜ãOx|ÅÁñ‘Ñ*½ë©(FðU´ï>¢nVs
+ÎŽ?k4ÝW‚Þ‰tø¯Bþ.š©¥…¯ÖT»ˆñâ6§=kŒÛ¢Aäp68k1þ$äÌ¡.ìà6¶6+>s/PéÉý-r¯0wcÈÿÔ~«™#³äZ+mdªÉ6è0þÿïw´×' `ÀÏù/ÊžÕan!p‰šjCÃû¤üGÛvÜåýÈçû·ŒúìBûe+ÝîuQ¿`
+$w”n io×¦•–²ÕÍµ—¶æ•–þ•u•V•(³¤y²ô;ûœ™}{nïïßÞu×Ê­;4¶übÌ5Œ>;Ñ¤—6[³+ýÄXˆÇ]Wã±=”ëXñîjÄãuÛÑµç¥‡åŸ[çÿË¿6Æ´Vþ•ˆü+Ó»Å˜dÄ;}1$M°ÅÓ<dµ¹ÇDŠð>bÄ×²´IìÙWj¾zêž¼ip¸
+‘“CäB!r‰PšØðibž§åjYÉçêYÉïÖ²’±DàŒ4¤ã2²…`µ–V;”þ©ù†U¯[âÎx+§æŒÜžæfcþ=Éð¹ÄŽÏ.¬‘:"ˆÑ0å/
+›k›}ÄÓH|y-¤O Å¸¾3ÎmÌùÂYÃûHˆÛG†|<ù|¥""G†È@ˆì‘%QðºIƒ‚#ÒéRñ/5é±iÒUÂ6=_©Q(—ÆK¥é’9oB:éOá­Ù;[:S¢gKh,”˜ïK‡†yŸN‡ã}|:ìè‹…Òá˜aÞ·$3=…pË† km#oÅœN‡à÷Å¹iÍ‚—l‚Ÿá_âM<˜÷t[(ž‰¤‡ÓãPíb*=žM3TZLÓd¢¥‹‰ôxÑ0ñ³¹‰/É
+Ãš
+ã"3+›Õ:ó“ôm’Á&¿•s
+´ZåmØÂ§¹ÑÎÄdb¶SˆXkäÿM|ÌÃk/B6Ôÿ7õï×|kË+ëÜz›`ê¼íV«X×³©›÷5Î]úAÿŽî»VîØQˆqïB·Ý}ðS+¡1_ófï>´í±Í*áL+†³Ì)Ì™N*Dç×ðfQ#‰ J·‰6kSMÀm°:ºMä0“?Á[Åeh`#É°\.†²-°ŽSáä P¡jòõØD‚!E Mo@×d
+ÛlFHš¨< G¬ó¨zðj£4åEë;áûzÁr:ô++ýF@›-};½÷¡-‡¿
+p½µd"¡è™zÎû‚Jë´…¯?d2ÉJÖÊ&^:ëaÓ¸iÂ4mš5±¦w ,YE·ÍØhÛj2HÁa”íŸMmíŸ¾j×“¶ð–'#¦-WïyrfágváçxAÕ®ùGJeZ)åaZßß
+¬ÙÄZhôbeÕv’ŽF:ll£ËéÑ¨R5ä³àžÌážÛ.j(Àà•×ê×(ÅŒWÄ°¾è“&9£˜:1¢õ#ºëúöNáNÇÒí¾[ä[‚üØè˜1÷È]å ^¼à¦¶njˆ{Q"IQ¢8Þ_åÞžÛÏ[W+°"#U¯%×î‡X–GªyŠiêÌ=7ÝúÒ¡—îüÈÝ?ÛZºéŠ™O]wÏ½Ì>ðÄ'ÞŸzìsÏŸnë©<z×ó+¿>öÃóŽcKüO+}ÌÓ˜“T™Þº†ÓëHæv«Ü˜àÉu+”Æ¤ÝDª»5’¸­O¶Ž‰$×V³15&••LV}Ú(Ø¦[1jJ8ÚGYŽØàŠÈu
+aêÅ2#È%"Â/IÏ\ŸÃ¢ºù’œ¤STë…÷¡¶
+@³$±HÖuá§#tí&R×­Z…XÈ¿Ó4jø¨ëHRHqà‡±ÂÓÀ\MÑµh5ãL-#T°¨¹,nw‹‡]¦ûsh]®²®?·;w£ëÆÜÍü®;rŸæãÞâÿd±Ö´÷Mú:ÔÌ3©´äÆðN¹¿ÁA^2F%£CÉ0µ–²)ÆÔ$¶#xšƒgRdGkKD˜èqaJxB`„·5š¸	š6©‰SQ)}FŸ9:Þ‰ÄÜ‚ZkµœN°àò¯ú‚‡8Ì(èÕ\âì|¢Øhk,$J\«†šíxÕfi×P‹µIû@A/e±ûâØv’ÓÉrŽ¦*÷›ãûV¿b”€Qµ)UF‚'“hó®Ñ$t›¬ƒ¨6ßwªÙÁ0Ùª¶h¤6öúì5?3ñí¾öT«¿Ü¿¢)I·WŒ…å*ZÛºïò«®ÑG
+Íq¦<ùò×íÿôÏ—9äuæWÞº¶-œH ŸµesýhAvZùöX×È•>õÏ¯”%ÈÅ[é3Q˜öCT–6¯¡}µ‘ˆÞF¯/‹¸pÍ;à [ŠäßÕæd$ä ÇAR0›ž¤ ˜Ÿ6œºÈ…XgXŠ%d6=*Y9‡Ag˜Ä*kÝ„Â"[d@$2@·Ð¬êTÃ;Då‰© ÉÉá<­ç§òßLË›
+j!ZÉtf‡D]Õ£C™ÍÙç°:ŽîÊìÉ¯W¯ÈÜ%T…FeïSÿ{ökÎ/«_9ú•Ì£ÙÇ}ßR¿üûì)ß÷ð¼’}'û^6£åoNÜœ:â~Øý°g!Ïmu£Þ‘sÉšO  ;Ã&¦¦¼V,’9ŽuT$â 2m¦"hÑãh
+=ÄÆÛ-¢wØK?ë}Éû{/ã%qUïú\=Cf.gÇ&‚VÍÄe°TYú•ê•ÌäxÊíû5*åÆ«„/¦¡¤åêþ(È=8Ù™…Ñìh`>ÄÎ…ùýœCŽU¹wæ÷Ëœ”®ò¾¹ýÒjîü¥.‡6ÃÕ_Ë–£ˆÍÐÁÔâFÉNæ&¹­o¥ÕÝòÈ»?³å¾Bž–Ç»J÷&÷U&Ž}ãæu×0O¼÷á‘Ö`"!ZË®ïúÃOßB	MÆ—›Ñ?`Äð½ïŸZh3"iôIL‰)ôÊÚÌ¸‘ÁlÄïJ8”#¨æ²XkáGêH<RÇÐv$>!ˆÝbÙ“‘ÈÈ>å»˜Heª“©c(y y(É$Sœlc°0\K~	ÛñÿŽ¾xi,—kÄç°²Ð|™ÅOJ±‹XêðŒ&‚8ž oè,™H$“¾ñõI–ÌØ*êè°™êl¥[:­;?eâôÚ“A¢Ä.¾?–Lj=áäJ°f\MD&ÊT—E²2ÅaËw‹t±M‘ÊP®x$ÑÐ”6­Ñ”&bKxA;£™µñô·Vçª¶ìäÙƒ“µB
+“Kc.Ãf-Skœë“‘b±8ç“Bf²²Uy÷S71)Ã5ª)!o{=§¸nMúWãJk]\7ßÑ±¹íôJÞ|Ám¿âò•ì¦E0Ûcj$) /óÄ‹/®Ï%Û7zÒ×®lHbˆ÷;qï±Ë‚†×sß…³ô/0Mµ˜n\CSÉ6BSm: H‘È"‘#ä¨|ÒãÉ¨³.Òœ Ì[a¿³…ã“Î¨IÊšÑf´ßŒÌ‰f„P†Sn£½aNh*W'TZÅlU9=6†qZ3nq3I½@F›.þ|Qü¹¡ÍW)¨5êLò¦Œ/,5™éLg\F‘úÍè&ó'Ì´9‘á6„Ñ¾ðÇÃt8!Y<át(ÊélkUy±Í’4Éd[kMkŸ6ÚÓI9‹xúôXE<MæÕfe¤-9%GKR“n-çRÖ²ìµíj|DübÜ,pBJH·M´Mµ±Î¶*Òô°þ©ý§ŽÓñÓ‰½ÿUîÓ±7âoå¬R%7–ûoù»sGÐú3å…šÌSÁÃù#Mv¨T 0rÏ7¼ãƒŒÏ#}!%ÈµÑ¾ûBÜ*eí©\_n¨mOÛíéÛs÷;=Ñö&óFÐ–æ[ÂÔ3tEP3)Ôš£žiª"Uweä°òL ¬FT$ªþä`§òŒv6HR<f·šœIÒ˜ÃèÇTSs¦…¢àCUïQ&
+x|ÍðÁÒ?“’ Yä÷Äxtë„;'œÓNÆYEíº’T•¦øÜL''’SIFK’tòi¤Q­H{²¿Î@P€˜|Ëy!ŠÆFËÍûÎ]@¸K~tâ<”ª$Ñ«³k
+`ä,`ë3n·zìvk½lÀ¨Q7`lò’Ê¸[«îÞ¤YìE*;jT8I¥#šèb¹ˆ+DlšRP—âRæ ª+°(aù{Ü»â»®÷R¦±Q4IŠŒèÊš¡g˜ëWíÓÞiu:0<Úðpl&oÃ>Ù&E£[›cÍñÏå‰?’3Á¯ë®”¦”-)¥Œt¡Lã%`¤hª$ª)”›ðPŽ,–²MK‡+cçeÒ(å¸‘è3L	u—s²Û¸–d\Ë)á[HøR9§IpÎ9ÝéÄ‡9ËŒhÇ÷±ÃÎé’ßÇŽÁ‹ì"Ë'œ]ú‡Œh£ÝNÓMªêkjá!c®roÌïÏpRwÖèÎz£ BMEú}þÕ²×PôÓÕVŸÒO®-~@OGo»fÓ-²ç¡Ÿ>sË¶ýQ¯ß½~ãÎëV~Ï?ò‰öÁ6—(Ù˜'VžÿÂ}ùÎTº©wï×ï>TÔûàç¯*o¼vº«¼óàWüNT˜ó\øºÛô}*@§Öf”†t	K¾	0ZmÄeóº‘ÙMºn¢"Ýõüw=êè†OÐ˜ÀnåsNŸÇ©¤b±Ž\>³Ø¼tº¦_­Ï#»(Õ¿‘FÖÞ5}ü-¾I|@j½£ ²$¡Ÿ	+²:È{ƒmñ r;0¾·5€ÌÄ¬1Ç’™èW³Ûp¥±äI‰fÅ?ïµÛ
+®q,‘|òÊò™±±qQ<=Vcbœ¢ìøzlå=hMWBG]G•g½ÏúªÊ›
+7B‡U4d²ï±í±ÿ—lfe¯œ”ŸWVTÁÊ8†o¡ö´L¦k+ÁCû^ò¾FÐÞ‡<ŸQÖ*zGÏiX-75‡fCtˆBÈd2Ç=Ãn4åFP8gÖ½à>ã~ÝÍºÇƒß9\7j–i¢cäÇ ¢4UY>JY\Â»Î"¬˜)‚z§`­L‚±r"€°lC&‚ûëäÉœIgvI—QÑÔs\×ÑFP_#d¶“BÑ}/¿Ü–Š^îJÆ¦64dþªãæ¼?múþÊ¿lZþ‡ÑËÓ©ë÷¶íÙK4ê»asã‡0ýÑÎ2ËÌ©=²†þ|Iâyåk¦„UKÕ¢/5L¦…kVôY#¶­©ä@U"‘©N˜RÝÞÆó$ICŠ×Ík‡œ`­šCfC9‡•ƒ\ðã`^óÕüjòŽ³ãzˆÛ¨Pújv-–ÛÉIò/X5«ìˆ'üøªÆ%­5/‘H›ÔT—T	ÌSâ[’x¾Q#4ª±F¦Q‚X*"Õs2 C¨T’’kc,x%/-¬H “+ƒ“’%”KHK‚þ™MšŠÖŽH—¶9²Y3«¼{¬ëèP8‘ŒñIÔÃ…ùš5â«h£î¨D«<x‡`¬Ö(™Èã fr¢	4ƒ^B&DÒ—$EKÒ°{ÚMOáÕ¬›1ê:ŠÉ³ñ‡.ÅŠðƒ$ËP1°^‚™”ƒƒ'_E‹J® SR¢+ †‚qo’Ÿ© öõ\œT¥8¹‚Õªò¶9laaô6K®™²S'W¹R´FÄx+Ybö:£¾HÒ±ò»ü­wm<˜vlF=£•ìÇúË»˜/.ÿb†LÔùÁÔ£N¡£=­”X~dj¸}€æ®ì EÅ´¼„iY£{‘–OX,”*±¤¿/^hæßŸ¤°Pÿ{¥k¦æ‹þÇY°x‹¥!ŠÏ³zˆkÝãf]Ä¶uI,MF°ÄÐHGƒë,f/þ7’R›_]É¼0Ý"mFäÝ
+£bv¥Ð†×yKÅ£Æ,BÔ¥IqYS4µËRº$(aÙ¥öñ[,„òFe‹zÿ5þ¨å¯Õ¯fþŽzœÌòuåëêãïñÇ-'„òIåiõ»…†_Èï
+ïÊï©ùj ™?ãEÒf[Œ6œ6ÚÞ^£M&63Z—‹´º®‹Î†»¨I4IO˜ïÒ>i¾Ïu¤ÁÒÅ…¢\<Ç.D©rŸË(L‡´Y¦Ý²'ì¦Z˜’WsËýzÎ¢*š¬(‹à±X„€ªÆ-<îñk6™xÝ†o«*V¹Š°ÂÛ# Qˆ3Â	áç‚Y¸Û bu¶ùŠsùÝåÊhðqO9¥¢¥–®í\k	š“¶eYÀ¦]={Bl@SÆ§‚ö„Ó]Œ‚¨VÄlêƒ\Q—å7Ìòyu	ÚIy‰ªÍ—@^?ðTÎ 55ÇÖ‘	a£bÆqAóÙ+XÈ½y·–¸’¥^ÇhI€ÔRÁ]æ5—ð‚‡÷ªn·¨”ÄªVÍåa(£è-¦7#Œñ;b†q»‰;
+êh®ÖÒ€Ò.ôD0™öþâe?om(¢lÑ®|7½rÊ—Š¸Z™/&µXa…¥í!‡ÅiM$L®ð¦÷Ç˜Û›EÑ9û…³æyÌW9cÖ@¯£a—ƒþ?Œ}	”W•è{U’J*mUZK[i©*íRiWK½H½·ÛÝîNÓn¯²Çû8iÇ8;Æ†$¶C„f˜dæÌ!ð		IâØCÿ?Ç6ðÉ'>þL`XÒ!Ì>3Kþï•Ô‹mÂÐêZÞ«õÝíÝûêÝ{“xhÔtaN«ŠJ~Yƒ¢V“eg‡xY
+ò²4F=÷2»Í«AÊšSW´í5Ö©@T¹ù]I˜·IPÒß…Q}ûîÉd*L§:zœ±¹QÃSù”‡µ½×ø{žµ(a8¼µ¢#‚ÌfVŠÒÛÓûu‡Ò¿”~ýwéß£|ÂsÖ¢rÞk!˜NÇv•|.—ß#0iö…“áJx½óIç“Ü“a­^*‹åÈ˜€“Ôí¨8™ŒNÆNQÇ™ãìÃÒ©è©Øñôg™Oá“¥óÌKÒKÑ¯§_“^‹þ@úAô;i?P«(]åÔITDÕÄŠÎAfVÏPsÜLìýiæ÷€ëá”t*|<í<©;á<&ºMðæV…¸¡T’hH!þaœ,Ï„  ±$Ì´‰7û]<ïGì÷<žÒuöÊÑz“Ä€–Òê(1µÅbQDR$£ÕÙ´ZÒŒ\v‘–l4-	¢˜á\6ŽsÅÂ‚‹sÒˆSi„‡óðmÄn<|ûy?4³¸Ä Ò‹P¿Ê0~  \	A‚Ø™; 	háçëæh½¬(FõËæÝ4²Ÿ=ó
+Ø°'†½î‘§]ð	|Ùõm×O||T”‘ ð¼0KAHïx Hç!ÂÀŽd¡NËÛÃ°>&ÂH9;£;‘µç@Ð"UŽ€(<}GºGÚº4ú¥COÇàqëž‰bõØWb¯Ä¾£b;RËÛ"žàr/6ßBfÚ­)€ªÜ¨æÞr#5/K‰BpÖÔgbõn)(H{±m.GÚÁéC´K‚C»º&ñþÁwV¯)FÛ£íi‡ë…öçÄ,Xª„q¸^lJa'+–(>­wycÃ›wŸsV$¼±+¥gíËy:2q%L,Tƒ¤Ò—ûÍ@#E•¤‚í		í°½ÖNT«5¢ÄäQäÌ’äé”¡@¶GüÂ/pG<3ÆÛ´ßù†-RÁ±Ö¥ØÏZ¿“Z?ôuõ ¤â½þdó·ðË'{œ&R’H'#ØìÍ…ï•VœpÎ¸ÿò¯‰5ÍIbMÞˆ%’ ò_DêRÕWi­†0ÍÂª@·“ñèVÊÊ]8î;Hñl[0É²xJYµ¿ÜàNú¤e˜†§§M§Ù“á“…ïë¿ïüaä‡y9¦%½h8Lß¦ÿyŽòVÓæÍ%Uº¦®15¶+\‹V
+™êý3ÅŽðkÂÑµ…zuÎ5'MWo£Žé1ÇØcŽcÎOS3³OrçÃ¼ImfÌ¬9égü¬?£cN¹J3ÕõºÍ¥éªª£ƒˆè½ïê‚]¸!·ËPN‡­iÜ>íóUÒéjeI Êr;®²"_i¯q›>F¼ìt8"…B‘Öy¤ØP”+\(òEÉrÚ!³-"ÅØaðuMó—¥yá˜@§(¸¤tº’Oýk,ÉO#ˆ-Â¢ZMI.Š‹’­X”ŽH$“7ØòyÂ>§38óÉ¥ï’ÃM
+TÑ‹…jR§XoöB¯áDNc„ %eqÏŸNðQU
+¦R<ï£Hé}aÞié,4=pA¾…)Ö]_qýÔõ®K…+p¿ï:O”@PpïsÅtÉ“çAæÏßÀiz‰Éçƒ×¤ÎÓL4·.þÛR’ŸFb©cÇÞíŒ¢7XiSÌ²NèÇ“¦£mVÅ;³TŽÊÜÛÌ[õ·Ð[*¹j¥È|èm´Gi™SÏIÓstao´ÚhQ-Ž¨u¸¡¹´Ã$ëWÒ=žÀ¥«8ñÈŠg„E[;6±u^¶f¬{˜‡kQoëV§©¦Æßš)­Jx¯ŠÕ´EÍønï~Õ\‘f¬\üïçÌØÝö§h“Ã‘Œè€Q©Á#2á ^XTÇâëp¬e¬<gioØ¶zâ1V -Îº¥Â0æ
+‹–dÝŽ4c¹âho,J")<ÞónÝj¯”´öJ4c«ÄÐÂj8' º™£«³h±WrxAOvâ§£_þ,[¹ÊmjåïÚQ xÕ,È4.¨ÒƒlÌõuú ‹Ô¿—LËJ,r>M/Å"¿J¨-•• .õ‰²¶3.µ¿òE®JÇTÆj–>
+zGÿÚ±P–²bvýÑ·fÇ*­é”ËZ?ñÉ¡Tªõ¿DOxó+OßÐ‹Äœ×Éå˜Ð¾}7¹í>$ä¸Ðá'[gïÊ’¢h39……-,!DQmóÝqåòÁ2â: ª^õÇAþV‘sKJô<Ó8ðø…hº)@h¿ÙiÆ“Ê±¥Œ„+6¯Y­x¨Ï^ùy]TFb~µz 8•3œÊì §2XãŒIxW£ÿ«Ø¾hç×Ê·Iè¿ÊCxeîò•AîYå0¼þ|¨@ŒËõÒÇä•¾(±ôÄÀ¥WKo•è}å‡~UúUù?Jï•©éˆìïOGBÒ>p"¤Žñºˆà<ÃûO1©Ôå$³æRW÷TÎ’Cuc·”öéŒd¢8•ÁH=E&à§utVV3fQõ¸ú5¡vøö 1PwŠáyé´DHF\ýgá–çƒ_jO:Ÿü·†’ÐºFŸyK™ú‡ãèã±àÃ=8ÒÛþÂŽqHê¶Yìè©Å“}µÞ¡I„{’õ ¨Å»Ê,á¸ò]fñ¼X(€M§º•`Ó)àˆFpÎú ˆj|z-**}`ÉÅ'¯|‹^šzÌ•q´‹%"lÏá»:…MÛmXñ^CÝvFô
+çá±CÁd±ÑêÚéµÑÚÔÝ?1è¼É@¼eGúž}v÷«GçLùC™JPòÆó»­nòSšfu¾†ˆ0Áï…?kXÍló©ƒŽõŠâä}ÄìÚ/Þ^Ù	¥…d»y¦8vÏr"*­!*ƒü¦Ó³0w›V_pÆ9˜ð0$‹3${ê¦‚&·ƒ€6@…‰Hx‰bÃËv{;£ÿÚ¦X·B±n7âCB9ƒPh…b	ÖØv Ð¬G;o(k\¢X£èPl'lÅ*’Å@Çd[ÐËÓ%â‰<T‚!­ñ¯=
+Çø@$Dœá©‚;Æû#kL&œ$Á¹ÃÑ¸3?#õ|êg`ÚÍ™B„e9"ý9]»Ÿqn7ºa)Oˆ¦yãi#a|Ôì*–þ%.Ñ¡âŽÞ³¸hYòsp®¦B.³Ø²¹LNÎá¤Êi[Þr–”w™‘îŠgžÆã;´=u–zç…ƒv 3ÚC„X`4š O^å¥¾Lˆ+”ˆGpÊ«(®ÈçœååÄÁ%å4»ü±Pc·“ºÖn~x´¥‹VFž}–š=³yÏÎ‡£öÊ`«2 Ø¸€”>R9%Æ@Ž5Ÿ98F$WˆØ8ñ?¾~x|ü½‘ÍeŠ"´Ò¥­Ä+0.}ÑÆwÅ_ÙŒu?Å×Œ|8Úyë–†mlŠG‚]Y;lv¥Öj9­”çìx%«ÆWû&ü¿k}8çUŽW@Î'Ø|íÇ™¶‡ÂópPñvrår…CÜ3Ü»à¦9¢ŽV;¸G8×ñ¸â:W\ÇãJ¹Jr¹+>ã‚=bì·ñö!#å ”âµ`„¢â®àÂÞTŠ»Â#†wöY Ï9;Þ
+xbÙbO'ç³¥rµv Âž3ê¿vXXöb¹Ç}­‡ùÌò‹‚à—ªíð›ê
+Ðƒ%–€ùª$oÖ¹Æßöã6U/¹±â¹óÐë7áá <Œ!_›ŠÎ¥êõTª^SWð/ãWÎA	~~€{ä‹ ’Ï#àì³j(c‘ç²‹Aø…–¾¥§;×¨=ÿõ5jÏ>®¾qåÞïšŸ­<´ÎÁ‘•k´Â5ZðûsÚU×0Â5øÍ9¦}ö€Íª-ªu€f$oý dP50
+¦À°ìóàp¼V¿ißÁéÙÙ­ïüPWÏ¡#ÑäŽ]âÄ˜A;TW-úybOR“=äFo!ccÎ»nüöÃ‡wîøðÝ¥Ü-,Ž™9BSí›C¿Ð¶Í¼{óÝ6o>p7¹'D›âét8´Èo^¬È¿£ÄùI¿ƒ½+h—¹ˆwW/ÊyPno™Kíó¯9ùºólBY*¹HgkílíÒqêšòµÛkSŽ«ËÒ5÷_zùz¦PÈ|
+¯~ŸÏæ³"Þk•sèïËùl6OÌàuÓ+ˆ{—Ïm>)är"Ì
+Yø-|°µ¯ÏþÞ#C«*µÞÈç³?Aø´3‡ïvZÁ—sr±9†ö>Éˆ@ç¤…v~/ûA!SH£DIØ7ñÃHúÁÍ
+½|Ý7ÄS@}$Öèë~š-èY•Ù¢Ý´ãLi·kçµW´*­Œ„–u‹?µ/$Àöm®6ù;7Vâ¾ª×«ü”ŠU\ãTm×¸NÄÎå¸ ðœ+)1Ú“‘?¼nÛß÷æ†2!ÎgOe½6½ÎWÄIÂþ­»NÛ=ÅPÞ¨‹%oH>‚½ßª?€UY¬Y\y‹|œü°"z?R_·1_“àkA¸1 7x÷z‰oyà·œpƒc¯ƒxÀï¶ÀSx—žÔÂÛµð$o# úFf„º0-‚sm7Ï›	3Oëmà,ù¨]¬!Úl\T"V!ªk\ós82¾‰Bi¢Xè#œ!*ã8Ú8‰vš€¿½ñ¯oíë:øÄ¾î[s×_nžŸŒùGç×MÌ	ÉÉýäo¦<`×ß?ºiúÁ¯Ï}å£ƒ7—÷ÿùcÞ¶fàÖ?ß°å“û*¨Ý· Æ ¿< û‚Ûl3@ÍY¸¦NlasCç,¹xÆ`öiPk. ôÎÍ7_eÞ|1Š¿“Ü‹sô^,z1¡Hˆõ§8Ü'´´ÑZŠs&kQòû¢1<Zi~­RóªEQè-7f«¼NÄÐ@BèƒÚI°£äA…Õ¤Jþ'•a!ËºÓå
+¸3Xq9Î‘y$ß©ëH bT„* šw_µ‹ÍÜ…F®Ö¼”Ã°ÍËJRKe1'_Ìc»9›‘rÈŠ¢‚Å>²ÜGb@b•5Ò§ÎwàMÙ‰­£ÇÓ¡-Í¸|Ë-»¥d%hvOË³·'ü”3\Z{cmúÐh°rç¹œ.‰Ë¡Ø;·Š‰ñzÙ\×-l×³]}µ| 4»+=p×}µ[uå
+ÈµæÉ"jW~Ò:‰j\ùy§zêŒ<ï TÞ‹Ê¯+e«—§^ö 2lWv \“D0ú’z¡v¥¼]qƒr…ã=\îä?GÇ=ÊñŽg<*O LÑ1 Ô»Ô‚u`7øD½zSüÁ8³u×ø‘qb|<.ÙxÐÍ3ŸFDªöpb#¯îÍ&¶ŠÕBOoµê‰gz¹­š¬,`×ÊÑãSsÒÐ¸ijŠ¶Hèµæ…œœgó2ÒkÍ………ÚÞ@yáÇ¯2Í…¨âGØýýUe$#‘ÓÀ
+ðjrWTDYvåkó*ê
+^UÂöGŸJÁ›½T‡ÒªöUAÌ.eFuOj}=b´»ö€×cvwù2%·ú©§œé±\³™ì³­Ýf¡;Ù
+&zÃ–{ï5»6Ü3“Û2³VÖnk½à
+‡‚bÒ[ìóëà_Z£ÁP?È%zE‹Ï®7p‚S
+%ÇÙ/¬iþÅè¤¨‘$}dm?±·ù=ã1³$¢kkÄÞ5òÍwM¤‘r@åëÍúíEBÎôÔ¾Ê©-ÁB"b×Á6n4GÕ#ÌÜ>_ºcäãûáþ›n©ÕÖÄbroÑ#9m€µ:å)fd8"ÈsZ7úAqnzã¦¹¹‘bfSÀsD3=Ù×,­‹öÒ7KÛ¶;nÚ³GÛÆÒâE„%Mmô(xÊ_‹(ÔG6LóB^FØZÀuÊÀFÙÅUÓ(øJ“ò8,²=¨¤<Ehr.‹„Žñˆ0×6ß“Æ¤³TZ…ÈB©l"TßÞ7"¤ü—Wò›}ÁˆË]L‰´ÉUFÙ„Þ_Ec¢4m#}?Ñj%ºeÄ¼ß|5zcÇnÎoLR]çZg®Â­Ç­µ;ÔG*5—R9ä¤·ÓŽpÆ#|xKIE6»«C¢J’Né…ÿ|Ä¬¥šOÎ¤Ž™ôL?1{Æ·}åäÖH_|ÛÆÅdo|¤¢Eò
+i^×'Z@OÔ³ëÖmµÎºb±Ù¾¾¡‰a‹(ÎŠbžC™!8;4;´ëÈ¶=»¶®Ä½»¶mYÛ×½£Ö¿µw‚öI·Ü’ŽY¨J‹yƒ”»f‡3{-¢´‘[[Ìç‘²“»åsâ…6b\3ò‹¹eL#,cÃOFxnOïíà™W¸¸‚!Äi}¤‚¹´#¹ÚFðU…?À·êmÀí6ŸÏïÈ•=êyƒdáb‚ %<mÔÐf«×³nn½ ‰+Îól¸'Ñ
+F{"ÖÖ>ƒ8Pj
+’ñjD›ÅîwLbT“Ÿ„­Åi$=úÊö£ÃÓ0hÐ®à¤kãp©"%í¤ÉçYóÞ\ßšF3¤ÃãýÄþægjã=.3£×a¹|äàöÑÂ³’o·5B>…øw3Ø[Ïž˜‚{§î˜"ŽÛ¡]ï;=Çúû¡èó¶&„Y±*•B!S³š	i¨ÄSø;A‚v^b4fÔƒ-â~­1K^%:q'Ö`ôÄÊ²¢VtþŽür¼†ÛVøk‰cÛ–R¡|ª¸ý¾éôPÊarð™!w6è9ZO>Ñú•Ö':LuòdÏá¿ÝSß7A,éãE·¯/ï.¤EÚ{¹Jµh'Ÿ¾¼ç¶/°bñ	KÀi$..ÁVöo"žÚ¸;gl>Ÿ¨„–XgÍ}_ÿP·Xî÷
+)+-Å£˜í†Î–T­Ár±5¢~Áõ6ð1ðx}Z&Döä]é4«Óq÷±Ç÷Á}Ûî…½¥Ò¬x(s²‡ØCÁ‡8Ë½bÐ#ˆÁ 2˜ïÓ¸tÓ&óÉôí·W²G¥XlPÊM)œÝ:¤6,´^‘E:bø/,äÿ€Ld–±€gÇ*Œ’Ç‡1£üÉ".ÿ~²¡"ÿÇ¯‘äÓ’¼;ú~´ëª–ì‰âöûò“+È—CN¡ƒüüõ¢’ÿåßûHT„Û?J"pîz¹I  GþHHn^¨AæcÄíâ¢&í6í-Z²¥…¿ÖÂI-Œk«ZÂ£…:-üG-<«…œ–ÖŠQÎr&MG%)ìñú¢>‘*P…v2jÊ¦VSfÔu5!ª¡ZG$wÔãÑr,mRCŸÈK‡2ÞŽzËVnAù!¨`.uÉyu—yù$“8ytÞÊœ4-¨ñ jD!Ëõí¼§·Þz¸}˜ÅÇ³™<ÖEaòäµÂ‘HPÉ2€)ˆ’´-MzàÚÂ‘˜³µ—ð³©Üz¢¨ÓÚy^sŸ!©“¾ËÏ¥ó.¤c“´ÝÂÆùcÇœAÆæ1S"<âÈV‘o ²Ì€/œš„îûy2‡ìú™«‹ãeôÓÌöÏˆdxÜ©Œ435Õ70,A>I÷÷IÞ„ì<)‡œj1‡= Þ\@ÌÐfåƒ4RùU¦A0Ç«ÚZ6¯V¶&R ñ­>ÒÅUJ)‡cÉÆÁEG¥î×è‚}%ø¹íÛÑÔç†F¬L¶Ü•ôâqÚÓ5¶}à°¹ê£"™BÒëI”Ši±9×F«³e7[ù³Mž¬YtÉq"’JÚŸÜÓS¶vO¤*iâÂÅÑ´<šõ©ÍVƒš°*BÏ%ú3ÙQÙkV‘äå¿Ñh¤ê˜`ŸX[&,ë×\yKE :¬Cua£ËÖQ+±W†}µð0ˆÈþå@ÈýÌYQûT&~ˆ~N½”­Õæ*°’Eäô¼SŠàXËµ<¢/86•D”Ø.Ì+
+õEœQÒäRGlãUx"§I½"/NDFŠ!'Rf‡ßîé×Ýœ*ãÓS¡ê‡ªœàuš­WlÜ=¹ë¥‡×Ï<x~ÿäîÇ[hµŠeÍ*xÌO&žÏÔnÿÂþíï›£y{$štÙ˜êðHU¿ÿÜü­ß<=4ÓŠP™^Ì¥nÄ¥[mù@ì¬{LÁj
+V’$‰jžÐÃQ-!á0²Ž1\üL<$þD\;J>¶ :xAby3]%/V”ß\h'é\±–—ÌLG«MP¨@AÕ&"t˜°>ö£GF˜øh©÷Î»î©µ¶%»üF(…a•²Ó;ÛØ¶V¼í‰mæhT¢É7¦îýR#¼sßî8bm•h
+äÃÄ]©®€^¸|I©Is¸¶ãþû>¤’$DTQD<µµ» ÖKaI4›-,+â(ÆŠbª”¦tœ˜-¢…ã¥°š¡––8NåÃ´VÊ/7V	bÝ¦„A@¹¹ÀtÚŽˆ!‡)"‡µ:Ôé8I í£<’gÛ¥Rh€Z2G‹êÌàdè»ÿP­ûTX³Ñ*/’öTl&7;Úã»›ºj/åÎ'È7~1´&¤iÝíIvùZ‰•˜£õ"ŸðŒ‰é¡+¢_®¸‰àZµK”AÔúØ\˜L,Ã¤@ ¢?IN$^ë%0J'9'ÃSR‚Oá_€çÛ‹í¦®4øÂR‹/æ”æ¢¶®4µ¼º©W=ÉÁˆÊ)µ>­Dì*Q$Lá¡òÃoo©ìª(_¯’b13œ²·ŽkùÞbëÑDÄ´.#»Ð-ŠŽÔ ê–£ƒ·ÐáöÏ®âöª»Ò°‡#&¸ÄLð‰¢§ÎAŽë×cª¶`n÷ð<ðz-Ìí
+«¿à´H"fv$*kù6·Ë—”…Ù/)Æ–ÂìÚV³:j4Ûžêb"ívE	¿ŽåUnÁÞ·áÈøîOnKIµ™M[¢b_!Î «å,X7~óð‰7»aâß½¿4Ÿ·rŒ^kq5„D|©xÓDzöÄ“³3÷î^#;¬UUÃ½‚ž!Ø“ýLùžÙ¹ûŸÙj³ëôÂlçtXrˆÛqOÒŽÔ»5‡èÓÙÌ"ðù’½¹H²(vóbHfÞÏËüšœ×Ô:;ßæÕ</s:O-¼(:mÞ!am¬=v€u2˜[1=¼¹ÄÍÎQD±óëÇ¡‚öë)ÃÞ¶_5|o	þ´Ø ¡Þ\+à)&=-¨UZ®rÍOQ|­þK©Ðöw"i· X#ùæÿ)ÇXQÔx»‹ÐßŒÈˆXÜò@Œ0)	‚#=œþ†J­T< Z7xÌvçžcŒ8°ÄâÁƒ•±4Ü_þµ$xý›*í‹­ªÜåÓ©<•"|µXñ¨t¾.Y´Çû¢Ä` Gö	¸?4_ŽöÅíøÙÞ+o;Ð³e¯ìþÐˆ©Hñ2zönwèƒ»›œ¬<ýRóó&ñn?Ï¦Ñ`9z•î¹Jù,‰…Š[¥Òë­•5‚³’ô6Ÿ•å,f-ëÑÙ9šÐkEø=òŸ[Oú{=™Ñgp'x3êth‹Û,˜¼r_ˆ´Ù E~½që¬•µXÜbÀî©Ew ðAôÚ_µè%;oE@[l^PÞ»¹$.æ—_~Yæ‘W’Ðõ42ðþ'W›Ä—/a0* ý'òŒ=1$7?éÚtTtn]ë‘—»}Ä`°Wöž8sö¢·ËÿVß·ÙO@x’kn)¤Yhfý,Árf•Nt—(dÃ‰ €ìAF ïßx|78fž)®A¢’ ¾H0	"¶˜žuCÈÒ>¯7Ë¹\ª,O´{ÄHÒã_máõÜsY±ÚÍ\[:ä.5(äóˆ%˜ìv‰Žd3:â°„ Ñïz	7#ÕS‚c¥¥öövµz²E—JÕz.ØzNÅDê™ÖÉr·GMº{*äÍ$ñºàÍG›ÿÌyE1X^#6\>Oz›_*Ôƒ(úÒeA÷l¬xøYüFð‹€¿ªß¨3g>à=àA@l0ÊBÀZXÔ#öCÈÀ Ì@BK,â	ft™-Pká<¼‹½¿{ÆEÓ¯âlðÄ³ÀŠZÂ<Ð)€{}QQi¢µ×Ñ.VI¡¼­q¡Ñ¼¤Òèà¥“…¼ÑàšØxƒW±ž ¯’ÃE(Ÿ5†jY8(…íB³¬õ[§*=^U0‹¹p*p±-	´¾rúò÷Iªù]<º€:‡ìh’Ø+Ä” ”l€o©Ê¨O±#Mq¾.—Ó£ib,
++QØeÏ¨‡ØhÝg%6[Xˆ9ãœØo7El&{ˆŒPÂn~EÔˆbÞj_>É¬OHjÅLQÂœ,^£.5Öå ÅÊT•ÛKGû6©ÖŒßö–Cçî_{ÿÙ›s‡í’¿I²ÒÐÉÉÃKªmÑ¡=c7']:ØÜ÷ÕSë¦úÚ¡ƒ/?8mÏÞpÇßn±­ß?¿¥»{Ëü¾Y[hÇÞÝÓ¹øXcïþ¶ýF~Q‚ˆ¬Œµ/
+5C`ä€LÈ²¯b7K¢Oà|R\2;Ç;èrAV©€Í…¶™Ñ12.,©‚°cR(¹±ÖÊöëÁek¾äœÝ¹ç…Þm‡‹µ0ÜÓl†údªÂ9­?œ°%Öä}‘Þñ4j#ß ÍBmçèØÞ~Þ¬o½'õÄìxž”¯V%ÆÓý1«ÐJ¨h­&Ø=“­­ÏÙ)
+ã7Òº¬
+ üA/øU}b´
+ÇŠpMHÜ vGn‹#XŒÀa?,ûáŽú`É1ç J8ÇîaogÉ"+ÆMÆýÆ»ŒªªnÒÀSR4lùåÌG¼ðƒ^¸Ó§½°ß3^¨ñ:¼a/yšDJÉ$á%½dèo2Ïf&È<’!3™Z_kûŸ¡á_Ópž>FŸ¦Iº,¡néc’—Ôy€óåÚÁÔÒ¶B:£Á?<rýç*¬¯„ÅHZ]\iB	Å“Nx‰©O·Î=¼õØlÚ¡ž8qöæ[ÏÝ·fÃ˜[ÎäøÒŽÍsÉËÿØ!¸?SÎ^"¸Öeâž£övÏïœ`½|jò†‡Î¸óÕaNðØuýÓi»ŠøöûÓÒQU¼"É‡Á'ê¶ªð
+L %¦¶T*ó"†Ü›Í¦>š‚·§àŽìOÁT®·×–3RyÑ¶|QŠ&`B¡qx@ró^DŸu:•å3Œmí…y[±XX,š++#hZ°„n°Xý³TÚÃÊë Ôh:|ÚÒî†…«(DÌN;t8J¥Uß®HoëÓ&+k5ð‰¬µË×‚z:X+À§“7ÌHÑ¢'Y*É&ñDÆ×°Ä3EŸðš|¥IÙ[bàkXOoý®ÒçS‹¢-9”!"òpÒ.¨Ì~okwz¤ r&Uë›ÞoÓˆð=dº™LæD¾ìJN”ý”bO"­ãuDñà^dŽµˆTØ+Ú\a
+Q(ô­‹J‘ˆ×Íö}¼ˆƒb;˜D@œ Ýˆ¥îcá»“=Ì’vu­òàG¢p:
+ƒQ¢L”ˆF+òƒØ¨ÀîÊÚ
+QñPÒàÄÄØ &aYò„ÃÖ°1x—tlî¶ÐÇÛU¥’HÝ¾¨”•O„•¹XP‡—>AáAlž\ú0¥˜’8E¹zI¦ k|‰à§Hâ"Ž[ã¡\ˆú·VäÍÃqaâö™p—l³¸X½JÌ¹jw^R‹Ã…€¿2SÈÝ¸.#ïŠöeÂ¬“Ó‡‰§[ò‰˜]H»"õj5è©Omÿÿí=Tcg™ÿ½7	!ï„@€ð !Cx30„$@fB IfZÇ1¤N†R[k[m­]Wmë£u×G]Ïzz¬Öv­®ÚîXuíÃcÝí9«vuÏîjÛõU[Ÿ…î÷ÿ÷æ3kÏqWwÓ¯¹ùîÿøÞÿ÷?r¹3æ\Žé:¥V_Å„|§·h¸ûX§íðØh³eâØ©ñ¾S3]½¦¾üÑ¹önˆõftzr¬ÙúAsåvÂ¶°Í–^k©CÌ»Yf“}3Ëb½,«c1Ë²Zy›®NCößÆ$o’ïî¹ï
+‹ÕGw}šØí±>ø]Ú€î[iP3qï×´Ê¬®1ÛmJ<Ú»×ã³Êoñxz®MÍ=õìÐT›jw¸ýHOC[[CÏ‘vökuÝG:Ÿéå0?^Ò øäÀŽ“9á\w²7ë™›tÌ[UÌõ
+fx¸±ÉÜÞ>F×‡ûÜ}\_Ÿa¬·ÕÌõÌ°u¤äþŒ&C2Ò}YëŠs¿ð]Üd‰%aåk?¸6^ä7Z.¹jt²Yf0µ¼.±âøÖ
+²Úýáà,gµxì2Ÿ-4s¤ÖP§„L:êæžj5ò9ö®Ûé™qh>÷ ó	ayPëÚ[RMFÚÕf'6Y˜»ñ`G]3)@	]¿erzÈÌÈÌuf»™3É‡ä0Hdry›Ùb4ËfKK‹ÅbnÔëåŠúFy£Â]ßh¬‡¹˜•––z£ŒQè­5âŠ²pnyìAÎ• ÿèÐC7J¯Ö‰G•´P®ë¦%}õ‚•˜Z;}¹¦†$»hòW^t]t§Ë¥Qî}C¡‘KºíŒÎÖko­ÝûAûÞµímdYÔÊÔ4;L»÷³ú&Gs½²¡¾µÕ:¶8¸kä¦=Ãf	Ù4¾üï2X^¢	ôÄäõW¨™®.\ScmSéõHåtö¹ñÝC÷±¡!fdˆ<6ÈÊ™LNÁÈŒbpˆ¾»ÿþ~ö}ýÌ•ýL°Ÿîg’žÏMnÌÃœmfš=ýJ)~fÈ[LXVááI„ªÛ†'&†ÍJ‰±P9ÞÓ¥‡Éªs¥­A²I_oá§Q]jÓÿÊP±m)™_ÔzääNŒ,’VsB
+¡[zbÎ‚E?¤·Ô©Uªÿü’£±«½ÍÈ\£4×ëäjìé¯s°ôÕ›±†éƒtîlØ{Ò¾÷»½çÛ÷¾\ooïh csª:ƒ±ÕºûEæ¡åÉi,mmeuµÊf›M³ûf·ª©Å¦©³è«ÙÖV©¾knò¥]vc÷V®kÌ×RE<Ñ³¤<1ÇÈ'ßçp¸'&úM&¤™ÖøÝ³}Ö~÷,¶öÛžfk¿5 Öø5*ß¦àû·úßÚÏÅÀö¦JÝÖ~£ÕÚßÐ`µÂJ1sÈ=ëV¶Ø¶›ÜÌÝÄu[
+fUÁ¸6EÛ¬Û8;ë†Ômcl6ÿüÜÜì¬rÒígüþÉþq›ÝÝiuL(fCÖF£1YëÏf‚Á‰<òáÎÛÅ£²â±;qÍšsçèE/Äº¾¼^[ªÖjµzØQÐ“{êC¦è2ÓPÉedTÕ	¹tf9¤¶ø³çÐG½ù¢Ñn­‘h,ëïP×ª«4u
+æhãøìbßU»fFÜõ{ƒU--ººÝ¬0Õ¨õõÕ{¯ôÅï<gêówWYeQ®orÙïz¤¦ÉdTjJ	ÓÚjôœÜ³÷µ™°½š%çýäï®ñORa›M§5($äAÖêŽÈ±fº[C¶Ö—_Î&¤7°võuˆlGÿå³sÈ8YÍ öfyí$‹ÄŸ"HjÝäéjöÃì¸ô½ÈûÏd½£–éÐ>¥e;äŒêZ»ÝS-Ì/ôµì'>Ý-•¢#½tê1aÏ!l9Ä½YKÈôY¶× S©Ä4=m7OLŒ8-®ÑÃCÆÎ•Å‘w0r]s¯­¥Ç¢«bª›z¬Ýƒ‚“´ðy²Sß>KOËÅFlû¥·¦“¡ð¤£Ë;U÷oó><ÎBï°÷0ORÉaÉ[g2)´rÄ^«5ÕÔ1U
+$gä ó½ˆüÒ©ï#?3½»}êïë%
+žý«0úP{3Û®n°7î}º¹³¾Zn‚¤j”¾w÷FK‹–kn–êq#sŸ«_YÝÜì=ìQàÞ.›4TIe²Ök5š†ž®êjØà7€½ü÷Y»däŸLóO.¯fFªƒÕ'«9e5Sª˜*"›•ÊFö±IúH:azéâïÀDÌÂ	oa)H&]á·xºX¬eÞép5é½S{Š7Ý3·ô›ìƒö:Y¯Ì4pé¬÷ÔX“¬Þµ°³È)¤ê:Ýmæø;Ó‹vÇp«®¡µCmšñ¹cþ&cÏi# !óÒÄƒ	ôG—N:šÆ¯•¶\;<.–Žsº#ÝÝZÝø83Þ„tZ py±?Èœ@
+Æo-hôcÇÄß8ôžÇ`æ!cUx0Sü¹¨¦LŽ‚:U¥5}ð¯ô\ëƒdejsÕ·¸šk«rKÿÂáö™áÖµÁQ³´c.>4Õ¡k3Ö;»œfw[]·±KÒ+5µÙ›ºÍƒ¹Y£7{Úk£íá°qlÌ-w_:Ý¥2Ö+Muú}mû¡¦CS=â¨þÐ¿£cè’Év-ÓÓ3í040hD:=Ý:7ÀH¥Lë²ö)Œ…Y+q§‚º“¨NŸ?¥Oú¢˜MÈ‘7y4T/-&éoåJ«aÉO¦1ÕÐwÅ@Bzª±ßin9õxb¶VÏp9¿¶O-ê¿tÊ®m›¸µ¹³®ÚÜÑ¥»JkSÎ6`˜•›z$­z{ïh›íÈ!K“kÔŠ6•Å38jëšñ4Yû¦`uæ8]ÛÑÖªw¸êe#=íSxGÞØÑßÚ0èl÷¨›;úZÈg¦—_dÇÙg¸*Í1„v£¨ú3ª5ØÀ ©ÝAó$­ÑÚªO#9l—h1ìQZ7w^ÝP5Ñºp¡Î®,«³Ðº(­SÞ»d+e9@"v¡ªßJ¯FKhkòð%—¨—Æç[šgÚ–¬K}]mãK Æ“s“Q-³i—ôiUak¿zA1ãs¶´W™ke­VŒ­,ì)zÉŽÞ—ž¡yœœDÒ'É¯5»ë=ºÝ¾â³R0F‰ÃZËþ¹=ò¬*ùCYUkMËG?8Tzá®ðû/]p–ŒÞf*{šäÓX"ü”¹}¡w÷!÷ñ¶ºœêê?Ze×I?ìÊx½Â?¶#Õ6uá½‰ZÜÝ¤“r:­ßí*–¦™½Ñ	[­R%9â™î6þî…«›»ÚÛû›s•¦æÌ)fâÐnn§µuñÔ‘¿ÝûÂñU¦ª­MQc©!ÿÏû{Ü®ÆÆù½¦7ÔštÚ¶¶¥¹é8B0¸Ÿ¿ ÜÎ|“• ÜÃõHœÒþÈ¢ /y5À¿U¾úóŠ*­º“€úˆæíÚ‡µë¾«@ÿ@Í¢±®¶·îºAý_5|ÛÜØô>ëG0c{s[oûìß¶»ã‰®ygSÏ²ëûîöCóžGTƒÙaëèÚáïüß€	×þÕÂdg^_
+T ¯®ø£À-¨ÀŸ |rò‘ÉïW ¨@*P
+T ¨@^xŸ+ÁT´RpY*P2xÂgð]ç»¹·Üéû¨ï“¾ûŠð€sþ[o›ÎÎXgÛf¿\þêhîèóÇNûIh'ôÀœàôÜËá›æ%ó;þ…ç/y0Ò¹=jˆ>ûêÿ|ïÿ/,Ž.î,þÇq¾/qI²dXÂK®"LPx¾¨@*P
+Tà÷Bh”ý""oÓ /Wk¤/$8ƒ¬ôŽ£ï\Ó°‹8‡N°ïqIY)ªg$â2dã
+tªÐÙb9rsn¯F7Hý"®ÖH¤ÿXxw!£®y\Ä¤5~GÄYTUÛ+ârÖÖ‰¸¤¬©j§D\†ôµa¯BcÅ6rT_óO"^|µ§E\]ÅÖ~(3x©š>Jq)àº¦û(.£åç(^EË¿Iq9Å¿OñjÔÆÙD\°¡€6pÁ†.)k#ØPÀ
+¸`Cl(à‚\­16ýŒâŠ2ù•D¶n	ÅUeå‚w)N^ï¡én£xà†î>ŠËÚ×R¼®¬¼öd0S^MKY›æ2¼¶P¼‹âo xÅÓ——É//ã¥*+WtùÂ¨¹é£ZG<|Ï¡JÃ'vÐ&-ñÁ]prCy’¶pA¥ 0Š@ÙôÏ£½ãá›‡Ögáš -Õ ³p·¥<Ú†’yJ=||B@}hot3@3‰V _|ê²E>¸(½y ³ï†“Ê
+›Ðß8ð!4VÐ±íQ¸[‡RR»2æŠ:;$©©W”g•Ú£)¸_†R§–Ø¯£@'#jŠ)—-¨]¡ú’»U ½}³´dZ%¨å0”ü™ˆu’´_šÚvŒöçim Obé½bQ¢B[LËsPBì·Yô`IRŸ)’Ð3Vˆ¶Aû`ú¦ÈmjÑ”Åi?A¯8•’ÄD‚Ê@´8Cõ]}Mñt°åèï•ƒDÚX-Eycä Iªg¦hÝNtœZ4WÔzx¹Ñ`uv‰òŠ¥ØÿðQÐOe”ü¹Œâ­óc¡ä)?†mhŸ›_®$E½zà¥ôÒ@‡^Bde©=Uâ¡ã´}^” Dm 2kB#à×¾D=Ñ{äØ¤Z
+ú®Rªyê¿“ÔÆ˜Æûµ©`ƒ|Ñ¯…Ö˜rÇ”>O£›§’%h»MÑÿNšÒ”Ï&ÕAè»"R)H§´7©÷6 UžÖ‘^ËTŽ‚?ú&/ö"%{^ÉjQgñ¾ç[g“Þ' ±®SŒ2¾Î"Ÿƒ$iLlS;­Ð‘s!›m‹š&é˜JÑÑSémŸ¡°CóWòUy¬^˜º ÃkµmùH(Äf–Æ~žzn¥ûÒ Àý|¹ÆÊb€h"è’§ü
+¹1KGÏòÆø4ÍñWÔTˆ½ø¾¨F~F¼
+Z	8ÉA›b&"Òž-Ž6iIòÝÅbTÈÚiÑ3%ê…’­œ¥¹‘d¶¤hg]åf	¢CŠjWÊ û£ÚI=§xBŒƒó3ÚÁ‘à ™è9Šzxš‘	34oñÔ«q(#Zƒ…º^‘æéY²S½¥l‘+Z¬ Í2½Ê¼›Ðh`K1š/‡2ÁO…¨áéœ™ç‹Rt_l.+Då+ÏgÄsÅ‘“+[-þ¢€y­ÑXN‹~wR³â<#ä’âÔþ‚Ÿq,ÄÕ¦¸"8d€ª0¯¤‹‘G¥ùü`>û#ø¢h¡8ÕØ-)æú„8VW€ú†8FJkLg´”3Ž‚Œ¯ì[Df½}3:x»³ÌF	:Ë¤öå™óu¼=š}“´_¡õ…³›ó@v+Øþ`ï]'&è]«´Ú*šÒLTð¡“æûå²Z¼çË"„ä-ÁC9 Vša©—©,¼8Sm}YžKöŠÏÑQ’*ÊP×ûcéÕ[µ|†´,ŸiöÇtÉÛÔŽ¯Ñ…Ù€¬Ó¢eø2	ôJx–ìr9´X)›;òÉÇBæOP
+3Þè¾,Ššq.¼¾Ö~…Y¦dŸÂLV²QyNÙß+Gs…à«eQïÏ¹ñWðh¶¨}N\QæéøMQ	H}ùŒþZ# 0¿Í¢ ­GÓp·DßKJ‚P†!‹F æ8Üù¡Ô%Ð"*ÖwPO-ÑyhÚ-Ò9N kîOÒ70½'wÇ }h‘¾t‚ò µ(m¡´ç 4ß±éáƒ’E¸'øÍ‚¿0ôvAqN$A9.j¸_ª åXlî"@V¬õí ¥Gä'ü§).Ê9-Jê¥6"”	MH¢w¤t¾ ]”ò÷RiÃT‡i¨t	P	g—¨«ÐŽØç¸XC|Dä”´òRÌRiJöóÁ÷HNèÏ@mŒÎóÐÓO5RëD›mCô®¤•à)Õ†X•ØÀø|fŠ¶‹Ð« K¤ŒÚ~Û-ÑúR+A?¯xõQËÍÓ;Á>z£¾"µNÑ—ªÇA®K4´•—j-FÈ4^AúBt
+<æË$øß–ËRˆj|‘1"P)Ô/Šž>ß.Äê^j"W´Èù•(»>A^ãÆ±uÏeÒ™üÎ&}™ìf&Ï'3iö¦R8’\[Ïçp„ÏñÙ³|Â…ÕêY~9ËoãùM>#}BñÌV§2kÉ¼’ÙÜÉ’>˜w{°|9q$žÚ\Ç³ñôJfå”Í¬§ñìV"G8ÅÖ“9œ*§³šÉâ©är*¹Oa‘#´É SœËleWxøZÍoÇ³<ÞJ'ø,Î=‚1J®ðé?†s<ùe>‘à8%”âŸ[É&7‰‚”G‚ÏÇ“©œ+–Üàs8\"™xšðŠã|6žà7âÙ38³úÊv*Ž¤á×¶Rñ,vÌ%W²"nçq>›#¬‡\îAÚZÓÆÑ¹X‘:5«?ßN¦×ðüê*ÈŽ{p4O§ø"›«9ññäJTÅ³	>Ç‡F<}EN8·µ¹™J‚æ«™tÞ…Of¶ðF|oòÄÚ¤ç3x%ËÇó¼'’¹Mð€ÇÓ	¼™MBí
+4!„ã9¼Ég7’ù<[Þ¡–.Ø3à–lY%œä›ú£(Îf6“ØZÉ;1‰#èë$}
+’i¼½ž\Y/“l˜&Ó+©­	º‚ô™tj;’‚_Ëš…‹I+„±f–Ïå³`7pB‰é^¤5F-àH—<¿A¼œM×Df;ÊÄû­Láêd€\·ò›Æ	ž¨IÚ¬ó©Íý…¡•Þ›‡ A°Ïzr9	2»Ôjj«™T*C@4µ/Çs k&]õ‚ëùüæho/Ÿvm'Ï$7ùD2îÊd×zÉ]/´<-ŠNp/‹Œ¹ð(¾Ðèû–Ø"DZ<IÌ|yt"¦áÏò)™ÔÜûÇ91å¾‘®V/çäè( ½Á<ôZËÆÁ2	'^ÍÂ¨…èYYg×@gbc°xºãÌ2ŒÖ41JœfšBœ½z-ˆ@ñ\.³’Œ“øHdV¶6À#q!!$S`¡¸O[SÍ“T¢“‚.Øo'óë¤¸,Üœb¸éÕ©$Ä©À›ÐÊ
+É8ÐAD4tâL"¹J¾yjÍ-P(·N,^Þ"ƒ7G
+Å({AñÙ(_‹Vº ¨Â€–Â -M…Ø^Ïl\DG2¶²i†§HÉT–Ëù•|!ÀJqÁŸHÒ7*„x|9s–/›1 û‘!Cå!ƒl³)bUn=Z-óûFn¼LÑ,aŸƒD™O‚‹`ð
+ýb ãm6€£óÓ±%o$€ƒQ¼™?ôü¸Ã…û'^
+ÆfçcZD¼áØI<?½á“øX0ìwâÀ‰…H Åóœ[PûB‹þ`xOA¿ð<LLA‰@46	C‘T0%Äæß,Üz§‚¡`ì¤OcaBsˆzñ‚7úCÞ^XŒ,ÌGÀÞdÃÁðt¸æá˜¸B‡õ†B”•w¤Pù|ó'#Á™ÙžùP8 É¼S¡€À
+”ò…¼Á9'ö{ç¼3Úk¨Dh3Qº¥Ù -~^øßÎ‡‰¾ùp,·NÐ2+v]
+FNì£Ä Ó‘y OÌ	=æ)èTˆ©ñ>@r¿”dñ¼! %Ë»`Í“¡û'²—IÓ}Ê2ÚaÔ°¹îŸ¡;©B}á4=!œ’swp÷rÏ}	>Ÿãä>Y9%¯œ’ÿ¶­œ’ÿñNÉ…_:+'åž'å‚÷*§å•ÓòÊiyå´ü`6¯œ˜ï?1/X§rj^95¯œšÿ‰š—í/ãtŽ(Üÿ€î7ù}ûO~ß“î1%VÉ!É1ÉŒd®#Ð:™¬Ó…|µÎ|ŠùkÑüé…öYúì¡!>3ŽÐË-ÐúÂÿ1â·ƒ<ÁH¥×D¼.'àð±y³i'öídSN<“åÏ8q(žO{³ñeØ¢ŸWGÎÍ„”º
+§Ù³ˆÝûˆaßÁÞŽ8ööÀïdïü.ö.À?À~ð±?üçì¯ÿ§Ggàˆãj¸iÀg¸c€‡¸7~wb¹7s/ þ"÷à»’b$yIq’-ÉàWJ®ü’w~‹äVÀo“Üø{$ïü½R'b¤=Ò1ÄIËüˆ‘d@_’Í–-~Bvð“²Ë ,ø–lð³²mÀ¯½±²d7þ6ÙM€¿½ê£ˆ©úXÕÇWuwÕg¿_îE¬|J~âäÿ1òŸÊ_ üÅj \}²zqÕW(«£T(ÕˆSj”À;•Àû•üo”Ÿü^åC€?¬<øW”ß üQåcˆU>®üàÏ(ÿÊ¬|ð_(_ü—Ê_þ+å¯ ÿµò7€ÿVù2âTHõ0bTÿ zð¯ª~øóª_ Võ‚Z‹µN]8uƒzðãêS€¿^óÄhâš8b5Ë°ªæJÍÕH¢y“æÀÿNóe(HóÄiÑ|JžÖ<ø¿jEŒö1í§ý‘öÄjŸÕ>øsZ°€ö§ÚŸþsD  q:VÇÎé8Äê$ºÀuPnÖ­¾¦[|Ý0†ÃaCq†£†£€3„k˜3\±&ã™E-4ï~=^ˆ€ýcrð¬ü„ì/¿TþzÀãò¸®Ê7ázV¾×+åWAí5òkázü:(¹^~=ào‘ß øò› »üfÀßž%>}^ô ¾ëÜ©ìË»•nêÐ]ùœò9jùspýŠ
+,¦z¼@l^×:uXÛ¤6^O¼ðß²mºKendstream
+endobj
+228 0 obj
+<< /Filter /FlateDecode /Length1 178256 /Length 33658 >>
+stream
+xœì˜ÔÕ¹ÿß©;»K‰ØEQET†&i
+lß>Ûfvvf§Ïì”Ù‚±+Å†Ø{	Š%1
+#ÔØI,1š¨ŒÁeïgYî½Þûÿ?O”ˆÞ$çëóÍ{Î{Êïw~çœ·dYˆâôR1wNõüCVŒ(Úû‚h_^=þÄEs'ß/¢ÉPoh5FÛçÕÍÔU"!ss*9¢âÂq¿Í†Ùô¹º%êä;ìdÑÜüˆÈÀ/|ÁlKèåÛŽÍýoŠÌ\Òêmô]}×…Ìõ%œÔŠb@ïž¥1SÕJfÖÞ¾ü1ê¯Šfòú`¤¹ñ­ƒ¶<'šÏ¹÷™Pc&Ú /ék·ÒDÈ›ltíLýB´÷~F=nyýñ7^íÌoÜ$’½“¤•öWûúGãÞè;‰­å¢¹g#î‘¾µk>8c×ý7^Y?hú_eIú°eÃÀtŸ|ãÙ¶£?“¯*ü¸¨Žj¡h¥Œ+(Ú5U/EÚ«
+?Þ=Ó×0;Õ§q´ÈbØ­ÐÊ`/g÷}æ_ìÖè
+6jVÑj2LÐo¡~y¿Ôn·Î®1hµú=sõˆö½±ÙKqh_ýTÛˆ2[Fôöõé¥`§¶n„V®Ù=é&Ãö¾•Š‰•lùúiWÊº£e¥|CèŽ”¿iß}‚[åÔ}5·¾SB{3NwˆT|Ç¯ò¡ÿû]þ!˜öbŒáŽöŒü+@/šs¾]©ÚWïòŸ¿ß>œ{Ö^Ž[ÿ]¿‹‚Â¿¸#-?ô;(üp0‰î¬ïn.É1ßÔïj¾oÿ|Mö‡z¶ÂÞ3ÓþÏ¡=b/Ç=ú>[AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAáÛÁ$ºWàK?ô{(üã`÷õ?«­ðÂ$2îû§       ðï
+“h0‰~ç7ï¯½/ßçï?_3yÎ}À^ŽÛgïô÷Ÿ­›÷mþ}ýNÿ ¯yêÛõÿaÿu/ö°o/üÐï  ð÷ í–³t‡i&|ÓþºRY¿/ßçï¡`†h÷ÕÜú‰íÍ8]ƒ¸¿Û7ùæÐ‹´/ç7íÅü†N¹q_¼‹‚Â×!X«¾³ùÖJt~Wó)((üßúÙ«‚‚Â?°WGŸã¾ï9þy ì‘‚‚Â·w5ô}Žû¾çTPPØ·P6DAAáÛ‚»ºW?›ÝÛqß÷œ
+
+
+ß-”ÍPPPPø×^öîÏö}óù5ûìÏ%öÁ$ÚX¿Ôì„5ûòYÿìØÛß¿PPPPPPPPPPPø×Â^üý?èŸ3R¿§þ¿Ÿ­þþ…OôýNùwù{åßf¾}ýûì&1|ãßAVPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPøþalR'¸‚‚‚‚‚‚‚‚‚Â7Áþî¿Â¿L¢{å‡~…ÿ“höû¡ßAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAáß¨ƒÇÊîB[£ï×i/F«Ù­×IÑn½^^¥~œŒ T"#eœ,ÄenÒˆa#¦:rõ¨kF­õ«Q/Œzk×‰½ÚÞ½ãzçõVõö2®ôôüÿô?¡Wóßý{ßù¯ÿ>üªNdÐ°7ohüÛþÛ_w§.§Ë¸‰—^«ûT·C·c÷[~#þ?«<ð¿‹Ú52X’üw¾öRíé‡Ÿ"ú´šU_]
+GöÞºŸƒáÒ=<zöp!Œïa-\·‡—ñ†“ú)ç3íà~òt1¤Ÿ}sŽÚOÞGFü¨Ÿ»Ëûõs÷ØaýÔ^ŠœÞÏñ•¼âÐ~jïC®îçø+EF]ÓÏÃŽ\×ÏÃ7!ÕÏ11äýS†|«Ÿcœ"»N€'ŠY¤WÓOíéHm?ù^Ò;°Ÿ}Ïí×OÝ(ä¼~ê&"«ú©;Y4;ÝM=9}7eìHçnÊÑ— ó»)ãžålIàZV>Dvýçž=*»öì²vYI_‰ã)‹ß/ÑP®ø±Hõ%}ÿ8»í”h8Ï~ÖìßP²û8ƒ€©DÃ©Œ…'–hŒ{´óK4{ŠÕ%Óžbc‰¦pO‘ÉŠö%šâ=Å|‰fÀžâ%š{Š+J4%{Šl”XûÎÉûR~‡y‘T¼g>Q*—šË¥ò·åµRõ„y±TýÞ|¨TWšçIíU‡½+uFó©k5 ÖÙæSÅj>O¬·š—ŠÓcž ÎðœÇÅýdy¥4´O¼C.6–ÆVóPi\až(WU‰·Ü¼P¼o›”–déÒry¬ø(¯–Ö3Ìs¤Mo®’¶ûÍ#%”6‘ðÁÃ÷—ÈHóþ›”ø1ÓÇHbli‹$GŸ$©'K;%sy¾d§—ž!Ù™æ£$»È|dO1!Ù
+s¥dëÌ'HÖe>Z²îÒ3%ë-=K²ËÍƒ$»Â<C²+KÏ‘ŽÙæRéXfž%¹æã%ÿËÒUÒU¸p£tÍ1Ï•î¸ùé~°ô2é1˜GË²Ìcä´'.“Ó²“³rºÅ<UÎZU-g:Í5rÎ`ó09gµy”œûYé]ržÆ\,çM5&ç¿`^ ËMæI²òÞéãdÕ”ÒdÕW¥¿”Õgš«eõ;æÙri]ér¹´×|ˆ¬™6<,kÜæ:YóçÒ¯dÍ—¥»ä²1\ô«î9Pz8J;wÛä§¤Ï v~b¶õ½J†9Í¡5bæ„™ámÅŒ¹4[a ž/„\9ó/àÃðqø†ÈÄÃáLèÒÈÄfdÞo…Â×áoá'"“8¤“¸ö“N…@®ô$LÉ¤gE&7jdrl§¼òŒÉoÃ÷!c'%2…—Ÿ2r¦Ì†\¯)ð:È•˜ò…ÈÔàÁ0o„ëEN¢ßI¼×I	x|ò%NzY#'ý	ù‘iœîiŒ›ÆUžÆW›‚ix–F¦ñ>Ó˜kÚ½S3mÜ7}<
+¢Ÿþ¼ÈLßŒáS3ó33:ãr¸>_™Éw˜9K#3-ï<“‹>ó\ÈÝŸÉ7›e˜ÝY|Y¼Ç¬;àÝð	ø
+Ü*2{*ä&Î¾HdfaóÎYË!{1çøüÜyß¹˜„¹¬u.ï5—qsƒ˜Ã¹¿9™3pò1ðdHÿ“Yã<ìÆ<ìÁ<¾ë<¾Í<¾Í¼jè€)ØÙËy?ƒ¿„¬o>cæc8æ	™k>}æ_Ù‹ùô™ÿ.ä»/¤‘s^È.¸C#yÖBÎÔBÞo!ï½}_´?ä›.Âü.â›.âžr|²ç§bO=r6sHOƒ]w°øIø|Ÿ=YÂ–à—Ðg	g`É¯!®a)ßd)ß¸ŒØ ¬ XÊöC×H®²ì$û[6¦HÊ&ê¥lõYF)[ˆ\Œ~©VÊpWeµŒqê¤¬	}+Ä•%hË"»§!Ï@6c/@^Lÿ+
+¤ìFÚ¸+e·Qç–qÆÊ60ÏFžõmOÒwõéû“”±Ž²àGÌóWÚÿf’rS‘”ÓJùA)?²‡åÇé¤|B±”sOÊç¢[@}ñ0)o¦ì‡AôatÜ‰òvÆ/3HùÙ¤|5ò*½”ß†~sþùsääÌ·™>¯0þuÆþ®@Ê·Ñÿ¯Ô?£½(ÿÒ(zTKÅþ…RQª—ŠÑRAXQq¢F*&BÎm{T1›~óR±„r²V+6Ú¹¯õH¾e…6¨"H9J9É|Ô{¨ÿ˜ñØ¦
+îMÅržµ†¶«™g-õÛi¿“wÁWl`ÜƒÔ¹ƒ¿¢Œíªx‚úÓô}9^E·ù–I*>bžÏ©ãž+‰‘*:©,†„3•„#•ûK%ç¢ò8Z#•8ÝÊc‘Ø¥Jî|å­TN6Hå¬©,G_	*-H;’µU²¶Ê&¤§H*9'•	£TæÐqf+{ài<÷ž¹‚yV#¹;•×"o¢Ï­Hl]å]&©¼ùê¿¢ÿfúbG+$”­|£@*ßå]þÈ˜‘ÛyÖW©“T!±UC
+¤ê0$wºjel~Õñ:©šHcPEøWuŠ^ª°'U5H;úfÚ9?UœŸ*ÎOg¼*Ù“ªnô§¡;žOùú_NÛ5”o`üOàÔï)’ªè6¤ŠûYõ4ågó"õ7IÕ‡è¶JÕß»RmÐIu¤•jBÈêa¤úÊ£R=^/Õ„dÕSŠ¥ÃS]…ÞÂ7ºTc«9CÕ~d°PªÓôïDº³à
+ôQÇU¯¡Î·®¾É½¬æ^V¯¥mÏþ)ÏºŸòƒè62ÿfä“Èçákèß<Pª¹5Äh5¦b©9X#5‡é¥†ð±æ¨B©á|ÔL m
+úi©™«•š´/A‡©áœÔ¸iãlÔ`ÿjZ(ûéE&è—£7äÜ×œ]$5— '$®¹†úRÃ}­¹Þ7Pj£ÿÚ95o¢{—2g¡æCúî ¾}ß»~iZ= —Úý´R‹ÿ¯«‘Úãà	Ô¹¯µ¼oí4ÔÎFÎCž‚\ËiÇÔÖ!íŒç{×b_jñiµ¹B©=“yWP¿€1—Â+áÔo)ZìJ-¶®ÿT‹¯¯ÝÄx|[íS´?ƒü5}±3µ¯3ÇÛÌÿGtœ‹ZüRí¸“ö¯´R‡Ï«+ÐIÝ@ƒÔ[ÔíOù$v¾nŒFêˆeêÆÓo‚Qê¦!gÁ“Ñ/€„ûuØðº¥Œ©¦ŽO«ãÜÔ5è¥Ž5Ôµ2'qD]Œ¶$ã2”ñeuÜÑºÓés.º•”/¦ý2xó\Oý&Ún£|7¼=~©¿W÷0ý‰‰ê6JéIÝ+ER÷ÏÀž×}D¿íôß‰üâ÷êzb)0Š…Ã2D+–a±ìYÖ‰åðb±«Ët“!öÔ2ý\ä|úcY–0Ö†¬‡ÄWOXBŒáÎZðw–,ý»Ð/£~6ò<xe"|ë±\iË-ô¹:ñ‡ŸkÁGYðãî{j!î±à§,ì›ûcá>X¶Âw¨ÿ²o– ±„å“bÕêÅj2ˆ•”Ïzd¯¬Ü+wÄz”F¬ØS+)—u¼N¬fäTt3ì›[d-G_ƒÎ‚ä®XY—•»bõÑÞ†$n³F!±“•ØÉš¡ÔËÚEb,+ñŸõ,£XW¢çÞ[W3îJêÄ¬ÖŸPfVîu=ÏbÏ¬#§vÊú4úçŠÄº•þ¿GÇÚ¬ ·Qÿ”òçz±CÙ8“¶BÊÄ7¶¡Èb#¦±ám£ˆ8Â6C+6Î¡¿l++›Ë(6b!›Ï$¶8uÞÝÆ·-£Ï¹Ô/¤~	ubfÛ[e#¶Ý€îÚn§ÏO‘ø<1„÷·q·l›ÐçÙ6£#vµ=G?l–ŸgãüÙþÄømÔw@bmÛNêØ^9±]§;	£} eÎ ý ê#‡Cl°hgÏìì™}<eì…ØŽ­°Ï3ˆßn¯€Ø6;þÏÎý²ã×íØd;~ÝŽ_·síHÎ¢tÜ~\Y¯»l¿L'ö«éÏÝ²ß9vöÈNhç,Úïç9Ó—˜ÎÎ:í›)síÏBb|;ñ´xÙþ&åwØB;¶ÐŽ-±s.íÄ/ö/ wÎ!q˜`1ÜrFœQ~ÒQJ˜ÖÁzø|1ãDÈ9u“8ˆ+äBÖî îuÌ‡‹)WhÅÿtØâÀ:ˆœUþÓAüåh§Žmq`[ùaâ¸¨Hì«ãzÆÜJÛí%âÀ†82‰éxýóÌù2óýþžòûôã,:¶1ç_ ñ˜ûîÀF:5zq˜Ä9D'NÖä$Nt²Î‘ØÖ9Æ(Îã)³wÎ)…âœ$pžŠÄ6:±ñNöÏi£Ìs62÷ÍÉÞ9#Hl£3‹Ž\ÉI,æ<®¤/¹Œ“3ê¼†¶›Äy7¼Ÿ¾œK'vÐIæd=Nr1çs8ÝInã|’8Ù/'9€ó}Æ|dç'HöÉÉ>‘nŠË¨W1r r°V\ûˆ‹}rNµ¹°'.òñ°ßëbŸ\Äž.ì‰k$.v- ß©¼ÂU¡ëta3]Äi®zêØñŽ‹µº"ýr‘÷¸²”9¯.î¦‹u»ð.Î¬ëBêØOwÔÅu±~ñ‹³ë"‡tq~]·QÇÎ¸°§.r4×}Œù:l©‹oââ›¸žB÷|’g»ˆ/\oŠ_áâÜºvèÅõ:î©k—VÜZ¸ùîbÊCør÷:qó=Ü|7çÖ=ò-ÜãÐ‹»'"g ÉÜÄ{nâ=7>ÑÍ™uó=ÜHÎ­ÛdßÝô'WuÐacÝñAâþ1ú³(Ÿ‹Ä×»/¡ÌúÝø7±‰ûZÈÚÝ72f-ãÉaÝø÷Ï©?È3ñ‰nî¬›xÊý$ågLâ~Í î7éKžèæ\»9×îíð/p'ã¾4I½±Xêd”úCôR_JýÊfÊ'Hý<Ô“ŸÕãë—h¥žuÔãßëëtRï Þ@?}#ŒI£ËJ=>¡~%ºÕôcïê¯¤ßµ=«¿¥HêFù>È=¬ß„|>±¥õìQýVÊÄYõ¿§ý}Þ›RÏ¬ÿ‚¶^)Ep N†KÃáHbîìf¹Cç³a$–m8	’5, ÛÑPC™¼¨Á…¾žz3ô¥»×€kÀ~6pÈáÈ/.@	c.GÇùkàü5\o’r††Ð“7<ÂÜÏ 'nxþ¯òN|ï†÷Ðq¾¶”FÑI#gª±(–Æƒ¨×K#6¿q¬VGšÑá£§#ç çI#ö¢‘{Ôh¥}ôÑÖÃ´6rf93Ë‘«˜s5¼’:ïÚx#$Fl$Fl$Fl\Ï<|÷FìFãFæzŒ9^¢Œÿj|‹¶wû!cþŒîcø	ul_#±mþ«‰ø°	ÿÕ4Ø(MJv¡éhêÇQÇn7ß6?5?5“7á“›Ã
+Ú­èíèð[MÄ·MÄ·MÜ¦:r·&ìAö )[ Mä>MçÐ¾|€4]¼=qEyDw¾‰³ßÄÙo"ŸnÚÀÜìCÓ#È§û’Iš°wMBGŒÞ´ý—:i&—h&l¬‘frŸæýá”ñIÍÄÍ£õÒÌjæ5ã‹š±áÍØ¸æiÈ™pãP?¥@š«([ÑqŸ›½Œk£ÎšÉ©›;(“¿5“5“¿5cÃ›WP¾y1rº«‡H3{Ò|ý@’S7“Ç5?B;>·™»Ûü:eÖÑŒŸmæ<5ÿÑ Í›ÄcñpŽ<‘ÄEž¡Zñì¥>¯{ÈC=£ÐøWñ„ÇL™ûà!^òÛzˆ×=eè+uâao<v$wÂCžçñAò<1 'AöÅCåÉ!ÉO=Äâ?öÚÃ]÷`«<¬Ësã¯£|eü­‡ØÝCåÙ€îú[xØfÏñ<Gÿ©“Ÿxˆ-<¬×óýˆ)<œCÏŸÿ	ÄWy¾Ò‹W¯¯I+^âxï(³‡^öÐ‹íòâ§¼ø`ïÑ:ñ’syO€æbñb½áRêØ oA¼Ü%/±“—¼ÐË]òbƒ½Ä¹Þ$å4$~ð²Nï2æe½ì¡—üÖ»Šñ¬Õ{)ò
+H~ëe­ÞÛ˜ó§Hìš÷È‡©³^b'ï3èðÇÞ!öÍ‹òþûêå¾yY§w;õOŸÓŽjÑB£^Zè¤eˆAZ&-¨O¥>«@ZQfïZ*¡¥DZ|…ÒÂýii§ø¼_ÒBNÞreÞ¹e5zìAþ£;ÜÂ]j¹®CGnÕ²ù ü¥QZ£þ4mØ´Þ¹åeøÏûubˆüH~¤ÛÖBÌ×ò1ý?-ŸNÄG¼î+ÐŠXÂ7IÌî#îóbgÒw¤N|cÑa£}Ðq}œGß$qžo>mKÐ“—øˆ|Næ%¶õ‹Å—CÇÚ|§#±y¾s y–oý/1‰ãcm>Öæû	¼“±ØhßF£ø6Óöò•ñ½Å|‹œÊGÞá#öm+ßÞ·K#­Äx­ƒEZ9_­äÀ­‡i¥•xµu´QZÇ¤×:­XZ¡Ç'¶â[«‘ˆOl%Glåµr‡Z‰M[ÃÌ—drÄV|K+qNë™èÏ†Ë)“;µ›·®anâ»Ö›xÎºBi%ïhÝ7£–çm¥ç¦õˆoiý“IZÿJ™\ÉO¬í×?1©ßâ/ÕŠÿHÊÄ)~bl?þÅ?=ïîÇ>û‰ÛüÄm~ì€ŸÕ
+$Nñ³¿IâåÇFû‰±ý­FñG©§‹ÅÏ{û—£¿ ^×PÇ>û¯…7Ñ÷¶¾©Ñ—XÌ:bTÿ/Ñù‰Sýäþ'áÞ™¼ÝÏ}ðùß†Ø8ÿ{è?bÌæøœ:1™ÿ+£ú~(‡Ï€ÜýÀ½@¤•Àa£“ÀqÔïûÁ]¡°×yèYS€;¨Øë€ƒz}ßÏî(¸ÿ ŒÑNÞàÞ8cîOàLÈCXs`¼¸ÿ§v+L¸	¹–qwÐÿg´‘?°åb± ±X€X,€p—Ï!_ ßë	¼Mó`ø¨ ç/°6bœ 1Nñg›A+m…puö´ÕFnßveb†¶c ~ª?Õ6Ñ(mÜ¡6îOÛôìeÛH®ØV…¾ÉÚÛX{qO[½IÚüÌ¦-ŽL3og¡´C¢x§x»<±ízxë@iÃ®µ=`¶M<ë)ú“3µ½_gÞßÑ÷-ˆ=kãNµaÚÈÛvPÿ$Ÿoc/ÛˆÝ‚äôAlxX Aö0ˆ}²¾ >8Èú‚GÑv,eö3ˆž„n¦^‚äPAr¨`zìCs´1G’˜(È>ñWAr‹ >+ˆÏ
+fèßIy™I‚ç#É+‚Iœ0xõµÌ{\o” ¾)ˆÿ>|>Ëì^ø9ÈÙ¾7P‚œÇw-¤G‡†Š´*¡N>b-!Îch8uâÑ>(t‚ABÜ¹Ð4½„°q!âé['¡ftäC¡ zö"”DâcCyduükß:Ÿò&	qÏBœ·ÐHb‡±Cˆ}	‘ï„‚Ä@¡G˜“Ø?ôò%t¯2ž¼6D^"÷qÖBÛJ$,"aö!\ —0±PxäýÃìE˜½V$aò½ð1´sÆÂä{aâ»ðêäåá¹:	/*0±C¸N+azüi˜}cóÂad²ab†p'ýNCrŸÂìCx%¼ˆ2v/¼†2ñjÿæN…ÉëÂk)¯c^|Sø^ÊP~È(áÇM&Îg‡_ƒØŽ0>)üÏ'^?EÏ>…É×#DØ+Ò‰pæ"¨BþH'‘ÑLx)2‰½Œ­—ÈxHì™‚žØ/‚-‰°w‘ù°²æˆ¥X"ØH$†ÓF8wö0‚‰`G"yžÓÃ\g"ñÃbóÈjÊ—ÓF.!vˆÜ`ÈZÊØñl„x6B¬!F£GˆÑ#Ò‡)ò*uî[ä·è°üp„»ÙF{!OŠ|¿ÔJ”3Å†D±!QâÄ(63:€ž5GÉe£ä²Ñ#Ø“(÷-JŒe¯£ìut2$‰NG²ßÑ“)/4H{­„Ü¿¨’?E‰£ÄPQÎp´É}‹.Cw’>JÜ%ö^ÌxìJ”»ÅOGo3J»½O/QrÖ(~!ú,’ýb+£¯RÇçE±/QÖåìF±)QÖýJ$¦3J¬X#1ÖÛD™8FA™X0FŽ§—g7Æ~ÆXOŒ½ŒÍ×JìÄðÝ1r¬X-uòÂ˜“2ùI¬bWbƒÄ¸Ÿ±,ìÄ1bÞØ¹”‰	c+!k‹×Ç.ƒœá1VŒ<%v;¼ƒñÐác›øƒ1aìÚžƒÏÓþõ­”‰¯bï2Ç‡X0öü$ŒugãÄ%qîkœûç¾ÆÙË8{ÇvÆGÁ±ôcãìcœ}Œ³î8ö'>Í$ñù´óÇË˜¯
+]-u{¡Ä}Ô¹³qîl<9Ãñ4º\ÄO§L¬çÞÆññ!w6Î>Æ¯…¬5~ºÛÇçÇÉ1ãœß8g7¾Q/ñÇh{‚2>0Îšã¬9N,‰6âà8kŽããØ×8±XœX8þøi$ð	lT;›(B²þÄP$1Y‚x?A<™E}´VøÃö6½ML¥Ž?L÷'ð	üE• æO—%ZŒ’ &Kï'ÒôïaÜ©ãÿœÕ>"qú+‘øÀkLÜDŸ[¿Ž2ùLâçÈûàÆa{ØÞÄ£ÈÍ¼÷óHbæÄkû” §IÓ$ÈiAÎp‚ýM|ŠŽœ&©ƒäsIîg’½M²§ÉR$ù[rL‰$¹‡ÉY”¹ƒIü{’=L.…•èj‘øÁ$~0ÙD½Å ÉQ’ØÝddmIrµä<ƒ8&¹R'ÉK!kK^M_bÍä´±žäÆ?ˆ|/'Ù³ä³Œ²ž$ö'INšü-|þñÛ‹ÍMî¤þÄÇc¤]§“öZig¿ÚÉMÛFÇÝl^ í£ÒŽmŸT$í¬©}Á i¯¡u´Û
+¥ÝÃX?í‘ÁÒ¾Œö3ºŒ½Œ:¾¢ýzêÄšíw1×}”d®'©?Mùyø
+cÞ`®÷Ðq®Ú±íÛŒÒŽíhÿ’ò.£¤
+ ¶#Å;¦†AòÈÔ!%’‡Ž82u¢NRø»Ôì’Âî¥8G©ZúK¥°)âÈqdÊI~RAæãî¤øö)|@ªƒ±=&IaûSœ©þ.EÌœºl¤°ù©uè¹3©{éÇwOñÝSÄ)ÎQj3sqORä_©—©s–Ro ±ý©w’úýÈ¿Rä)¾j'Ä^¤°©]"iì?a¤FI— ‡ÂýÐa3Òäilšû“æŒ¥ÇP‡4Ów:r6zò‚462}*r)’µ§¹Ci;tI:€$gNÇ‘YÆçõ’ÆV¤Ykú$ö0ŸKsÒÜŸ4ö>_Oÿ„¾·$¯KãëÒØŠôŒ%?H?±é-ð×ô{	ù
+|99sé·ÇJˆÄF¤‰—Ó¬7ƒÈ…HÎ\feÖš!–É`3#t’9ý±}Í`3fÚñqòÏyP[‘Yˆn	eòêyuÆ‰Ž(ÓññÖœÁFfâ”Ùç>>C¬–ážeðwò…~!s>Ï»ˆ¾—Rçd®¢|òê·Ðv;òN½d¸s™û’yùhd°™çŒ’ÁÇgÈó2ø¼ÌäÎoæÏðcê;iÿ‰íÈ5’%'Ê²ÇÙÁZÉ²·ÙáÈ#%KÎ—eÙiÉ²ŸÙyèOÄ0Y|x¶=û™­§¾.‹Èâ²ÄÐYÖ˜MCrÖ,ùP¿—=—öHö7{:r¿ìèX[öfæ".ÍÞMŸž]Oûƒè¡þ¸Q²øõ,{š}‘þØ‘ìëð7èñwÙ?²Ží´±ŸYö“Ï*ä@ä|Ò]ì`?;ÔKÇptŒ¦Ž_ïgÖ×1Ù$sé·„vüx‡6'úzê^Êäá~ô¬«ƒ3Û‘¤Ì¡é Néè1JyxÇ¹”W1çµãêœÓüwÇÔ9«?§¾¾›˜ó	ä¯Ñs>;È:~ßeìŸÑq;¸‹ŸñžÄŸ9ÎfŽ{˜cŸrø°ö&ÇùÌ¯ä°79bíû•#Ë9@räè¹©”ÉÑsäè9ì~n¾^r‹‹%Gî–#.Éasä¹ IrìQŽû—ëFrÿrœÁ¾:‡­Ï-7Hîâ’#¦Îaor¬'w'cïaÎû‘‘ä;¹ÍÌÏþä°59lMŽ¸:÷&er†9Cî#ÊÛáÇ<Û™Ã¾äE/yÖ”çÎå‹)ÑIÛ’çÎåYSž}Ê³¦ü‘È±ZÉ“«æO€3‰þ¬-?‹ò\8bgòä¬ùò¡’'¦Ì³gyâÊ|¾äy|už,ÏÍs×òø´<kÍ³Ö<kÍ“·æÉ)òÄbù‹‘Ü½<1JþjÆßñùuèîâ}È'òøí<~;ßÎ?‚|ýæÆwä_[i'.É“Ïæñù ÷/OŽ‘ÿ„~œÕü´ñ-:9¯ÚBé$>é4H:±7ÄžcÑMDâ¿;§ÎÅFé$ÖìäŒvÚÒÙˆôÒ7€Ž„¬3JçÙIÎÚÉ¤ìiç2úGwžÏ£L¼ÙÉýëÄ—t®FwYt^¼®"2öWÌý¤I:_BneÌ›<÷}Ê¼çú‘'tb?ºð]ÄW]&ta;ºˆ)»ØÃ®CLÒEÞEî×ur"$¦ê"¦ê"vî:Ù ]äâ]Kau|CWmVè‚øÄ./’;×bîíì_¹m—¡‹5u‰<¿Hº°!]—ë¥›8µ›ø¼û$ƒtc‹»R^R(ÝV¤ƒz=l6IwH#ÝQÈ|ÝÄ¨Ýä•Ý§Q?yžQº/FÏwéÆîv_Iûuèo¦|+eòÉnòæn|n7qj÷zú‘gu?„ÿÓßí&é&Žè&öé~†:>¸›Ü«›Xµ›Üýò]êä^ÝØäîmÈáçƒ¤§jâðö¿g$¯ê9âwz&è¥gjôóô, Î™ïáÛõÔAÖÙc‡núWöWöàsz°Y=“ôpö{È£{:µÒÃùï9çœÇ<Ä«=œ…bòž5Fé¹Ý:éù	óÜ‰înê¬·g=ã6¡g}=¬¯‡8é?Ø8ïðªª´íßÙé		:ØP9Ô±7tŸ} E±+ê&…¤wJ		˜“SrNêIHNz¨ 2XÀÞ‘u}Ç±caTGý~¾áïº¾ï›gõ³×ZO¹.X·±·Ûöò=pÔÛà¨·aï·<VøÞÆè5¢Ïp·Æ“9U#yrãéôáÏpîÆ‹è»”2zÞˆž7ÂÑ‘F¸Cã, ojLV#Ü®‘;l,‰R#1¦½h¬a|-ÜˆnÄ7¶3†ý4Â“ÑFt£‘<£ñÚï¡m+åm`;óv"£íIæsw/Ñ†7’?6¾Þ¤ý=æÿ‹¶Oèÿœþ¯cÕøc’Ü±ñrÿÁûää¹ÏŽ’›{r_'79¢ä¾†¶›ðm7œÀMÌtg!ÉÝÄ7qÓçv—‚E”—"ÉŸÜp÷ªH¹¹/wk4ÑFå&¿p“C¹±_w7’;s÷1n9Jß`ß¶#Zî§ègOî×(ÃÜp ÷ÿ$Èý9møc7¶ì&pÃƒÜð7öìþ%BM§&¸@÷ÖDŽÔ4yÞx5]N{jº:ZM7Q¾5QMè[S!ebb6Ú„M5ÕRÇÇ6­Gº©{"ÕDßÄw7u±^_œšàsMcÕD¬o‚Ã4=Iû‹Hø[ÓnÆa;M¯0¼¡‰¼¡‰xßDß„ý4‘ç5}Jß×€XÙôògCÐy"#ä!¦x¢å!æ{È…<ø$>ÉC\ñ 8«çÆ`WbŠ‡˜âA÷<ä¸öè¹Ž¹ðUüÍ“%<Ý“'O ‘ôÔÓNNáá=Ä¼ÜÓ)OÙÈ‹<#ôÁi<ø~ÃCÎçÁ–<Ø’[òìL^ãÙ•(zæarx9¼‡|Ã_ó°?ûóG(ÿ!/våe^øš—;ò’Ë{'òžH6æu 'ÇÈKïeoÞK¢ä½‚ò5”ñÞ)ÛÑòf‚…qò–SÇ?x« <À»†5Ð7¯‡¾Êè˜7Œ„£yG)so^b¡÷>€yÙ‹—ÜÃûë<K?÷çÝÍØ¿S‡Ûxß¦Ì½y¹7/¾Áð¢{^tÎÇñþÄ¸_ùà8¾¨Hùà7¾$på¢åÃgø°-þÐ‡Ïðá3|äV¾‹hÃßû¦2—;ó]Éxöç#žøˆ'¾tdfŒ|9±òÁ|ð ßbÚØ§o9XÉ<öê#FúüŒÃž|ø>Ã‡Ïðáû}äˆ>îÐçöÁM}Ü¡ïæ<Èxü½ç#×ðígÜÔ‡Ÿ÷ak>lÍG¾á#g÷û}_Rÿ)Z˜°üìÕ+8ÉŸœÖÏ½ù±3ÿŸ(“Kù/S€IÃÏ÷s‡þë þÄs¤üø?\À?—yð:?¾Ñ_D;>ßð“gøñ%~|‰Ÿ|ÒO>é_KNàw³y–Ýõ³oàžýpW?\ÀOžåß%?öé‡»ú±Q?~ÒúÑ[ÿ.öB®áüoÒ‡þúÑ_ÿûÈ‡¯ôãcüß²æ÷1òÿ!(ˆš#:Üo¨9)^ÍpòfößÌþ›ÏB^ .¦ìDN‹TóÌ5ßÒhË¯ærÚñÿÍ•ÌÃß4£·ÍÄ¶f|esC´š‰ÍØe3|®.×ÜË\öÕŒî6“C6ßîcâ@ó6äC`åÇÀ	j~™5þÁÚoÓ¾Ÿ¹øýæ¯‘‡Yã¿†
+ÀÇì!€¥ ù€ü?À}Nø™ ¼5p.mì%àŒQà
+ÚØK€ûÀSäPbw€¸ ‡
+äÒGÌÄ¶@5`oºXàª_´ì) GtS`>?p7 ×ÀÍ ·ÓÇ^OP†Ÿöò}äJì0 ÷/ÐÉ |4€-ˆì1€=Èÿ¿ ‹Q06BAüL09AAøxÐ§ ~%ˆ_	â3ƒp‘ ¹oxœÉXô3HžÄƒ©Œ]ÀØ| bÁÅHøiÛ’×!ÝÑ
+Â¿ƒðÒ`s{¨Ðwg¬‚[¨og-¸vðq@<>Ç¸]ô½Êúï òÛ ü:øøŠ29`ð?Ì#ÇâWXV-ø•–0ž:9SË	j™§øUüª…<°ŸÒ¿j‡´`o-Äïî«åªhµÜÈø[˜ŸàY-ó¢Ô’K[eî«…½µ°·–*ú±µâvK=õÛÓ„Æ¨…¸×ÒO}(R­. n…ã´^«V›zõ¹QjÅŽ[¨³nky´Z‰©­ðùVl·µŽ1ëÄÔV/å ýØokå>Æ²úÝº)^­Ûi{„úÓãÔ
+ŸiÅ7µb£­û˜ó¿ó1ã>Ä™V8h+±¦õ;úƒ#Ñ"T«-ÒP[l”Ú’"ÕÏiãÜÚNäŽmì¹m1Ýk[ð+mÄÅ6âb6Øèk['uüK±±;l#7n#.¶a‡m›é#.¶qÏmø˜6ì°íQÖ}
+ù ·j{‘úËÌƒK·ÁËÚöR'¿l{òûà €Ÿµa§mŸ#±Õ¶ÿRþMjgíQ†Úã¢ÔÎý·sÿí'€I1j?3BíçR¾y)uòÉö™Œ¹yC¼ÚçÐžMyeöÛ¾„:wÜ¾ ¿í¬‰Co‡“µ³ÏöÎhµÃÅÚ‡‡nÇ‡¶ß§vüg;¹;þ³}µ?ƒ|ž±/3–œ¹»ißØKû‡Hî¥Ûl?H}n?+R6uû;¢‘±‘êÀ.;ÆSÿ}§Ä¨ƒ<¹ãO	ê¸4NWÄ«~ÖÎv¤E©c.å…”(&©ãþhu<DÑAîÒÁ7uðMpÅ¸}ÇËHâY¼±¿ÑAßñ!óá\™÷¿	OìTŒ:ã¤ÎDä„HužDùdÚ'E©ó,êçƒ)qê¼‚¶«)“uÞ”¤ÎyÔPÎAæ#ápúNòôÎjê+XŽÕ¹éVg;sÑŸNâS'ùxçíÔï¦ýé¼<«Nx|ç“´=‹|žqäâpÈNbT'ñ©.ÒùOÚ÷ó÷àœ;9çN|`ç×ÔÉË;¿c~#„ß¡7!ö"‡	Á³B ÇÅ(D¼ÁKBøøÐi
+³Cp“Ü$ta”BÄìE;¹LnÂ/†®§û¥³fV´BÜE^ª ½
+áëCµ´‘×†°í:ÂCèT(Œ„S†F zÂÆCØOˆý‡î§{=Æü§ÚÃ÷Á™Co1ï=ÖÀ6BpÐg´}IÛ÷´ýD|9ô›¡.|cW|„ºÆQ>&N]Ä®®ÓiƒƒtÁ».¤~i¬ºð‡]WP¾:^]·F©+‹±ùÔ‹£ÕUÉø•´­¥Lœêò‚fúøþ.²«‡ùpÇ®»À&°™~¸Tvß…Ýwá§ºžf>vÞµ‡5^§ûêâ¾ºˆY]pÇ.ì»ëú¿D~Cùr×aÆÂ‰»¹«nâq7wÕÍ]ucçÝÇÑN,î>õuÃ¥º/‰V÷t$¶Ý}C”ºoE¦Ò?‡2±·;—:ºØ]Ìî¥®ß_ë†7u×úuãÓºƒ‘êÆ»áÝ˜‹>vs/ÝðÄnxb÷Fú7¸q÷C¬û(@'»ŸOP÷kôÃõ»ß¢ÿ]€vÄÄßîïÁaÊÄÞ‘Úkh~wÃ„XmH¡m2 Nm`/¦DkÃTÊìg>kÃ•€X²áæÜˆœnä/2‘Ù¬“Ëxá¸Å†¥”áMàêékD’_öÔê!¾ôÜÜ”}ñê	Eª‡³‡øÒ3<N=›i'‡é÷÷<QÏóHbrÏk”áû=ï"áú=ØW/úÔï=I¬íÅßö¢W½ì£wJ¤z]1ê…»÷r/½73f6íp¢Þ9 ‹ú‚(õD«>Û»TrÍÞjæÕÑÞ ”½mŒ…Ã÷r'½ÔÑ·^8DïVÆ¡_½ø·ÞhßÍxüm/±°÷mÚ?d~­—ø×KÜKüû¨q
+'Q&‡OˆP˜˜ž­ðäH…á¨aö¾˜29H˜¼1|rò*Ú°õ0ùc˜ógÆ*Œn…ói+eþRÚÐ«ð*Ú×3ÆKþ†¯†‰!a¸]¸‡v¸B›/Ãðñ0öÆÞÃÄË0¼5üÖÚIþ;/
+£cáçFÇÂØÛ	ïç[> G
+¤þ-¿y„:q±/"V}p×¾qqê;!J}ø´>|Zß#Ô‡ý÷­¾K.C}ð»>î§ïzúfÑž– >|v¼®o¨ì©ïëƒW÷ÝÏzèGß#´?ž¦ü\ŒúöÐGœë{Ÿ~8hßg€×÷¿÷ìƒ[÷ãú‰oýÇÆªÿä8õ“÷õŸIûy´_HyJ”ú§E«Ÿ8Ý×ì'êÇŽû‰ÕýÄ•þ —z/íØfÿ0eøF?ñ¢ŸïëßB}ó¥?îçÛúŸgìK”‰wýèD?vÙOÞÿ9ëÃxxQ?¼¸ÿç(D üÌ@‚¡äh 'În€x0píèÇ ¶:@3 ·€S8#5 Ÿ˜Éâà ß=€~àæ#á}y àƒ*X‡ï ¾Àƒ¶#bîã1xžþ]Ô‰Õ¯$j€3 ×øþÏèÿ–ñ‡éC—ð'¿Åj0.Bƒ‰‘$ŽÇùîÁ“¢5˜B;1lî0ÈÙÂ}§!¯ø’Á›‘ä™ƒ|ç ß9ˆ. ¸ï`	u|Êà"Ö©æ7ÖSob±k°z/uòèÁa~w#íœýà6€nî@ÂéŸ¢o}¯€½´ÿ“¶ýH¸Ý |hð íðºÁÏÁWü~rð0sØ× ¾ß?„ïŠqÑ«¡“b449^Cœÿ¹×LØç~rèÆØÔ3¨ãc†æSg?C% ,JCØè>f.2´2RCuÔÑ×!r¦!òŒ!âÏÐ!êø‹!bé0:;ch8‘r28–úñÈ‘§Din6L®1Œÿ>—qÑ~	rz´†¯ŠÕ0þz8•qpÍaxÚ0Ü`¸YÅ¸j ·†ûã›‡ñÓÃ> ø¼á.$9Ó0ñg^0|/ó¶Ò††Oï¤ïi°‹ún ß~ƒõÉÕ‡Ñ™aòÁaö6ÌÞ†áBÃ™ÏÞ†p<ÜFb¾b$‰ú1†FÈsGð…#Ä‘ÕHxÚˆŸ¶ á!æôDjûÁþFî÷ ôxäAäÎX Ã#èð:<²‡ú^êäÛ#ûYn6Â|ÉºßQ‡«Œà³F9çQââhr¼F'"S"5Ê¹Žr¦£ä¤£Sè‡{¢Ã£Ób4Ê]^¥ÑY´Û ¶ù´å Ki_«QrÑQâûhÀÿŽv°æ€bÂ3Gï¦}}‚9/ ùæQxå‘ä!6!6!>!>9òY†¡Dýþ—†î@Þ¶ïeDÌ´dDž–ƒFð“Œ¨Y2¢ãÁ•à/à-1Ç‚³Á—2bgƒ—dÄÅ‚éàQñÉ xÀ°Œ„bð†ŒÄI`ì‘tàw“ÈH¦?y)è‘1>OÆ"À	V€µàŸà#ð‹Œ	§ \^qÜÒãxúO¸<$ãÄpµŒ“ž”1ñy'Ÿ,ãÔ,“. üî¤B°t!ðgÀ7Mú@†ãÒ#Å!#e8"c2¿}ÚI2N§íôûeœÉYœùg/ ›eœÓ!ãÜ2Î»ÌŽ0ÎÛ(ã|öyþ2.`oò}!cÊ#àùc
+ç}i5øx¼a\ú&òð>`—þ*Ãœa˜iÈ@›s>Ø Ø¯5Õ0,öêNÜ«(Âp}‚üü&c*¿?•3œÞ'ãòõà)ÀºÐ2c÷3c&àNfüa\¹NÆÌ›A¯h‚qÕ.ÀØ«¿’qÍ€ï¼þp·ŒXÿFÆÍºUÆÍœéÍU2n9AÆ­ÇÉ°£ kÛ.°´È˜}HF*:”Ê]¦îÿ–‘Î™¦ß"cÎ… ì“‘ÉüÌM2²øæ¹èá\ÆÏåNç¡Ùì=›sËÞ+c>÷=ÿ_Æ|¾gÁvùþ…èQw™Ëz¹|[.÷œËùå>ÞŸÊÈ;,¬‘Ç}çý,#ŸsÌ?äƒƒ2
+ùÎB¾¿pðÉ(â‹¥œS)6SÆý–¿>—QÁUpý€¶Eìiz½¨ S‹¸‹%œÝ’0SÉÙWò]UÜgÕ†±ì;Ë“À45ïD5œýŠcÀM2Va¬š‚Ä–VuË¨å|jÙCmºŒ5^ÀÙÔÑ·öAÀ¯ý«ŒúË:ÙÀo6Ü.ck­ç[n‚Çe¸k ÇMÜ…‡ý{¸ïbðR„áãl}è~ ðÚþ#ðX„dAö¼p?Aöd û
+¢§-Ï‚¯e´RoãwÛÓÆ·s¾í) »m l¢ý—€etñ]ø—2z^•ÑËý÷~##<¤ÊèC'°›aîyx¿Œ‘ãú=Â÷°¯tcä÷öÏdŒ¾ØÃíØýíöz;¾ìÏ¬}ºr'ws:z7º³‘{ÝÈ¸´ßû±Œìywº#`s;Ð•ÜÕŽUÆ|ÚÖÚÁ÷ï@·w ³;¸Ã[À ³c7àûw¼Ð¹ìa'w»“ýïäwÞÄg}ˆïùw…Œ?ÿý¬/”zfìMJ}1f·Ò.IþDiö¸«•6ÇÑ¬´6;Oi=Ž Òî:Æ§´-–GéÕÎUGßÎ:âüvìí¬ŒõÎ~eÜõž2vÇ¥ŒýIYÊxÿ˜¯4§Üù“æl9öšói|‡2·Å|uô­KŽÍPÖÕQ”uKÂ“ÊzæØrÍ}Åš yÎqGŸÜÊŽ¹öJÍ?'ù|-øÄêÑÂ+AÓbkaþ¸ÆÞâÊÙ~Ù&åŽ}Z9¿8¦*·7ùfåîv«Ü÷“RîÏÑ«•×÷‡§”÷dÌÊ/Œ®{³+dê«*ˆŸ0öpWáUÒT¸×u©Š¦;FE3’©hnâ~UÇf©èùÄ‰*®š0¢âº„U¼-!¬âÇ~ô©¯MI{¾÷Uí>úè×Ã×åŒ=úU–Ÿ¨²¬ø÷Tžîzsì°òpìkª(÷‚*ªâ+TŒËVÅ†ñûTñ·Äµ(1©E‹f$V}+ÌN¬{0lIuÌ:-y7ü¿O‡-ý"ê¹±÷Ã*ïˆzH•;WU•V¥–Ÿôœ–9ÆmÕ²3Ö²yãžÕ²Õ1·iY}ü8-·Fµ<}Ú–±Ç–7$Ü®ê³VµÓùUOO>¢ê[’Æ«:;ºBÕŽÿmì=²×xÇØ£d+KÒÊãO˜¥•gžp«V>qB•jæEª½;9åèkeÓg=¡5WÅŽ×šb}²ì_+ûÿ=T¶mÜ­ù(i²êNL
+}­l}Âª{éÄKµ6.Æ£µ+Oœ¯µ÷'Ü©µ;“¦kí_“ÿ¤µïX£ú+ÆïRýºäoTïŽ{Ú¬þ-Ë7ölØØÓfA(Ïÿ¾o¶þ‹˜Óµþ›˜D5.?i…×'^!÷¼“î‘»ë¤roŒZ-÷“Îr5µCžÑ{äù29[ž¯^yMþ£¼3’—÷Þ¸Zyˆ_'ïáøõòÍ™xôm4ß‰yòGN\&fü!5GOlQ +ú\^w®P0!Á¡à$Ò¶àe‰Û¬LØ¬à£I>Z?Œ½¦<[{ôIµäqÏ¨åü¤{ÇWkY?ùAµ®Izpì™µÖƒãlµïµ‹Õñxâ!u<X¡Žç¢^QÇÉ÷¨ããèBuž˜p¶:'&¥¨ó´¨*užîš ÎË“îTçUãVçÂD:
+^{¢-tÁ8‡B7Ç_­Ð»Ño«;&®^Ý+cKÕ=ø©6dŒSoìåG_q[~Ê!…=Ño(ÜÿŠÂ÷'_øÿ¼çö]T£ú£“ª\ÔÇê?&.¤þ¹1O¨ÿÙ$§&žš®Y—íÓàæ¸¾W§¡‹¢ÕPzòíŽ?õçÇÅ½'íÃ5	Ï$°Á MëÐú´-Â#ÝàˆpG€r©RiÒÒ°9Œ™ó©ð>Âù ÖÊºÜ~äáv ie6ýóÏ.GxÀzóA¥ð6€ô1‡+·ð;¹üFîÏÂÍ€'…#Â»€vá[ é[Ñt ÷)šøÞ¢ç…SPìb¾«øCáPÀ&@¹´¬ ¤*e'‚%üð‚°p"€5*‚€ß­øý¿B‘j-âw“ú-æ¼?&\ _ZHe*IË+ï ôU±¯e¤dËHÓ—qÖËæÕ ^8Àï-gL5)Z5gTÍ>ª9·jR²êÂ=Ç ¼xBø@j°ú÷ÆÈØ5ìÍ8 d’Tr÷·†=¯ùHX=˜	ÖRžµ¤Nkï;Á_én½<Þ¦=³ŸõÁßí°Ÿõ¤Ëk¸ù~wØèoâ»=À—à+aÊ€óñÞ Ü§ò-?
+™ÂvÁëÂrÁe€3>
+ÆÑ5²:Œœ¦~¿ux0®{ïxpöÏÒ¤Ž…}‚‰à´ìÉow ô*t¸¼+lpÝÂ…ÒÒ° oaÎ©oëË_Î¦?Ð³þg…ÁÒèÁÍ€ó"âN‡ãAþï.þþÐâ~™†³IvœÙ/;Ù^,{¢õ¸ì3í%²/¾üTÙÓ¬…²/sþ »Æê’ýgë²ï2e¿ì|K³MëÍžíüU³ó/whv]©Ù+Í›4{½Ù:öôæì‡­Išý´ù‚RÏ°
+”z“Y¤ÔÙÖ3JÍ²«”Zb6(Õk¾®Ô¹V©/§\¬ÔWÍ»Æ^ìL=h/Sê¡ô­J;Ùu’Ò®77}Å³ÜºVi‹íåJ[bº•Vë¤£ÞùˆÒŽ€Òº¬·•Öm¾¡´‡Ì\¥íqÌTÚ~sïØãŸi¬ýJûÅ^¡ôHë¥Ç˜O*ýëN¥OuîPú,çûJ¿ÕºFéÅ6lg¹]«ô•Ž”ÞF¾“þWëG¥ÿÓ5IéïY±JÿÐ:ÿè;¢rýCÑÖ‹Êˆýã[Ê8>eŠ2Np)cšµEWÚk”1Ó¤c–u—2æ[Ê(Iÿ^Ëne¬vÀ£bè¸wÒ;ÊxÙÙ©ŒWÌ2þé<¬Œ2e|ëHVÆ!³MsÆ›{4gª3¤93íµšs£µZs¶;ÿG™ÇX^e^êhSæ4G«2¯u˜Ê¼ÞŠSf†s‹2¦^¦L¯Ì!»aìÅÓÌ{S.Qæf'3>r´++:ã"eÅÛëÇ^AÍZa>¥¬ÕŽ9ÊºÛÑ©¬­)—*ëYsŸ²^±=ÊúÊöjn’ùŽæÞ`Öiî"k•æ¾eû4÷;s@ó!Í›˜bjÞÛôAÕyŽÙš—m7}ZuÈªÑ¼Íæ~eŸ’âTöYÖ\eÏ¶ÊNsÞ¯ì×ÊÎ'‹Ë.´[•]cÅ(Ûc}¦ì»­4eï6Û•ýŽù®²¿´¶)û7ç‡šªëlÍ·Ì÷4¿ÔzHó‹4ÿ)G—æ?ç:Góÿ6éÍÇnÓ‚ùv»ÔØZPowjÁƒf•<lÅkÁó®ó´àugìÿãZð©ëZ-L°fka¢õ'-L¶Zµp¼•¨…g§XcoÂæœcíRŽm¾¯¿ùrv›”ó7s¥rÞ0?TÎ+B9ÿv¾¨œOÉžsc¬»•;ÉZ£Ü‹ÍZåÎ°^Wî5v·rç¸.Rn‘õ„r‹=Ê­±žTî:§O¹›l¦Ýon{w6wÏÔmÊ}5®ûZŠK¹8NVî¿\S”ûƒY¡ÜÃæå1×)/Á‚õ^`þKySœß+oªÝ«¼ë\¯)/õòÉÊ+´”WáÜ§¼ÅÖ"åÝæÌSÞŸí°ò¶Z÷)ïak±òþnu+ïmëåí³ö*ï=»Oùrv)?Õ9•žô¡òKÌGÂ;z•×å§)»ù°ò_´ŽSþÛæ¿Uo}¯‚ñÎ›T0ÃüX7Ú…*¸Å¹K¶y¡
+
+í~”M:|ôÝNÜe>­‚íÎ*8d^¦‚íAüj~¢Âc¬Tx™uP…WZoªp¦¥Â¬*¼Ññ‚
+or”¨°ÜüT…Ë7¨ð/Ö_Uø7—©ÂWÍÏTøÚ¤©ðug
+ÿ“rº
+›AÝbæ©¨Ì|QEåÎ¯TTá«¨ÒUQ“uŠš?ª¨Ëü‹Šþì|GE›œ/©h—ËRÑwÎlÇ8úT<ÞüBÅ§ºœ*>ÛåRñÕæí*®°ö©øù¥Š°oWÉ$ós•ä˜U’kß©’B³F%µÖÃ*ir¨Äoß­’€½Q%íö=*é4w¨dÈùµJžpæªäEW‚JÞŸóŒJØ›Ušl}¬RÇd‡JóÌ¯TZfoQi…µI¥•öý*­6A¥Î;Æ.íµòUvÞ¨ÒgS¦«tŸãx•¾ký¦ÒïÌ&•~ïš¡Ò­h•þìzU¥ÿu¦2ÙQYœó!•Å[?©,ÑzIeIÖ£*;ÞZ®²S¬·T6ÉZª²g³Êr]W¨¬ÀÞ®²ufXeƒ*»×üZe/ØªìeG™ÊöšÝ*ûÄüFeßZe*˜|±Êû!•Opœ¥ò»Hå“MÊ¯1·ª<Çü«Êë¬C*ot%ª¼Í5SåƒŽa•»®TùŽSTþ’ë•¿ã˜®Š$sP›‡T1Ã~X¹ö#ªXl~«
+·™£ŠMæTñ¸ë:U<ëRÅçnUì³ÞWÅçÎåªø5s²]k~§E™™giQž3 E5®·´¨Ý¼M‹:ÍïµhÈÞ©Eûc¾×âI“öiñdçgZ|Æåghq¯u’?nVkI\ÊeZ2Á<¬%Sí'´dú´b-¹Ï5KK8j´äS«\K¯0·ii…óe-­´ÑÒÕVŠ–6[ÉZú‘ý´–þl­Seœý¬*OO¹\•9÷¨²Ò1ªÊj›¤nùU;"U¹Çù…*ß´_På~ûEU~™2C•¿šGTu¬ùÓØ»ÑU§AUW˜?«*Íº]UsœÛUµÀÞ¥ªbû%U­°w«ªÏu“ª¾v8UõÓ´°–âºEËÎ²²µlÖ´-[æ\¢e÷[¹Z~Óøµ<Û¹@Ë]·’:ÎÑòŽõZþà´mZþš‹ìñ7ó¿c¯TW[æãª¾Ìe«ú
+{jNu¥ªÆ²Ž):Ö©ÆïŠUM‹óNÕ¼ìHRÍ+Ž;TóoóÕ4ÔŠKÌ_µ"ÏüM+
+'×hÅ6çZ­xÒ~U+^v¥iÅÛ™?jÅ»Ît­ø ¾¹âëÌÿje”ãN­çŒÐÊ$Ç]ä ŽrPÇÝZ9ÇÚ¨•9ökZù¢õ VÅÙohÕ™Ž‹´*ÝÑ UÅö^­ª°ßÔªj§¡Uk­Vu;6jÕ.s×ØóÚ«öf¥hÕ~ëB­zßúD«Y_hÕwÖ2Õ¦XT­Ëþ§j§›÷¨vý¶jÛ².VíYST»ÅÜ ÚÏœµúk·VO·µ:Ç¯ÕKL¯V×;6iõ^g”Vj½«Õ_;oÕšs‘ZcNŸþ?æ=Ó•}ô1ï×ü£y¦œ÷½Þ½f“½Ok¶ºr´æ/ö;Zó˜3Zu‰Vê&:cT7Åqêò§§ªn…Y¯º:ç½cO}×õ8cUN¹Bu[Í5ª{ÊÞ¯º]—ŸCB2YkÓ¬­íwÜ7ö$øÚÝV‘Ö~`¿«úã\dÕ)©þJëÕßjMU}ª«Hõó\Åª¯ÈÚBºí¨S}À|FõŽÍªßê í3NQÖ7jˆ·ÿG‰ÖWjH²zÕp²³[§˜Ïªájç5\ï*QÃÂÉ]jÈ5ÉÒ‹\¥j¨qÆ«aÐq¿F¨a«c«¶Ûï«a¹S¯šw¨á=g‚>µXå3g½¾6‹¾`~Š5¬u§¹Ê´î<ëe­s:Ç^5_wk±Ö-µþ¥u­ÿ‡º/kêÌú>÷Þl„È’"¹	—€Ü{AT"
+*h‚Hp)BµîVik• ²E‘P+.¸t›.:Óµ-µûtÚNÚN—o¦Ói§ÎŒmgïôm;!ïyîˆË¼3¿w¾ß|¿/ÉMžç<çÙÎsÎÿœsm¹â:h™åúZÊÄõÐR7c
+´¬uìƒ–Â*hñVýZî
+ åa^-Ï;ùEq3´¼$n–×EZÞæÿ-ïšÐò±9	Z>á'@Ëç¬Zþ.üZ.9^/˜½àeòßP÷ê]Ÿ‚7†¼&á÷à¯€·JÈoÞøHðÖ9îïFÇ›àÝÄGƒwó;x·òQà½Ùñx·ózð6;Žƒw—ã-ðv'ÁÛ%ô‚·O@–“3ÒÁû¼„£àý?®ß€÷#á5hU	´j?†Ö0×o¡5ÍuZ—ðh­à‡ uÿ´úx#´>ÊÇ@ëúkï°4vë\Ÿ…þî{‚ësØ=Éqv³ü£°;Ã< »ówÃn§ëØ=ÏñùOÃïî6Ÿ…Ý|ì~‘ÇêÛæs°ûSñ6ØÃ™ÏÃžrþØ³Íü(ìyZÜ{ÞáWÃžw]¿‡=¿à{~i^{¾äM°W'¼{#]€½q'ìMbgËt~ïò¥ó`ïmŽ§`ï®?ÁÞ¯Äh3™ƒ¶9ÂƒÐ¶Øõh«äã mÅÒFh«w}	m{…~hë[¡íM×_¡í=>Ú~-t@»Þz?´OUÐîr}íeüh_É?í«\ÿí>××Ðþ£:&ò¡C÷BG¾Ø¶:v›¡ãÞ¥ß‡Ž§ÅèxÛüt2ùJèTŠíÐÁÎNO€ÎB×7ÐYÌ_‚ÎÒ¥/Bç>Ë7BçJ¾:ëùèÜ$¤Ag³ë[è<ÉO‚ÎŸñ‰Ðùo†.­ùBèOëO‡ ËÎ³Ð•Ï[ k¶ëoÐµ–·B×F>	ºZE
+ºÚdîË‡¿ë´ãt=b~ºž÷ƒO/¾¾Džë8¾Ja |ÝÂà;äøøî²Àwÿ#ð=+lßkB6ø>»Á÷‘ù)ðý‘ÿìS°/žö%ðoÂ¾DGì›%€}³ÍOÃ¾*×w°¯FDÚr×%Ø¿Ö„ýýÕy°ÿ.áqØÿ€ãìo„ýg7Ãþ—ù‹°ÿUÁû/9:¡[É'ËèŽämÐÝä¦¡{“0º·Š~ènæ}Ð}Tì…îŸ›Ÿîù>èþ«ã43?âA8P"Þ	º…¿À^>ÜÍO†¯;nÆ­€ƒù9èIsœ…žLÇÐ“+|=sùfù=OñïAÏ‹Âdèy)	ô¼Á ç'ü}Ðó®ðCèùÜŒ__˜Ÿ‡žß	Ç¡çÂNèù“xzþ,`Âþµ[=ßŸAÏwâaèn?KÀO	ÀÏ8¿Šï?ü‘‚üQB#ø‚ü…màO4'ƒß,?+,¿E(†Pþ,~üÙ‚ü¼xT~Â?O¨ÿls%ø'Á??þaü¥<N¹Hxü.¾	üeâ1ð—óià_"tƒ¿‚t«t¬µYjùåà¯çŸÿávð¯JÀ¿Áþmþf¡ü·³Á¿ü·›wƒ¿Exü­âqðïW‚/¿übø»uà÷‰'À¯y)øï†Àÿ {øO;üàÿ†?½Óx;ô.ä¿‚ÞEîè­âÓ¡·šŸ
+½«ùèÝÂOƒÞ­|&ô6óoCï=|ôžæs ÷>z„»¡÷<ï€Þ<½Ï›_„Þ—ÍjèýTh†ÞK32àÑÑw,sÜw|îŽ„ƒ¼;
+®Îï„ƒûÜÑpp?ìã
+ïö¨ààÃŽpðC1 wNwëáÎf^€Cwð-pèLþq8ô¤ù%8ô”8 ‡†Üè›â6Bß"GWè9>¡úîä·Aß^„¾{¯CßîXè;+žƒ¾'¤½èØ }/óÏAßûŽŸBßÏ=3¡ï3Þ}_ùÐ÷gÇá°Õ3'›‡gò¹p¸Òú]èáñ<^.äÀáZó+px½ùU8¼ÙlÃ7'þ~‡÷ÂáfLƒÃåW…ž”¡ãóáH´c;Ñ;ÎÃƒ¹
+Ž$›_ƒ#Müópd+?Ž¼ÀÏ„#¿âáÈ¯ø}päwâcò5ŽoÂ‘!Ž2âãp4L„£Z‘†£ºÄá¨_G­î‰ò“7Ž‰OÀÑRñI8ú–°ŽMöÁ±"~»A|Ž­ŸcŸ…þ8ñ9èŸê˜ýæ×¡Ÿ÷Üý‹øè¯>„þjÞ	ý‡ÍCÐÿ {ô?ìN„þ'Üfè‰ŸýUÐÿ	_ýáç@ÿ—æ7à¸ÆÍÂñd·Žç»­p|¾9Ž/#àøoÝœP›Ã	øœ˜ÏÏ…ë„·àÄ³žáÄsîd8ñC·N¼ÉÁÉÃŽ7àä)Çœüžø#8yÚü&œü['Ÿ>‚“Ï
+¿†“¯‹/ÂÉÌ9pJÃÃ©|áœ*_†S¥âr8åâSàT“ø
+œê5pê¸ù-8uÂü|m†ï’­hþG3Šia:‚Îéž,= „^µIÜDŸ(åÐ'gÎpÓ÷O_ ,iL#hÀp0RŒ» +¼vú@4s@ ÿ·•Ü~kƒ²^~ Ê^M°¸BŒ‡Å‡Ä‰°ø<ÿ!,þ(Wå[\·À’‡X3TæˆT>äøTžqí‚Ê_‹ÉPõ°ËK¿b ºÆòx»|ä–È§PóŒã#XvŽ_Oîc”‘»:Xùªc¬üÔuV~ÍWcú.fcÎ?BòðM˜}»Žaö-¬Ã¬Úñæ›"¦Ï»&¹àh2Yí$!ü)¦mÂÇ$mÃ„k‚`"ù×fÌœø3$iú³$Ç×˜¹ž†uÏ:ÖbZ”=Ó"áæ<ŽoaÃ=å‹1¿q½€¹Œ8¤,/“‚ú’$Ç¬ÁõFùü»$0^†Á-CU!ƒQ×‡$<ü˜„}7bÄ'®Å¨¯Å¸Ìõ+ŒËÄ­’‰
+ƒ„ß`Ø"8å‡Çì~Ú±£v
+´Ít¼ ?Ñ¦ãmv.:o±|Z!=¤pñ¿%^îïÄ£öº07….Œý‰[‰^Ä­B·áV#ô]àOr¬
+=ï¦P@ü¯äK	È2²î0Oñ^ž'	n¾Éÿ‘Œ_xcý3¢Œ;QFœ€°Â¯!Ðà@hàóX" ù“;-ÖÑDLô]Êßš.F¢‹/m#JyUˆFy¡!KDŠD…qmE]q4½hÅãwõâÙòägá‰æã9ŠF<3~
+Æõ;²^-Yï}d½§pv·	§s'àp*ÎZ‹Ãñ‹É 	Û÷Û]„-9(lé=Ø¾‰´ßOÚï–Ö…µHížÑÚƒXsë¤nX{h´pz´pf´ðýÑÂF‡
+îpç¼öŽö¶½{v·z[ví¼}Çm·ÞÒ¼}ÛÍ[·lÞ´qÃúu7­]scSãê†úUuµ7¬\±|Y§ziUeÅ’Åen×¢…¥%æÏ+žÌFiÃÒ©pínÎjíÔtÐ†c1|j:PÍ	¨%bÀm·œ‹«­¥åÕEs¬VOg8
+[¹ê|õ£{a_¢t	Wº¸¦ÚRä«•‘RqEMnÏk•ôœŠê@±kãêó¤úXuþUÍF›9K Ê|¾†`lHw&PRA9gŸwâá«ìœ•«^¼ÐY+jç`I7Z¢,ópDË`¬Â«~)7H…J5ÕKm£g>rmHŸ%ƒÀs·ÈåÚ€¥Þb	¨lÜª²jŸ5@Õr	¡zy5JŒªKðY9«Åã>?‰psV‹†ÂŽê\<à¤:—ÔT?`é¬¨>KSôœÚBÏ@2¶U?apJTšP	‘T,¤¥žÌYZ#ñ'<áðJ­
+‰ ÕëqM3J£ ~–iQòD)ÒDNÔÑúA…ÜâåV M#Ó¼Mz¡PöN­Ò©q†9uô¥MHg‘r£àœŽš@%`¯r‰<HyÂœ	2‡9œò
+;+/O]YS}NØMúÆ‰
+ÉkjzÑ í²s—õqq5Š½h€rÙk%dlEÔÆ€sI5á¬M@œ;5h„¥š[ÀyŒFß¦"¨S¥ÔÚ}²buà¢¦£21¶õ\q-á@åÆÏ$ÕWYj«jíX´DûŠÉÙÕnˆ Û ¥°Q³`î]¥h¹Õ…p®p¬¥ 
+äiQs…*V–\Wd‰[ã«çV¡ž8Ëª›=u8vÀÉÕ\aÂ€
+Q«ã(ÜDÑ ¸ì¸›RÔ·½lšÙ¹Åç›kp*RêêëH}®%á5qsçzÆõ(²øÎºúZä(òHÌh/H,âê,(RÜ.Êj	‡ÅšÒ§¢¦Ú§kà8¨Óé«Ãm'Xê=	>O½$`ìKƒ©éÊË‚šX¦­¾¿-°ª–[%ˆ]MkºšÐˆ\ãi\	™Nú¥¤__	WÔ€äªk0¨\VKƒGÖ(“¬û2Qã˜,x¦Òà¾¨üÑªa?¾@Ó•ÕÇªÅäªE©eÈºP¤]«¶Ö&Öyìc,uï*‹ÏÅMçÈ—Ôy¹jJ,xëë„¨ˆî!¡	–êU¨½8`q­oTã°›"el¦ÀûC"ðQ85m#Û	xË,µKm-RÑT¬	–€-uD¹8–Éû)C„ÆŸ:ßìœ4! Fœn¬[ÍYS‘æñÈÒ'kTàê`Iu |>Î p‰¶bdÆáSª”ä?›ì\Ýj<D2Ÿ¥nµÔ·—+I‡Œ–PÄY=ÈBÛ$Y¢àV‘¯zjc`Z›ÒíÓû,y¾ê°aQ‘R_U‹àm‰²[¤£®CM&BX@jHf³Fì/}Rëí+Ô¶Ëé³Ñ.3k¤QqeåÕ²QµôÁÂf{€6åb#Ù<UŽ>@!žÒ¶ ÅëD­J ½-º¢:t<Rÿ¤kÂèÉÝ"A'q^ÖÑõ†Ëë•'UIô	³46<è€× 7«Év.+–qÑrFZ®¼,ãT–P‹´‘ÚPEa[-íIvZ‚–èÎë8r%Ÿ+C¯YË‘Ëã!Ók¤‰HihŸ<0—Š4^O¡™äO8ù,¶0ž¬•>jiÍ¤MÞ’òJÁ‡¤÷Dð9%g½ˆÎ]v„¬2dw«7zìr/UÁ-ˆ¨ˆÜõ‹¥˜`ZgU#ŽáöÑª,%vôÒÞ:d©–Èè@´’*æ u(T€X 7Ÿ"_€¦ÅÍÐX+qgi 4\.ù	ãrhJhOÀ(j‚ÞW_Û »S”2ä&Ì ŒJ:è0él·hª¨V&(<’Ê¤ší!-–¿·ÛÇÚ›‰MªG%©!m¾±F¥4\³¬)¡ïívÍu{ù4ÿÚdšÐiÂ¤6‚F)šÿy*F> ù¸Jhyä'šRïóhXA,T—t=.-™Z%Êæv\J™Z#Q¤*š›š,G>6[86D!ïó²j‡cc®æù™?Oƒ°Ý>Ê-×­µÉzjõ–µ³ÙîÁR1¹j‘¥˜\!K
+Y©î*Ô/ŸiØ•ÜØ`ÄÑsc#’Ú ¥ÃHU‘ ÄS,Q(®é’<Sp©X÷M Ô)!%a mÓ}¾ðQü'ðÿ†‰ …€àñ]MìÄóÀ³žpýÍÕÔ	9tÊÆ~	1dÚ9ð9$~!¾)Œ(@žïÎC˜#…ã#‘ˆ)Ž§ÆÙ«G!a£}´ï¨Ü%“õ½ŠZQ½©DR/O ðW™b%W4ÑñöP°º“œîni¸Ýv‹eÆYs(Œ¶ÐQ®!®ÊB¸5)Èù0àYSW'á”lÄa,UN"\ŒÓ¹(5fÈ)ÊÐ(lÕ3ò<ý?Ÿä‘¡ŠF'W…Ïb‰ŠÆ&ŸEé@ Mo¨“hèÅU)!.²ƒ64N‰o,ùšŠ'(=ÈJƒì#¥UìÃ%[Ø”Ùï—xÙ3‚ìéùAö¡ù^öÁùyìó‚ìýóšØïdï+²÷{Ù{Š‚ìÝsg²wÍ²§æÙ“…AöD¡›=>;ÈöÏÞÂ›=™=ZdÌ:Ãždûf6±‡fÙ;gÙƒ3†Ø;òƒlo®™õçÙžÜ!öÀô Û×ÄîÏ²ûÄ ë‚l¿’íä‡Ø>È¶ó^¶-gˆÝ›d÷8‚ìnÇÛšd½ÙA¶%s&»kÚvç´ {{fÝ‘1“½-£‰½5#ÈÞ’q†mÎàØívÛÔ {óÔ*vëÔ4vKºÞd7Ûƒì&û»ÑÞÄn˜2Ä®Ÿd×MYÉÞ4E`×NNa×Lv²7¦a›Ò‚lãä »zòJ¶!5ÈÖ§zÙU)A¶.ÅËÖ¦d±7Ø‚ìJ›“]ÁiÙåÉ6vYr­áÜ¬‡²ÕINviÒ[•d+“šØŠ¤©ìK-·±‹­A¶ÌdÝlu%d%Ù…‰CliI4;¯ØÎÎ-,aç±…Î!v¶3†‘_ÂNÏmbórSXŸÉò	ñË9^6‡ÂBvÖ6kâvZæ63#‰Í˜d§¦{Ùôx5kÏœR9%>È¦Mb'ÇÙÔ”™¬sEJx\ìr›IÁ&s1,Ç˜b—'Å*Y«ÅÍZ,æJÖìfÍÞI•‰“ÂÙI±[Ø„ÄxXgŠ…eIÉDJ1ñb¬½Æ¯¯ŒÎªÔ{¢<–	IYÅ’t•ƒÁ”XQ&)*ÏŸ«dÏQo£ZÎQeç¨sÔÙJ8KÕž¥ÎRŠJÝÁvçb(Ø®ðy"‡2‡ÜC‡Z†z†RG`•TžzsèOCÁ¡07VNaE™Qi	ÇYÂ“´Ò”Ùj¬¨“T•T*#^¶Gx^÷h_¶k=¯yTžS*
+^¶ƒçU%9Ã’4R7ƒ&‰®Ô¼l×x^ñÐ?¶Óž{Ný˜b¼^%õå‡
+{é :X^Ð”-PÛò‰N@Õ€ÊšeÕuÀÓÖÝ‰…¥ì%Õg™ÚÚÄBOi ”N©ì%å¨(,`&¾¸z@Áðl;ØíÒyI‰6žŠ¤›·#m½Ù¾u+~õ°SãÞãF’*”\åŒQGùG{]ó¢þçæqp5áÚqªY Ê?ƒYù03Ï‚
+ƒ¿½FV/)ßrßŒÅë8< 3ñ}ÌÅw ÜÁo¡¬ðÕ…°•ZePÂ8±T>5fC-4@ø¡fA/ÜK°_œFÇäÂqJ`Rka?tÃ1øf@R(‡l+ƒ*ÿx
+ž‡W©-T+µòSý8jlAŽ³ÔBœ3æaÝƒ3ƒûàû0 ƒð´BŽî†ûá4Ô*—š°@.À|œ}®l-lÆµÆ1fá
+K¡k‡pN²ÎÃp<ÃyxW»@Zïqü-Ãã|õ°ç ë>ƒ+Ïé(ƒ\ÿ­°©r–CìÁò!ºôAð+ø—^Ê¯!_5òGj”?…|B€¡`Ž:Gõ	Ž©‚0ÐA$°Î	èH¥šÖ(µ(ÈÌÌ‰{OË2X£­”•¢¢)ÊÆ©ÿvL9øÝ·týòðÎá<¥b¸e˜§Û†w¨>ù¶\=÷ÒÅK½ªlü>Ä˜†ó˜&hÜµ•z^à@ÿ¸BaœÁ@AÁ>/sZe4¹$^ài&…wädÇÕ4“mŠÅ_—”Š4Q Ö«¦G)ÕYñ7Äe¤ñIl*—Î'³“­ôŠÂ|«Ñ~µƒ2v§mÜ˜Ö=òÝpZJRV6¶&Ùó¸Dr{µGôQ\ÁÔÀ	ç'ê¸Ñ‚œ¡lÜßØœNf»¢ö“YŠå5Š<&n"U>VT¨›¦d¡Æ6²Ã0¾LnÁÞGgÑ­ôS(ßðó}zŠÓŽŒ±òtëG?µoá*Bu=ZÊæ4¦58E°ŒVxè9³ÙÄ„"M†E“C^øFåá9P±9Ù"Y˜J­Š1ÆbM¡wŒ‘Ká’ÔIDJ¢À3¥"kO¥S)Ž1Æ¯Ç…oïHM!²Í!Çš(Â&ˆ” |º¨©j§Ñ¸'>>ŒR«¢¢Ñy÷ß´öhDÄî¸x•iä•¦S„fcÅÈ…XUb¤•-‰‰9TRÛ®×oš«Ñ0úøI{õúS3\IÓ¨øøÔ´È*¥q(¿ 5l­IKÛvé·wMKŽ7iÃÔŒ)A£I01ÚÔÉ™óÃyŸü^¯§âž¦ÿxé¤)üBá¡ãO­M›Ì·0Y†5ÉÉèX«†¾uãpSÞŠúä7ÜôÎíä¤×ƒUQ‚H4íPtš•JJ•®H·X’ÓuÔ¤ðôŒ[×¥«“…Û×%‡CßÑ(ãhüÈ?(ëh”VvM¤h’¥OUuY1sÐ;‘11
+<éÉp†´‘1Ûï6jt‘6½~O{”"«¬¨ø­›ÜúèöºŠ—-Ú´ËšZÅì¤ÖwZÒÆIÊØ#ï?=lz<ÖÌÐ±qŒÖdØbZ4ÅvGË«èÜZ°kÓùg×yš²Ê(W1¿èQÒ—˜‡lN#dfddÃòêDVKG´®ÓÒj(²£éMy™™d_¸ÚËfÅ‘uËúqµvðW
+@EuµïrXR-‰16[Tz^~Dôš¨¨eU;ôú™1QáF}lÒC|ÏÎ8£~ß›•ž¬7,t­üÃãÍjÆ«PÄ¥Fxž2·¤Úñ1šDAßLv!ÿÿ©w…læq6£€KØP^âÒ\ŸKßŽqÝG»”Zúžëp)µ?FßSQQ]Á÷èfU˜ ¢Õé Îˆ{CòáK"bè˜QTr0’®B$šž3Õ¬MªDE‚~C®5ÑfÉÊM2§XU–„éG6ŒüõÝ³8SþÜvª>çíî”mßíM±f‰VdÉDF\o9ýKæa&ï:ëe¾t“Gž¸J
+™Ï•_Â2˜æ4-]:ÓÅ%ed”Ñà¢óó&Ç›bfjô(däH?™99Ñ2¶Ž‡Ãõƒ¡å]1X¼>\®Ä
+A
+ƒ@Ÿ(¹ I±8B£¢µîÝ=ì¤½ZÝüÈEävg"=)Ž1æöFÐQšC†NW°Ä´K«¡Ôjt‹t+–å†ÇVÇEëãKã”THèaÎ½Ô~1Ù®¡kTñÄæí3ÃU#ýgccÛ©úÒ¥c?ÏŠÓjÕ£áSï1[
+YìËªèÍ;†ÿèß×zœºèG<( +ó‡Ëxš
+“'[ )Éb4â©SQáÄ‹:ñ îâšÀeà®ƒ¦qÃ\ƒ«ŒÚˆ	¼5*ªiœ*cÁœâW6×¶oð5è¢íùSßpÛ‚YUÖßVjµºU³¢/~=l°“â#†ÙóK§¤öþð·¾ÛVS7µ'¥©â&*-ÃG;6ÿé›jÖ¤/¦ÊJ§mC-D-YŽh Hh05=}*¢AÎ¿×`Áç×`Á*Ä‚.Ä‚rƒ1*6y¶!¾ãúH@ÇÈH 6ØÃâÀ¢åô‡ÌQ!4™9!C8ziˆÉDó¦™Žà{Šm!»Õ?.Ù­¢/Çÿ¢å*àÿ‚åî ?T·I«|L²\åb;ÄZ¯ºíÛ¯¥EÅäÑ(^b²®Þ—â¥‘­LVUPÔ­ô/U
+è¥™ÖÑTD™KÕñÝ—P°£†RÔê4¤9WÄ$hÈ¹5ädþGc†ÏþŽh¬*ø3(ÞÿÏÄô‹P¨<öŸˆ˜‘“=c8atæ—üã˜ùÕ(R”xÿåŸÇÌOƒmŠ4UdS4ñÝÓ²”\tŽ"­¼|‡ZK8Þ£ç*ìÌOÆsP„Ã^UEÏ¥ºMŠ™ŠÕ3˜ÉEƒî\X„’påd>FJbÆ
+LÃÔ—‹J"ßŠ™ôtMAfø%ù05hW¿£úq)sÁ¨Cñé“S’&ÆFhÑ5'ëâ+*tËW®ÔaÊ•Iô%‡\ÙÑ9ÙÙh¯¡/ÉÏÕEá‡œeÐ‹‚OÀ ŽRKŽLxP“þM£ÎëT#ïS6Nþ½›V5¬}P­¸;\õÐÚ†U7Ý¯×i¨”‘Ÿ©FZ%Í46ifÇîk5sáfI3UŸëÔÚ‘¥Ã‡/ŽxÂqàÇ)Õï©t*–¢©°A•jpä›‘‘‘/FÞùÝÈwkušpê:žŽ§Òªu—î¼B«ßŽ},–¥izøXýÆ„EödY«;7ŸFÖêEóÛÈ_3þn„LgÌUòÏž5ë²ìÿ}¹ÿ¯ãèIâÃÏ\Ïrš+jš¯±œGÞÃaŸ¢$«Ó—xÊ¾”¬Î`R(LF¦"VÇîšlWÄ¡Õ‰‚“”I¹P­VM—óøÇ¢44g‰C¡êód»‘vŽ¾!Ù&…“l3^&Å2KBéúí”áÀd)]ÿÛð”ñéºò”zz”B=-nã†øû¸LW øZ±Y­Ríòøˆó¦Š‰‘oXàìc“ÚˆÏ¿¢¦ÔP)êÃ¸‘ÛÐQ\.«òÆòú‘‡ÇŠ?R]ÌYUãÕøÁœÝ·OÑE}ˆ^[>¨úêyXCô­¦ºjAÑ¼“F¥Hˆ˜W&ŠñóâC¢‘tŽ¼¢%÷Œ©ä…8S.‰SªÔ¡·µ¤:ˆ¤ÐPm<•B–/&‹oK"Šv-¾•ÙÄ¦‰€cÈÈ*5EøˆVý2ä?'oÿwýçõctÃpã˜¥\EMÕ·ÅwÇÇkÐ÷GGY-®˜˜Ó§B¾ŸG}?Ud’|©ÑØ_´¼Ë0æûÚôúãNâûG.Ê¾ä›IãèçÔÕIÉ3':ucÁ<}zttÜäl¢w9’tC6l%°Š‘Kæ¬DZjYÊD)S.+aŒ1Õ²[‚‡¤§bë8ð‰yÿ©KEðÑšô[¯q©Ù|ømÌEDÇ’ˆq~»m¯„ŽóÞÜÖØsËc»Û\ÅËCèDkŠ÷TÐÿÆ;µ™S¦ª,UHUÈnHÜ6>\%A'ŸýÕ'Ÿså¦S˜K×&ß£&-;RvWÈ‘Š†ÊÖ+"ùÜÿgˆEÌe´L:×«-¢¯¼œÑÊÁk8”!Ž¯5 qÐÀ¹ŽU©¨ AÑˆùÚkŠ>5¯Ü+Åøç“b“'Y¸$[27Š3Ù6Ié•WaŒšÇ >qdó?	â•š+Ò€›Bi —˜b%ñ³\‘©¼&~È¬©Á,k99IÆªº¨ú³ò4§~áì™1Ñ*…ÓÜâÌLCá*ã¾Öò•×·y[²¼¯oñÊ+­]Il]«úTÎ §²â¥¶ëgÐ&S›œA¿Ÿ}m=Ç|uýYb½kúüåŸÑNÀÿ^óhŽÑìœÄL2)Œâ$ÇÕgêt…e¦–±¡.bÅ¢21”ã/4IÍ$¢E¿6jÑÚ$ýôéqOÊÖ]mÑÄ™ŽY1+VSÛÕ­v\N¤Mq‘F}áÕ‰´:~¢’>v9‘v/œ¶yp4Y?^õO“uIA{.Ç¬íyª5“OE{Îü_Ùó¿`Í´Q¶f)fws£¶Ü¬´¶ïÊ‘m9Ùž+gåÍ‹Ê›¯ÊÊ‰¾ÃlVØT÷]£Û6´äÍLZaXé†Ðûˆóæ‰“"ˆÊ›	­[Ôd%¼ÞÝúæ(F;A?aNfj¬žYÿJŽíjJgN±Ð+ææYõÔ~ŠéÌØ8ÚF.ç$[3³H
+>EHš„z’£ FÄ„#˜œaFbµ‘ŒVƒ5—ïÜ+S9FUÓüÈ¥ÉDåÇ(›æGt¨L&rã¾YÔO“oÛ7‹†LrÓž‚A:‡î‘îÙ_ÎÏÕV‘îI™›@?ÕÕ…<4æÞ÷`îÝ9NÓrtöŠ¢ÿnïL £8Î\}ÎH3šé¹5ÒœÝ£[H£ˆKH²Àâè@Ý118ß†ø
+ÞÄ<{Á‰‰Á^_›¼Ä'^œ8»q|á}Ž¶7o×	<Ûë€fØªêžÑH	Ér^X\ó=ÍTwÿU]ÿßÕÿ_…Jæ§§ºáèÛhæ¡óBÑ>;[ª›ôÑHõÇáR”gx©³í%ö¡ñðÚEÍÄ…á¹Ò(æ
+šŽCÃp^UÖS·]Ã2ú16ëV‡m­še„ïwtÜA3ÚþX«ý9ƒoÅ‰p£š·<d8i·ZkTPäöªõ»à¯¶Ã‘’vÄbµÔ*yN}ÏÂ5å²¨]6“#'×Lm®Bƒq•Y å)‰w¾~È­ÕÊ˜³R.W´a‰ŽG˜×¼q¾?ü»VûeeèÑ;î¯ÊÒjÂ…I@"­H,zƒ¾°7Õ£Âh¥Y+§[öy;~øÝ¼Æ7½ë6hå~àdÂ‘x.X‚V¦Ô%Æøøˆ'5"5Ø¡jÄ§Ÿ3Ïå7t†Ø²þžØ ¥~»Kl™‚$“‘%™ê&Wúbd§=ë¬%ÛQV{i8¯T*øÆùóÖ«e{žÚ·lÁ‰G~»gÏÚµµ¹…÷îˆµ1ÔÞ¦$ViŽ`L…ºÎ£#;vste¸",,œIpv¤¿×¼ö ¥úå±’ªwíø“ß=óÚîôØžA3Â¼2@t©Â!£cÓÓÙèÖï³DÑ¬T@‹5{¿
+fkq£Gû£ž./bu#ÂMù*«§›—«rvÕ¢¼¢«9“íGm1V»Þ(7Ô_÷ùþ[¯¥†)Û¢Xç=<¬2/ß‘‘àrdTŸ¢n]’šàÔñj4+g¦«Y3žw?{e–¦æ±„<„„Üü•_blV~œD`Jžåô9êÅÉsÔ‹¾{ñ4š)?G—$àW:^š48k¨zß("JÐµ“Ë k½—¤2ê¡Dõä2ê©‹>*cü8òp—ê‚Ç‘7Ìƒ#I<ŠD#È9Ž!eØ'd_}vnÒ}Ðô\Ì„Yúœóô3u~áÙ¹l	C«t7êt2Še#TzÃ<¥²»­¶3<<× RjYÝÙËyƒšË©û‹†7)ôºAIÓK—®_¬³p*a¥VÛ”Û]ÿ·Ým!q.Ô+hìÂÈ’ûtŠÑÿ9).22ll\ÂG„ÄÑ‹ïÂÿhµ?£Ìhô’ðlfdXxÐà¥è&S¶Ñ§ÄC—þaoÇ}·ýd½k ,Hº’-;ËÜx¿@ê‘4Ï‹‰Yœ’²¬hõ²@DàNÎOžo™nUÐlðq;è9iôØ8Éá v^âSdw)Õq•jå#Z¹\á±h„‘%»zß“Vok;8´es±§|~]Ó—s‰‘Rœÿ`ï¾}{?8ïûÂ÷…?M).¿ýû›vï¾é÷o_¤˜*i‹ÅÁšô´.;ü³G½?¸Ãb¤ix(×¨jÍ»·n:úJÿ†œŽ†ƒ?¨]Vã®¢Àü´f¦urÙâ==ãKShFÆoÙlP	ZþùZZ©,WUðpâÔâ´“((*æäŒ³¹n–VdF‡öÔÚ£Ìj‡M]œš®]©TVª«TåA©sejµCZz6<û\fb¬M%–U¾z¿ÖÂ1ƒLfÐsã}Ÿm´¹8³ ‹LUÑ›fg²1‹m Ãà^Pó/1.àŠ¯{ñ
+ü”&Q`{×­GººŠó;‹;ó:“ã›¶éjJŒ2tš¢:MúNàEˆ_¥»Ýîôt·&?§Ün@Þ0K\p…ZÌ–4eñ¯NZô{™ÜÉó3³|6\Íúœ<ØK­‹T±´Aè„[++v†‡7	:^s¶¸Ž×…q²Å‰¶´l¤ºQ©ôô
+ÂJ½6ÕÈ5£Ü–T_˜ö«ù‘®ôçLÐÃÍü!r…l¤™³Zïô>{Ô-gL–5Dq¶˜;è_xßyüCAÐk®¦y{Ý‘è²	öºî¦×D)šÍò2Ñì#&¯ïPÑª[¨ÏæÓY_óù@"X‡z¹ÙÖ*kUj¬c»püÃÞ qÏTž„ eydú€©ñÓÒà‘~ôz
+<° vÐ^\×Qµ  v]™up
+ûÝ¼¦û…Þ¦mm¯£m,Ór‹ÓiOåå<px¥3ÎÃÐZe8õd¥kEÓÊ=‡n\Ÿ\ÈLñ±XÈÇ~SŒ]°ÛÉ×‡66º(!œ‰chF¥»—þj@e÷h¸ø†5™·À¾ ß:&°ŽA2•ÕþÐM2•<4ôGWl¹,©áúéïºbX0…îÑ¬û¾:WR6CéJ!¢Èéê^œº×n¯T„g'ç*,1ºd—-Ö–ºÿÓT*{=›]yj…#e££Û>¿Ýl`˜Ø†ç“bN'|}I©G¥KKHr´­?„Z÷A­ó•	3Ðõ|áIøÊÆ'À–#ùQ>‹ººÁÚëtFR]ëÑéô!®3ØÑ¢¦âšÊ,tgTú«¬Á`1f¾c{rÍ§³I¥gúr§«výúZ§}•`f?î7ÙUÃî³¼VµÞjíèìév97¨M¬J·ÆåZ¹’ÿpªWÆ÷½–[¼Udå,.ÞI'4vÉ2c…Q¿ÁíÝûhªeÝ<ïNdKÚcôaïKnßív*mvz°Dqþë¼ÙùSzðØ5IJ—¡xß}eXv¿4ŸXÇ0Þ/Ê]˜’–VV²°lÖñ~úõ§Æ©Ó85ìóJu‚GÚïÑÊÃ•¹6Ð=¢b“æþ´uíHÇC;»J
+*‹ë[»œå£vYÂWïxø™UTV¯ÅÅŒ!Kyñ	ïÌ‘ÿz¡Ñ°ÀeÙòÔkC-žÍz¬®r{Å—¦·0I_½Ã_üÛBþçÈÃøõÍPcýóói•ªÀSX0!
+_e1#DæÊ)vÜšetFGilNUiºG©]­T§eÇUª
+V¥seëõ7õéÙÑ¿bç~O'ÇÛMñÒŠ×Ö£jây¡Ñ>osÅ±‘Z™9Mh¡w…Òe==µ oih`745Ömhç-gä&nx™2Äùœß$•¹îÆÜÆrAh5jXØqê„æýMááíz=¯ûä‘0Þ$çõ·}n`£µÍ*ÕÚúæa•)†	×6	ªµ«JœÖ·j£KN'_¶I6áZx«‘‹µ<è½ûÙ»œ6ây9.Æõ ýï³¾AƒV›AÕÐ]Þìãî™xÙHËb=‡é]e‡ÙÎhìüP…÷ŠD=Ôã¡,' =XŒ,g×åiXR£›6Î }gSž°—¬G1%Œ)—dóÇ‡¦½¡BÈ«!$©¹³ñe¡ƒÅ¶¿h£ƒƒÚ÷'éÈ€Bè7­t<'ùM¼…õkF†nTæäÕÂ€>I
+?„Õ~l\Í`ÍãÑö1®æSxwýœÝ;Ö½}¹ÞmÂ¾|õ§c¢/_©‰dÏkî‹´«¶¹ÏÊtØ—oF¾¼ImdUZäËkæœ¯õ;Þ¿(2sA¯½¡‹‡^;Ü¤kŠV{÷NµqAnûGô£Þuûž„n;}vxËXƒÝvÌOéÑmóÐk7^Ù,;Ì?‰½vh®RõÒ²ÖZè¸[¡ã^¾¨uù8Ç-NSÎÑw£¶ï0#”tBQÆ?·,®ë¢¹iö9¥:>/àÛí‚Ðµcjß®©Z6ÂÅŽTVUUm¿ôþÈ²*OQá ëë/*..ê½
+‹Æ{ý/çõë"§òú^[µ¬ªrøÒ»CÕ•Ü]—|½¸XŽî-.**F~ÀoÇ\P}ht©¢¤ nŒKç×-DÑz_3(ÌÔjá0hDf4V]Ýb3'FW]ÕHc6ZzÀÔ?hmÜmØÌîÚÒ´{Kðæø¿s¬™¡%¹®9(µ˜4mD±¨	Ç¢0i?}D.3ÊeºýŸëÙ(]ŒEu-8¹h1Õ®®—bÑ«É—ÕW5õ7¥.ïžM«@,X…¢Wº£ÜÈ:”FÇôÑ+„gÍüÁL ‰Áì…ªŠí\ìvh †/½¿½¢Š-Øš÷ŒlÜ„¸–\à}‹sTV •ßZ^QQÅì‚Aî™3[7n˜/¹xä"ÐˆèÂm´Í#HA®F¿%t FŠTu§ö¯zBiû5c^ãD5™—Y÷½õ3‰#´cÍ³‹…cvCsÕ®«høw‹ãm _Æ<tÂ8¹6xÌƒÿéþ¤1zÕºiSw8æQ£8¹ª—ZQUµíÒ»ƒÈBÜÖÖ ‘Ž3ÑH'ZÄL™Ì3ñPGŠ™h¨#ÆL|ÇÌAÌ¤@?}Ž¹oò\w?cýÍuÓÍÑ£3ÛÿFµL·ÿî¿òw—´/·ŽÖ]¥ByiIQ¶#ÒdP0nÍÀ7º;òôé_ž†Ÿ—_=}zæ›ug¼ÿÏSnê¥Kæ¸ß—»	ŠY|}¾‹oV!±Û¨–¬7'o†VýòÊ[<mÜ@û\|LlýìÏIÕ¿0˜që¨x?A%îÎœxG¬½Á7úÊ"^cËÌŠùÃ]ú$K˜#ÚâUŒSÂnqÙó³nò=ê;u³Âe.+¢†©¥©Íeº…fó„*²Ô*XÃ'a ä@Ob/ÈËHqXè²Ü4[<°Ö7ÐâeV Êôø
+O¬¬3äs›˜‹UØ£vŸx<:RiOO6<´ÑîŒ÷©ðž‹LË–à¤ë‚ú&Kó%ÖHWÚ»¾ßûî*¸!ÎTMm¦ê·¶o½´/æ‚æˆIÏCyÇÒÜŽÐ9`l¡LÀÎÊý¾ èyéŸ#°!x|ß*Kt+²Àì¨½M´áÉdt:<¹ú£÷Ù¥—_¤cÏ<u¬¥½½åØSgÎ?ÚÚÞÞzôøß¿=ñÑi*ŒÊúÍ‰N1™5Œf‚Î•ÿÑ)ßÿË¢=ì2ÿ]¼/?áÄ{©Ó`b9i1(Än»š…ùNme)u÷T+íÜýjFž§¬Ô·ž	Z©G;î˜7a/ã¬^§‘qJà4ãb/gÛx”FÛî¶y´éâ¦»mMLqgõ|;^‘7ú^•Öé#€b’ØÌI¾fÜ®„‰9yûíìÎhêgÑxÏ]'^:à³*_¸8ŒåóâÆüvÅ‰Ûkðôu<¬‚´ËDÜfí„÷ÏäPA{lBH‰»l¤Éj”+h£[^	w'Þ=£•ð*C­„ßš´þ]o{`%|tAoý°À2ºN;^Ç¯U±´ðhsËA%Mkûã¬¶çôÔÓ'ûF5gÍXÿŒÍjAëøê{–®¹EÍ2ÚMöÔÔ#V«e’ç„;—¬Y*7ãu|O¤ï*¼¯nD6?„×ÙÍ¥áÙE‰z½:³H4ÀÏ5;+ÇoØoÅ&õÇØ±W6µ±Í9ü›ë$AdB¶Ú{_d«ŒTVÊvstÕ¤•òˆ—ÑJùÍûúôwÏüÛî´Dæç“×æ%W_›Çûr°¿ãÒ`K1èVk¬.Ö¿ƒ ©†6VÂš³XÅy’czXqj…ºEôùÀz9ÈÝÃ[C¬–sëÇ/¾;ÑÒûüÌ‰KïxÜEæAþb¨tôEq'ï”¸JÂwA>“tó&WÃÆñ§Bíòáj¨~,Q%Ä=n°Ë€%4.”à_ð¡êñ^!öd@fB)ìIšÇ?ƒÇC•rÜ§¢.Š;ŽvB™C¡dÁþˆFN.›UÉžåÃpÞKòr9qx¯+à²éü°’’0ï¯Å_îhê¼êjß9Ô7åvî\L!o©>zt¹àOðèq|ÌiOlµôâÙÐ‹ç@/î‚^ZÁœ-b{ß~iÔ÷Á+ÇÞ~é2å:uô²íô±O(åÓß?}ìSßOŸ~kE¢ïýWŽž}ÉK¹ÐÏ(:‹dèý{Øã&ôÃÐýé@Gýkj'›ÄN¶NR+Yv¼©*>?o¤ôÄôV©gÇyb˜M¤–ªÉ@uAê1gV$øÎáÚR±¸îþJcÅ¸—F‹™W.D*Çœ:
+|œ:Ê~‚” JÜžÉ©¹AõÏŠO¦†®˜³¤oJö^ó¼6ïÍfdV|65l5ácÃ·œÇgÄKìësâƒëîÎ«ÁSÓÐF @ @ @ @ @ @ Âÿ[¶òû¾üøúDÖ55r;@ \£4ÉÉs#¬vV¼<5á¶9‘>KJ§äÆkž¦à‰¹¡X0+ŽM’!|Ð¾qV+ïÉ?Íˆ³âôÔ¨Ìs"y–NIaÖ4¨zfÄnÕ}„oêýÂ73oÌÍ¯	ßn´k¦á?fŠî;„ë¯¦Fß8c.®WÝÓpf¦ë×!W¦Æt`¦D®'\wüçÔ˜WÌ˜/„k›(~–¸gÉ‰¨ÑtôþkŒ÷@°˜-Õ!išVvVl†Ssâ³äü”|I˜-6™Í<#’móCP=Kú	@ @ ®3^$Â5ÈëßbÎ¾)ìñ@ @ @ @ @ @ @øGÐÇLePlL·Ã?1M-<Ó4PRš°_J³ & ÃHpTJóA22˜ú¥”–ƒ(Š•ÒaAiÈ¥Ê¥´2(Áì§n–Òª óBPÝ4ºi`Ýë9^JS€çZ¤4$Ãcà¼dqÛ¥´\¢”JAåˆ÷ZzA t€M`j{þe	òaª,ëÀjP	–ƒ2øç UPª¤ÁÔÐq€š@îA|´þn„enƒßHrØ
+Ïß ¥z@+”ë•¤:àù.Ð%‘DðõÔ	××àò¡D/”qÀº¥ÁÚeI%¯‚ôA	T·NÐ%QžxÜ‰kÔŒeÐÙ6(Õ¯nçz¡å§×p ×•2„k€ôqàz¢|Íð®Í0†u‚G 2ŒI›¡ä¬a*¼[/¬W/<×Š¿7CÙt¬q+,µ–ê‚¬?åû ]ðšx·v¬ó®Ï:˜F#~[±¥ðê&IW¿4:‡ìÜŠkÝŒëŸÛ°\¶ë>ƒ4@÷éÃ­@ÌÛ*•²Q:nÆe÷atC©!|åjÁõ@÷GõèÂ¡\þz‰9±µ&iè8ö—Ê:}ø¸æi…Ç)Ø^bKï›¸ÏDÄg6Œí„ÚXh›KšŠ-±Þ§MjÃ“mòtáT"”O‚¿¨mµHv	UºX‡¯kÛ±ÒÛpIRûDms k5$½¡4ðß}r½
+ƒÚ ÒDÔeß¯[³—/êÚÏcÍ{ñû4]Ûk×ª6âçÒ+}‹Z‰é­øÝÙŠs¢ÚúŸ¦¿$Ù%¦k£¢?ê‘žÌXéþ7¤S²2j?›°—è”ìœvu/ØöàŠåQ#Åuk{òÎ·”ÌÜ÷õäµ«:¬ý<ûÕò•ÿ•q$ãðûÏ£½ï‘Ñ³mç÷²V/ÙlÎèÈX½6þ\É†÷
+ý¡¤ßDøG·uõtHiË ˜^ÿÒÊ›{:SåÍð{`ËPŠ£¢¯¹'ÅQÙÜÓ¼pd +Å±t`ãxm¹GUóPtG9,Æ!Àv¶¶·À¿¡Î¶½½Ý=€_´¤jhi…¥‚M°T°i,´le€–.TÆ¦iófá¼y8oÎ›…ófá¼y0J£ÇâïdüMÃR3À<(1Ú…×¡gÈÀçQ*¦Ñy|.‘ðˆºÒ(þüÇ:Q°%S²Cð÷Ëÿª2¡sendstream
+endobj
+xref
+0 229
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000391 00000 n 
+0000000775 00000 n 
+0000001159 00000 n 
+0000001543 00000 n 
+0000001927 00000 n 
+0000002311 00000 n 
+0000002695 00000 n 
+0000003079 00000 n 
+0000003464 00000 n 
+0000003849 00000 n 
+0000004234 00000 n 
+0000004619 00000 n 
+0000005004 00000 n 
+0000005391 00000 n 
+0000005780 00000 n 
+0000006169 00000 n 
+0000006558 00000 n 
+0000006947 00000 n 
+0000007336 00000 n 
+0000007725 00000 n 
+0000008114 00000 n 
+0000008503 00000 n 
+0000008892 00000 n 
+0000009281 00000 n 
+0000009670 00000 n 
+0000010059 00000 n 
+0000010448 00000 n 
+0000010837 00000 n 
+0000011226 00000 n 
+0000011615 00000 n 
+0000012004 00000 n 
+0000012393 00000 n 
+0000012782 00000 n 
+0000013171 00000 n 
+0000013560 00000 n 
+0000013949 00000 n 
+0000014338 00000 n 
+0000014727 00000 n 
+0000015116 00000 n 
+0000015505 00000 n 
+0000015894 00000 n 
+0000016073 00000 n 
+0000016260 00000 n 
+0000016400 00000 n 
+0000016626 00000 n 
+0000017470 00000 n 
+0000017527 00000 n 
+0000017584 00000 n 
+0000017729 00000 n 
+0000017915 00000 n 
+0000018066 00000 n 
+0000018242 00000 n 
+0000018421 00000 n 
+0000018608 00000 n 
+0000018748 00000 n 
+0000018974 00000 n 
+0000019153 00000 n 
+0000019340 00000 n 
+0000019480 00000 n 
+0000019706 00000 n 
+0000019885 00000 n 
+0000020072 00000 n 
+0000020212 00000 n 
+0000020438 00000 n 
+0000020617 00000 n 
+0000020804 00000 n 
+0000020944 00000 n 
+0000021170 00000 n 
+0000021349 00000 n 
+0000021536 00000 n 
+0000021676 00000 n 
+0000021902 00000 n 
+0000022081 00000 n 
+0000022268 00000 n 
+0000022408 00000 n 
+0000022634 00000 n 
+0000022813 00000 n 
+0000023000 00000 n 
+0000023140 00000 n 
+0000023366 00000 n 
+0000023545 00000 n 
+0000023732 00000 n 
+0000023872 00000 n 
+0000024098 00000 n 
+0000024277 00000 n 
+0000024464 00000 n 
+0000024604 00000 n 
+0000024830 00000 n 
+0000025009 00000 n 
+0000025196 00000 n 
+0000025336 00000 n 
+0000025562 00000 n 
+0000025741 00000 n 
+0000025928 00000 n 
+0000026068 00000 n 
+0000026294 00000 n 
+0000026473 00000 n 
+0000026660 00000 n 
+0000026801 00000 n 
+0000027028 00000 n 
+0000027208 00000 n 
+0000027396 00000 n 
+0000027537 00000 n 
+0000027764 00000 n 
+0000027944 00000 n 
+0000028132 00000 n 
+0000028273 00000 n 
+0000028500 00000 n 
+0000028680 00000 n 
+0000028868 00000 n 
+0000029009 00000 n 
+0000029236 00000 n 
+0000029416 00000 n 
+0000029604 00000 n 
+0000029745 00000 n 
+0000029972 00000 n 
+0000030152 00000 n 
+0000030340 00000 n 
+0000030481 00000 n 
+0000030708 00000 n 
+0000030888 00000 n 
+0000031076 00000 n 
+0000031217 00000 n 
+0000031444 00000 n 
+0000031624 00000 n 
+0000031812 00000 n 
+0000031953 00000 n 
+0000032180 00000 n 
+0000032360 00000 n 
+0000032548 00000 n 
+0000032689 00000 n 
+0000032916 00000 n 
+0000033096 00000 n 
+0000033284 00000 n 
+0000033425 00000 n 
+0000033652 00000 n 
+0000033832 00000 n 
+0000034020 00000 n 
+0000034161 00000 n 
+0000034388 00000 n 
+0000034568 00000 n 
+0000034756 00000 n 
+0000034897 00000 n 
+0000035124 00000 n 
+0000035304 00000 n 
+0000035492 00000 n 
+0000035633 00000 n 
+0000035860 00000 n 
+0000036040 00000 n 
+0000036228 00000 n 
+0000036369 00000 n 
+0000036596 00000 n 
+0000036776 00000 n 
+0000036964 00000 n 
+0000037105 00000 n 
+0000037332 00000 n 
+0000037512 00000 n 
+0000037700 00000 n 
+0000037841 00000 n 
+0000038068 00000 n 
+0000038248 00000 n 
+0000038436 00000 n 
+0000038577 00000 n 
+0000038804 00000 n 
+0000038984 00000 n 
+0000039172 00000 n 
+0000039313 00000 n 
+0000039540 00000 n 
+0000039720 00000 n 
+0000039908 00000 n 
+0000040049 00000 n 
+0000040276 00000 n 
+0000040456 00000 n 
+0000040644 00000 n 
+0000040785 00000 n 
+0000041012 00000 n 
+0000041192 00000 n 
+0000041380 00000 n 
+0000041521 00000 n 
+0000041748 00000 n 
+0000041928 00000 n 
+0000042116 00000 n 
+0000042257 00000 n 
+0000042484 00000 n 
+0000042664 00000 n 
+0000042852 00000 n 
+0000042993 00000 n 
+0000043220 00000 n 
+0000043400 00000 n 
+0000043588 00000 n 
+0000043729 00000 n 
+0000043956 00000 n 
+0000044136 00000 n 
+0000044324 00000 n 
+0000044465 00000 n 
+0000044692 00000 n 
+0000044872 00000 n 
+0000045060 00000 n 
+0000045201 00000 n 
+0000045428 00000 n 
+0000045608 00000 n 
+0000045796 00000 n 
+0000045937 00000 n 
+0000046164 00000 n 
+0000046344 00000 n 
+0000046532 00000 n 
+0000046673 00000 n 
+0000046900 00000 n 
+0000046922 00000 n 
+0000046951 00000 n 
+0000047363 00000 n 
+0000047616 00000 n 
+0000047641 00000 n 
+0000047670 00000 n 
+0000047965 00000 n 
+0000048208 00000 n 
+0000048233 00000 n 
+0000048410 00000 n 
+0000048593 00000 n 
+0000048669 00000 n 
+0000048941 00000 n 
+0000049261 00000 n 
+0000049337 00000 n 
+0000049617 00000 n 
+0000049660 00000 n 
+0000093153 00000 n 
+trailer << /Root 1 0 R /Size 229 /ID [<e99b210cec2337b88a4a3a6a129b0754><e99b210cec2337b88a4a3a6a129b0754>] >>
+startxref
+126902
+%%EOF

--- a/packages/pdfrx/test/lazy_loading_test.dart
+++ b/packages/pdfrx/test/lazy_loading_test.dart
@@ -1,0 +1,244 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:pdfrx/pdfrx.dart';
+
+/// Tests for `loadPageDimensionsOnDemand`.
+///
+/// These drive the real PDFium through a fake HTTP layer, so they exercise the
+/// actual demand-paging path rather than a stand-in. PDFium cannot be downloaded
+/// from inside a widget test (`TestWidgetsFlutterBinding` fails every HTTP
+/// request), so the module has to be supplied:
+///
+///     PDFIUM_PATH=/path/to/pdfium.dll flutter test
+///
+/// `tool/fetch_pdfium.sh` downloads a matching build and prints the path.
+///
+/// Note these pump explicit durations rather than calling `pumpAndSettle`: the
+/// viewer keeps a periodic timer alive for as long as it is mounted, so the tree
+/// never reaches a settled state and `pumpAndSettle` would spin until it times
+/// out.
+final binding = TestWidgetsFlutterBinding.ensureInitialized();
+
+final _pdfiumPath = Platform.environment['PDFIUM_PATH'];
+final _fixture = File('test/assets/multipage40.pdf');
+
+/// Serves [_fixture] over a fake network, honouring `Range` the way S3 does.
+///
+/// [onRequest] observes every request, which is how the tests below assert what
+/// was actually fetched.
+MockClient _rangeAwareServer({
+  required List<String> requestLog,
+  Duration latency = Duration.zero,
+  bool supportRanges = true,
+  int failFirstNRequests = 0,
+}) {
+  var failuresLeft = failFirstNRequests;
+  final bytes = _fixture.readAsBytesSync();
+
+  return MockClient((request) async {
+    requestLog.add(request.headers['Range'] ?? 'full');
+    if (latency > Duration.zero) await Future.delayed(latency);
+
+    if (failuresLeft > 0) {
+      failuresLeft--;
+      return http.Response('boom', 500);
+    }
+
+    final range = request.headers['Range'];
+    if (!supportRanges || range == null) {
+      return http.Response.bytes(bytes, 200, headers: {'content-length': '${bytes.length}'});
+    }
+
+    final m = RegExp(r'bytes=(\d+)-(\d+)').firstMatch(range)!;
+    final start = int.parse(m.group(1)!);
+    final end = int.parse(m.group(2)!).clamp(0, bytes.length - 1);
+    final slice = bytes.sublist(start, end + 1);
+    return http.Response.bytes(
+      slice,
+      206,
+      headers: {
+        'content-range': 'bytes $start-$end/${bytes.length}',
+        'content-length': '${slice.length}',
+      },
+    );
+  });
+}
+
+Future<PdfDocument?> _pumpViewer(
+  WidgetTester tester, {
+  required bool onDemand,
+  required List<String> requestLog,
+  Duration latency = Duration.zero,
+  bool supportRanges = true,
+  int failFirstNRequests = 0,
+}) async {
+  Pdfrx.createHttpClient = () => _rangeAwareServer(
+    requestLog: requestLog,
+    latency: latency,
+    supportRanges: supportRanges,
+    failFirstNRequests: failFirstNRequests,
+  );
+
+  PdfDocument? captured;
+  await binding.setSurfaceSize(const Size(1080, 1920));
+  await tester.pumpWidget(
+    MaterialApp(
+      home: PdfViewer.uri(
+        Uri.parse('https://example.test/multipage40.pdf'),
+        preferRangeAccess: true,
+        params: PdfViewerParams(
+          behaviorControlParams: PdfViewerBehaviorControlParams(
+            loadPageDimensionsOnDemand: onDemand,
+          ),
+          onDocumentChanged: (doc) => captured = doc,
+        ),
+      ),
+    ),
+  );
+
+  // Loading is real I/O -- a cache file on disk plus the HTTP client -- and none
+  // of that progresses inside the fake-async zone that tester.pump() runs in.
+  // runAsync steps outside it; the pump after each step lets the widget tree
+  // react to whatever landed.
+  for (var i = 0; i < 30; i++) {
+    await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 50)));
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+  return captured;
+}
+
+int _measuredCount(PdfDocument doc) => doc.pages.where((p) => p.isLoaded).length;
+
+void main() {
+  late Directory cacheDir;
+
+  setUpAll(() {
+    if (_pdfiumPath == null) return;
+    Pdfrx.pdfiumModulePath = _pdfiumPath;
+    // The block cache needs somewhere to live. pdfrxFlutterInitialize would
+    // normally point this at path_provider, which throws under flutter_test
+    // because there is no platform channel -- and it throws before any HTTP is
+    // attempted, so the symptom is a document that never loads and a request
+    // log that stays empty.
+    cacheDir = Directory.systemTemp.createTempSync('pdfrx_lazy_test');
+    Pdfrx.getCacheDirectory = () => cacheDir.path;
+  });
+
+  tearDownAll(() {
+    if (_pdfiumPath == null) return;
+    try {
+      cacheDir.deleteSync(recursive: true);
+    } catch (_) {}
+  });
+
+  setUp(() {
+    // Each test must start with a cold block cache, or the second test in a run
+    // measures a document whose bytes are already resident and proves nothing.
+    for (final f in cacheDir.listSync()) {
+      try {
+        f.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  });
+
+  setUp(() async {
+    await pdfrxInitialize();
+  });
+
+  tearDown(() {
+    Pdfrx.createHttpClient = null;
+  });
+
+  group('loadPageDimensionsOnDemand', () {
+    testWidgets('off: every page in the document is measured up front', (tester) async {
+      final log = <String>[];
+      final doc = await _pumpViewer(tester, onDemand: false, requestLog: log);
+
+      expect(doc, isNotNull, reason: 'onDocumentChanged should have fired');
+      expect(doc!.pages.length, 40);
+      expect(
+        _measuredCount(doc),
+        40,
+        reason: 'the stock path walks the whole document before painting',
+      );
+    }, skip: _pdfiumPath == null);
+
+    testWidgets('on: only pages near the viewport are measured', (tester) async {
+      final log = <String>[];
+      final doc = await _pumpViewer(tester, onDemand: true, requestLog: log);
+
+      expect(doc, isNotNull);
+      expect(doc!.pages.length, 40, reason: 'page count still comes from the page tree');
+      expect(
+        _measuredCount(doc),
+        lessThan(40),
+        reason: 'measuring every page is exactly what this flag exists to avoid',
+      );
+      expect(
+        _measuredCount(doc),
+        greaterThan(0),
+        reason: 'the visible pages must still be measured or nothing can paint',
+      );
+    }, skip: _pdfiumPath == null);
+
+    testWidgets('on: fetches strictly less than the whole file', (tester) async {
+      final onDemandLog = <String>[];
+      await _pumpViewer(tester, onDemand: true, requestLog: onDemandLog);
+      final onDemandRequests = onDemandLog.length;
+
+      final eagerLog = <String>[];
+      await _pumpViewer(tester, onDemand: false, requestLog: eagerLog);
+
+      expect(
+        onDemandRequests,
+        lessThanOrEqualTo(eagerLog.length),
+        reason: 'demand paging must not fetch more than the eager path',
+      );
+    }, skip: _pdfiumPath == null);
+  });
+
+  group('degraded networks', () {
+    testWidgets('server that ignores Range still opens the document', (tester) async {
+      final log = <String>[];
+      final doc = await _pumpViewer(
+        tester,
+        onDemand: true,
+        requestLog: log,
+        supportRanges: false,
+      );
+
+      expect(doc, isNotNull, reason: 'a 200 with the whole body must still work');
+      expect(doc!.pages.length, 40);
+    }, skip: _pdfiumPath == null);
+
+    testWidgets('slow link does not lose the document', (tester) async {
+      final log = <String>[];
+      final doc = await _pumpViewer(
+        tester,
+        onDemand: true,
+        requestLog: log,
+        latency: const Duration(milliseconds: 120),
+      );
+
+      expect(doc, isNotNull);
+      expect(doc!.pages.length, 40);
+    }, skip: _pdfiumPath == null);
+
+    testWidgets('a failing first request surfaces as an error, not a hang', (tester) async {
+      final log = <String>[];
+      final doc = await _pumpViewer(
+        tester,
+        onDemand: true,
+        requestLog: log,
+        failFirstNRequests: 99,
+      );
+
+      expect(doc, isNull, reason: 'no document should be produced when every fetch 500s');
+      expect(log, isNotEmpty, reason: 'it must have tried');
+    }, skip: _pdfiumPath == null);
+  });
+}

--- a/packages/pdfrx_engine/lib/src/native/pdf_file_cache.dart
+++ b/packages/pdfrx_engine/lib/src/native/pdf_file_cache.dart
@@ -81,6 +81,21 @@ class PdfFileCache {
     return min(countCached * blockSize, fileSize);
   }
 
+  /// Whether every block of the file is resident, so the cache file holds the
+  /// complete document rather than a sparse copy of it.
+  ///
+  /// Only worth asking before treating the cache file as a plain PDF. A sparse
+  /// cache file is not a truncated PDF -- it is a full-length one with holes of
+  /// zeroes where blocks were never fetched -- which pdfium opens without
+  /// complaint and renders as blank pages.
+  bool get isFullyCached {
+    if (!isInitialized) return false;
+    for (var i = 0; i < totalBlocks; i++) {
+      if (!isCached(i)) return false;
+    }
+    return true;
+  }
+
   bool get isInitialized => _initialized;
 
   Future<void> close() async {
@@ -349,7 +364,18 @@ Future<PdfDocument> pdfDocumentFromUri(
         );
         // cached file has expired
         // if the file has fully downloaded again or has not been modified
-        if (result.isFullDownload || result.notModified) {
+        //
+        // Only take this shortcut when the cache file really is the whole
+        // document. A 304 says the blocks we hold are still valid -- it says
+        // nothing about how many we hold. Opening a sparse cache file as a plain
+        // PDF hands pdfium a full-length file whose unfetched blocks are zeroes:
+        // it finds the header, rebuilds the xref from whatever objects happen to
+        // be present, and opens successfully. Every page backed by a block that
+        // was never fetched then renders blank, permanently and without an
+        // error, because this path has no way to fetch anything else. Falling
+        // through to the demand-paging reader below is both correct and what the
+        // 304 actually licenses.
+        if (result.isFullDownload || (result.notModified && cache.isFullyCached)) {
           cache.close(); // close the cache file before opening it.
           httpClientWrapper.reset();
           return await entryFunctions.openFile(
@@ -357,6 +383,13 @@ Future<PdfDocument> pdfDocumentFromUri(
             passwordProvider: passwordProvider,
             firstAttemptByEmptyPassword: firstAttemptByEmptyPassword,
             useProgressiveLoading: useProgressiveLoading,
+          );
+        }
+        if (result.notModified && Pdfrx.debugLazyLoading) {
+          pdfrxLazyLog(
+            'REVALIDATE 304 for $uri -- cache holds ${_fmtBytes(cache.cachedBytes)} of '
+            '${_fmtBytes(cache.fileSize)}, so continuing with demand paging instead of '
+            'opening the sparse cache file directly',
           );
         }
       }
@@ -511,7 +544,27 @@ Future<_DownloadResult> _downloadBlock(
     await cache.initializeWithFileSize(fileSize, truncateExistingContent: false);
     await cache.setCached(0, lastBlock: cache.totalBlocks - 1);
   } else {
-    await cache.setCached(blockId, lastBlock: blockId + blockCount - 1);
+    // Mark only what actually arrived. A block marked resident on bytes that
+    // never landed is unrecoverable: every later read is served from the cache
+    // file, returns the zeroes sitting in the hole, and the page renders blank
+    // with no error and no retry. Short responses should not happen against a
+    // well-behaved server, which is exactly why this needs to be loud.
+    final bytesExpected = min(cache.blockSize * blockCount, cache.fileSize - blockOffset);
+    if (bytesThisRequest < bytesExpected) {
+      final blocksFilled = bytesThisRequest ~/ cache.blockSize;
+      if (Pdfrx.debugLazyLoading) {
+        pdfrxLazyLog(
+          'FETCH block $blockId SHORT -- asked for ${_fmtBytes(bytesExpected)}, got '
+          '${_fmtBytes(bytesThisRequest)}; marking $blocksFilled of $blockCount block(s) resident '
+          'so the rest is re-fetched rather than read back as zeroes',
+        );
+      }
+      if (blocksFilled > 0) {
+        await cache.setCached(blockId, lastBlock: blockId + blocksFilled - 1);
+      }
+    } else {
+      await cache.setCached(blockId, lastBlock: blockId + blockCount - 1);
+    }
   }
 
   if (Pdfrx.debugLazyLoading) {

--- a/packages/pdfrx_engine/lib/src/native/pdf_file_cache.dart
+++ b/packages/pdfrx_engine/lib/src/native/pdf_file_cache.dart
@@ -18,6 +18,10 @@ import 'http_cache_control.dart';
 import 'native_utils.dart';
 import 'package:pdfium_dart/pdfium_dart.dart' as pdfium_bindings;
 
+String _fmtBytes(int bytes) => bytes >= 1024 * 1024
+    ? '${(bytes / (1024 * 1024)).toStringAsFixed(2)}MB'
+    : '${(bytes / 1024).toStringAsFixed(1)}KB';
+
 final _rafFinalizer = Finalizer<RandomAccessFile>((raf) {
   // Attempt to close the file if it hasn't been closed explicitly.
   // Use try-catch as close might fail or already be closed.
@@ -486,10 +490,13 @@ Future<_DownloadResult> _downloadBlock(
 
   var offset = blockOffset;
   var cachedBytesSoFar = cache.cachedBytes;
+  var bytesThisRequest = 0;
   await for (final bytes in response.stream) {
     await cache.write(offset, bytes);
     offset += bytes.length;
     cachedBytesSoFar += bytes.length;
+    bytesThisRequest += bytes.length;
+    Pdfrx.debugBytesFetched += bytes.length;
     progressCallback?.call(cachedBytesSoFar, fileSize);
   }
 
@@ -505,6 +512,22 @@ Future<_DownloadResult> _downloadBlock(
     await cache.setCached(0, lastBlock: cache.totalBlocks - 1);
   } else {
     await cache.setCached(blockId, lastBlock: blockId + blockCount - 1);
+  }
+
+  if (Pdfrx.debugLazyLoading) {
+    if (isFullDownload) {
+      pdfrxLazyLog(
+        'FETCH whole file ${_fmtBytes(bytesThisRequest)} -- the server ignored '
+        'the Range header, so demand paging is NOT in effect',
+      );
+    } else {
+      final resident = cache.fileSize > 0 ? cache.cachedBytes * 100 ~/ cache.fileSize : 0;
+      pdfrxLazyLog(
+        'FETCH block $blockId  bytes=$blockOffset-${end - 1}  HTTP ${response.statusCode}  '
+        'got ${_fmtBytes(bytesThisRequest)}  '
+        'resident ${_fmtBytes(cache.cachedBytes)}/${_fmtBytes(cache.fileSize)} ($resident%)',
+      );
+    }
   }
 
   return _DownloadResult(fileSize!, isFullDownload, false);

--- a/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
+++ b/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
@@ -833,11 +833,15 @@ class _PdfDocumentPdfium extends PdfDocument {
       }, (docAddress: document.address, pageNumbersToReload: pageNumbersToReload, currentPageCount: _pages.length));
 
       final newPages = [..._pages];
-      for (var i = 0; i < results.pages.length; i++) {
-        final pageData = results.pages[i];
+      for (final pageData in results.pages) {
+        // When [pageNumbersToReload] is given the worker returns only that
+        // subset, so a result's position in the list says nothing about which
+        // page it is; keying off it would write page N's dimensions over page 1.
+        // The worker records the real index, so use that.
+        final index = pageData.pageIndex;
         final newPage = _PdfPagePdfium._(
           document: this,
-          pageNumber: i + 1,
+          pageNumber: index + 1,
           width: pageData.width,
           height: pageData.height,
           rotation: PdfPageRotation.values[pageData.rotation],
@@ -845,9 +849,11 @@ class _PdfDocumentPdfium extends PdfDocument {
           bbBottom: pageData.bbBottom,
           isLoaded: true,
         );
-        if (i < newPages.length) {
-          newPages[i] = newPage;
+        if (index < newPages.length) {
+          newPages[index] = newPage;
         } else {
+          // Pages appended because the document grew. pageNumbersToLoad is a
+          // sorted set, so these arrive in ascending order and stay contiguous.
           newPages.add(newPage);
         }
       }

--- a/packages/pdfrx_engine/lib/src/pdfrx.dart
+++ b/packages/pdfrx_engine/lib/src/pdfrx.dart
@@ -1,13 +1,38 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
+
+/// Emits a [Pdfrx.debugLazyLoading] trace line.
+///
+/// Callers are expected to check the flag themselves so that building the
+/// message costs nothing when tracing is off.
+void pdfrxLazyLog(String message) => developer.log(message, name: 'pdfrx.lazy');
 
 /// Class to provide Pdfrx's configuration.
 /// The parameters should be set before calling any Pdfrx's functions.
 ///
 class Pdfrx {
   Pdfrx._();
+
+  /// Trace demand-paged loading to the console.
+  ///
+  /// When enabled, every HTTP range fetch is logged with the block it filled,
+  /// the byte range requested and how much of the file is resident so far. The
+  /// viewer additionally logs which pages it measures on demand, and when a
+  /// measurement changes the document layout.
+  ///
+  /// Intended for working out what a network document actually pulls down. Off
+  /// by default; costs nothing while disabled.
+  static bool debugLazyLoading = false;
+
+  /// Total bytes pulled over HTTP since process start, across all documents.
+  ///
+  /// Sampled around an operation to attribute its wall-clock time: a slow page
+  /// measurement that moves this counter was waiting on the network, one that
+  /// does not was waiting on the pdfium worker.
+  static int debugBytesFetched = 0;
 
   /// Explicitly specify pdfium module path for special purpose.
   ///

--- a/packages/pdfrx_engine/pubspec.yaml
+++ b/packages/pdfrx_engine/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/espresso3389/pdfrx/issues
 
 environment:
   sdk: ^3.9.0
-resolution: workspace
+# resolution: workspace
 
 # Some of the dependencies are intentionally not pinned to a specific version
 # to allow for more flexibility in resolving versions when used in larger projects.


### PR DESCRIPTION
## Summary

Large remote PDFs with `preferRangeAccess: true` still blocked first paint until
*every* page was measured. Measurement walks each page dictionary; on linearized
files those dictionaries are spread across the file, so the viewer faulted the
whole file (1 MB blocks, serialized) before painting page 1.

This PR adds an **opt-in** path (`loadPageDimensionsOnDemand`, default `false`)
that measures only pages entering the existing render-cache extent, plus related
correctness fixes that show up once range access continues for the document lifetime.

Based on tag `pdfrx-v2.2.24` (not rebased onto current master). Happy to rebase
if preferred.

### Changes
- **Opt-in lazy measurement** (`PdfViewerBehaviorControlParams.loadPageDimensionsOnDemand`):
  skip exhaustive `loadPagesProgressively`; measure visible pages via `reloadPages`;
  fire `onDocumentLoadFinished` when the progressive pass is skipped.
- **Concurrent visible-page measurement** with a 3-attempt failure budget (no permanent blacklist for transient errors).
- **`reloadPages` subset fix**: apply worker results by `pageIndex` (was using list position).
- **Sparse HTTP cache / blank pages**: do not treat a 304 cache file as a complete PDF unless fully resident; mark only blocks that actually arrived as resident.
- **Debug**: `Pdfrx.debugLazyLoading` / fetch byte counters; tests with real PDFium over a fake Range-aware HTTP client + fixture.

### Trade-offs when the flag is on
- Unvisited page sizes stay estimates until scrolled into view.
- Whole-document text search / `loadText` only covers measured pages.
- Default path unchanged when the flag is off.

Motivation / deeper write-up: handwritten-notes demand paging in a Flutter app
serving large chapter PDFs over HTTP range requests.

## Test plan
- [ ] Default (`loadPageDimensionsOnDemand: false`) behavior unchanged.
- [ ] Large linearized URI + `preferRangeAccess: true` + flag on → early first paint; progressive MEASURE logs.
- [ ] Reopen after partial download / 304 → no permanent blank pages.
- [ ] `PDFIUM_PATH=... flutter test packages/pdfrx/test/lazy_loading_test.dart`