### PR TITLE
fix: BackgroundWorker.compute hangs forever on a genuinely async callback

### DIFF
--- a/packages/pdfrx_engine/lib/src/native/worker.dart
+++ b/packages/pdfrx_engine/lib/src/native/worker.dart
@@ -109,7 +109,17 @@ class BackgroundWorker {
   /// Inside [callback], you can only use passed message and create new objects.
   /// You cannot access any variables from the outer scope, otherwise, it will throw an error.
   Future<R> _compute<M, R>(PdfrxComputeCallback<M, R> callback, M message) async {
-    return await _sendComputeParams((sendPort) => _ExecuteParams(sendPort, callback, message)) as R;
+    final result = await _sendComputeParams((sendPort) => _ExecuteParams(sendPort, callback, message));
+    if (result is _ComputeError) {
+      // The original error/stack trace object may itself be unsendable (arbitrary user exception types can hold
+      // non-sendable fields), so only their string forms cross the isolate boundary; reconstruct a generic
+      // exception here rather than losing the failure silently.
+      Error.throwWithStackTrace(
+        _WorkerComputeException(result.errorString),
+        StackTrace.fromString(result.stackTraceString),
+      );
+    }
+    return (result as _ComputeResult<R>).value;
   }
 
   /// Runs [callback] in the worker isolate with a new [Arena].
@@ -162,8 +172,43 @@ class _ExecuteParams<M, R> extends _ComputeParams {
   final PdfrxComputeCallback<M, R> callback;
   final M message;
 
+  // A pending Future is not a sendable isolate message on its own (SendPort.send throws
+  // "object is unsendable" for it), so a callback returning FutureOr<R> only worked by
+  // accident for callbacks that happened to complete synchronously. Awaiting the result
+  // here, and always sending a plain, sendable wrapper (value or stringified error),
+  // makes genuinely asynchronous callbacks (and synchronous throws) work correctly too.
   @override
-  void execute() => sendPort.send(callback(message));
+  void execute() {
+    Future<R> asFuture() async => callback(message);
+    asFuture().then(
+      (value) => sendPort.send(_ComputeResult<R>(value)),
+      onError: (Object error, StackTrace stackTrace) =>
+          sendPort.send(_ComputeError(error.toString(), stackTrace.toString())),
+    );
+  }
+}
+
+class _ComputeResult<R> {
+  _ComputeResult(this.value);
+  final R value;
+}
+
+class _ComputeError {
+  _ComputeError(this.errorString, this.stackTraceString);
+  final String errorString;
+  final String stackTraceString;
+}
+
+/// Thrown on the caller's isolate when a [BackgroundWorker.compute] callback throws.
+///
+/// The original error object is not necessarily sendable across the isolate boundary,
+/// so only its [toString] representation survives the round trip; [message] carries it.
+class _WorkerComputeException implements Exception {
+  _WorkerComputeException(this.message);
+  final String message;
+
+  @override
+  String toString() => 'Exception in BackgroundWorker.compute callback: $message';
 }
 
 class _SuspendRequest extends _ComputeParams {

--- a/packages/pdfrx_engine/test/background_worker_test.dart
+++ b/packages/pdfrx_engine/test/background_worker_test.dart
@@ -1,0 +1,62 @@
+import 'package:pdfrx_engine/pdfrx_engine.dart';
+import 'package:pdfrx_engine/src/native/worker.dart';
+import 'package:test/test.dart';
+
+import 'utils.dart';
+
+void main() {
+  setUp(() => pdfrxInitialize(tmpPath: tmpRoot.path));
+
+  group('BackgroundWorker.compute', () {
+    test('still supports a synchronous callback (regression)', () async {
+      final result = await BackgroundWorker.compute((message) => message * 2, 21);
+      expect(result, 42);
+    });
+
+    test('supports a genuinely asynchronous callback with a real await', () async {
+      final sw = Stopwatch()..start();
+      final result = await BackgroundWorker.compute((message) async {
+        await Future.delayed(const Duration(milliseconds: 300));
+        return message * 2;
+      }, 21);
+      sw.stop();
+      expect(result, 42);
+      expect(
+        sw.elapsedMilliseconds,
+        greaterThanOrEqualTo(280),
+        reason: 'the delay must actually have been awaited, not skipped',
+      );
+    });
+
+    test('supports multiple sequential awaits inside one async callback', () async {
+      final result = await BackgroundWorker.compute((message) async {
+        var total = 0;
+        for (var i = 0; i < 3; i++) {
+          await Future.delayed(const Duration(milliseconds: 20));
+          total += i;
+        }
+        return total;
+      }, null);
+      expect(result, 0 + 1 + 2);
+    });
+
+    test('propagates a synchronous throw as an exception on the caller side', () async {
+      await expectLater(
+        BackgroundWorker.compute((message) {
+          throw StateError('boom: $message');
+        }, 'sync'),
+        throwsA(isA<Exception>().having((e) => e.toString(), 'toString', contains('boom: sync'))),
+      );
+    });
+
+    test('propagates an asynchronous throw as an exception on the caller side', () async {
+      await expectLater(
+        BackgroundWorker.compute((message) async {
+          await Future.delayed(const Duration(milliseconds: 10));
+          throw StateError('boom: $message');
+        }, 'async'),
+        throwsA(isA<Exception>().having((e) => e.toString(), 'toString', contains('boom: async'))),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem

`BackgroundWorker.compute()` hangs forever (never resolves, no error surfaced) when the callback passed to it does genuine asynchronous work — i.e. actually awaits something instead of completing synchronously.

## Root cause

`_ExecuteParams.execute()` ran:

```dart
sendPort.send(callback(message));
```

`callback` returns `FutureOr<R>`. When it happens to complete synchronously, this works by accident, since the value is already a plain `R`. But when it returns a *pending* `Future<R>` (real async work), `SendPort.send()` throws:

```
Invalid argument(s): Illegal argument in isolate message: object is unsendable - Library:'dart:async' Class: _Future
```

A pending `Future` is not a sendable isolate message. This throw happens inside the worker isolate, where it's swallowed — the caller's `await receivePort.first` just waits forever with no error ever crossing back.

A related gap: a *synchronous* throw inside the callback also had no error-forwarding path, so that case hung too.

## Fix

`execute()` now always awaits the callback (via an `async` closure, so sync and async callbacks are handled the same way) and sends back one of two plain, always-sendable wrapper objects instead of the raw result:

- `_ComputeResult<R>(value)` on success
- `_ComputeError(errorString, stackTraceString)` on failure — the original error/stack trace objects aren't guaranteed sendable either (arbitrary exception types can hold non-sendable fields), so only their string forms cross the isolate boundary

The caller side (`_compute()`) checks for `_ComputeError` and rethrows a `_WorkerComputeException` with the reconstructed stack trace; otherwise it unwraps `_ComputeResult.value`.

## Testing

Added `test/background_worker_test.dart` covering:
- the original synchronous case (no regression)
- a callback that does genuine async work (real `await`)
- a callback with multiple sequential `await`s
- a callback that throws synchronously
- a callback that throws asynchronously (after an `await`)

All pass. `dart analyze` is clean, no regressions in the existing suite.
