### PR TITLE
fix(PdfPageView): dispose the previous image before replacing it

### DIFF
--- a/packages/pdfrx/lib/src/widgets/pdf_widgets.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_widgets.dart
@@ -450,10 +450,13 @@ class _PdfPageViewState extends State<PdfPageView> {
     try {
       final newImage = await pageImage.createImage();
       pageImage.dispose();
-      _image = newImage;
-      if (mounted) {
-        setState(() {});
+      if (!mounted) {
+        newImage.dispose();
+        return;
       }
+      _image?.dispose();
+      _image = newImage;
+      setState(() {});
     } catch (e) {
       developer.log('Error creating image: $e');
       pageImage.dispose();


### PR DESCRIPTION
Fixes #697.

`_PdfPageViewState._updateImage` overwrites `_image` without disposing the previous one, so every re-render that changes the requested page size (a zoom tier change, a layout change, a `pageSizeCallback` returning a new size) orphans a full-resolution decoded `ui.Image`. The only `_image?.dispose()` in the class is in `_clearCache()`, which this path never calls.

It also lacked a `mounted` guard on the assignment — the existing check only guarded `setState`. If the widget was disposed during the `await`, `_clearCache()` had already run and nulled `_image`, and the assignment then wrote a fresh image into a dead `State` where nothing would ever dispose it.

This is the second half of #110, which was closed as fixed in 1.0.51; only the `dispose()` half landed.

The fix matches what `PdfViewer` already does in `pdf_viewer.dart` (lines 1760-1764 and 1847-1852): guard on `!mounted`, dispose the old image, then swap.

```dart
final newImage = await pageImage.createImage();
pageImage.dispose();
if (!mounted) {
  newImage.dispose();
  return;
}
_image?.dispose();
_image = newImage;
setState(() {});
```

Kept deliberately minimal — no reformatting, no changelog entry (happy to add one if you'd like). I could not run `dart analyze` against the workspace locally: dependency resolution fails on `meta` (`pdfium_flutter` wants 1.17.0 via the Flutter SDK's `flutter_test`, `pdfrx_engine` wants ^1.18.0). That failure reproduces identically on unmodified `master`, so it is unrelated to this change.
