### PR TITLE
Fix O(N²) page list update in pages setter (freezes UI on huge documents)

### DIFF
--- a/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
+++ b/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
@@ -1278,6 +1278,10 @@ class _PdfDocumentPdfium extends PdfDocument {
   set pages(Iterable<PdfPage> newPages) {
     final pages = <PdfPage>[];
     final changes = <int, PdfPageStatusChange>{};
+    final oldIndexByPage = HashMap<PdfPage, int>.identity();
+    for (var i = 0; i < _pages.length; i++) {
+      oldIndexByPage[_pages[i]] = i;
+    }
     for (final newPage in newPages) {
       if (pages.length < _pages.length) {
         final old = _pages[pages.length];
@@ -1295,7 +1299,7 @@ class _PdfDocumentPdfium extends PdfDocument {
       final updated = newPage.withPageNumber(newPageNumber);
       pages.add(updated);
 
-      final oldPageIndex = _pages.indexWhere((p) => identical(p, newPage));
+      final oldPageIndex = oldIndexByPage[newPage] ?? -1;
       if (oldPageIndex != -1) {
         changes[newPageNumber] = PdfPageStatusChange.moved(page: updated, oldPageNumber: oldPageIndex + 1);
       } else {


### PR DESCRIPTION
### Problem

`_PdfDocumentPdfium.pages` setter looks up each page's previous index with `_pages.indexWhere((p) => identical(p, newPage))`. During progressive page loading (`loadPagesProgressively` → `_loadPagesInLimitedTime`), every batch recreates all trailing (not-yet-loaded) page instances, so none of them hit the `identical` fast path and each one triggers a full O(N) scan — making every batch O(N²) on the caller's isolate (the UI isolate in Flutter apps).

For a 47,352-page document (a 1.9 GB aircraft maintenance manual), that is roughly 2.2 billion identity comparisons per batch: measured **~5.5 s of main-isolate freeze after every ~250 ms load batch**, repeating for the entire progressive-load run. The viewer is effectively frozen the whole time (0.3–10 fps while scrolling). Small documents don't show it because the cost is quadratic in page count.

### Fix

Build an identity map of the previous pages once per call and look up old indexes in O(1). `HashMap.identity()` preserves the exact `identical()` semantics of the original lookup, and `_pages` never contains duplicate identities (both internal producers create fresh instances per position), so behavior is unchanged.

### Results (iPhone, 1.9 GB / 47,352-page PDF)

| | before | after |
|---|---|---|
| main-isolate stall per load batch | 5.1–5.9 s | none observed |
| scroll fps | 0.3–10 | 46–113 |
| max frame gap | ~5,700 ms | 19–274 ms |
