### PR TITLE
Keep text selection alive during progressive page loading

### DIFF
--- a/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
@@ -540,7 +540,15 @@ class _PdfViewerState extends State<PdfViewer>
         _canvasLinkPainter.releaseLinksForPage(change.key);
         _textCache.remove(change.key);
       }
-      _clearTextSelections(invalidate: false);
+      // Only drop the selection if one of the changed pages is actually part of it;
+      // otherwise incremental loading of unrelated pages would keep clearing it.
+      if (hasSelectedText) {
+        final pageFrom = min(_selA!.text.pageNumber, _selB!.text.pageNumber);
+        final pageTo = max(_selA!.text.pageNumber, _selB!.text.pageNumber);
+        if (event.changes.keys.any((page) => page >= pageFrom && page <= pageTo)) {
+          _clearTextSelections(invalidate: false);
+        }
+      }
       _invalidate();
     } else if (event is PdfDocumentLoadCompleteEvent) {
       _notifyDocumentLoadFinished(succeeded: true);


### PR DESCRIPTION
### Problem

`_onDocumentEvent` unconditionally calls `_clearTextSelections` on every `PdfDocumentPageStatusChangedEvent`. During progressive loading of a large document these events arrive continuously (one per load batch, every ~250 ms), so any text selection the user makes is wiped almost immediately — on a 47,352-page document the selection context menu appears and vanishes within a fraction of a second, and text selection/copy is impossible until the whole document finishes loading.

### Fix

Clear the selection only when one of the changed pages actually falls inside the selected page range. Loading events for unrelated (typically far-away, not-yet-loaded) pages no longer destroy the user's selection, while a genuine change to a selected page still invalidates it as before.

Verified on an iPhone with a 1.9 GB / 47,352-page PDF: long-press selection and copy now work immediately after opening, while pages keep loading in the background.
