### PR TITLE
fix(createImage): surface decode failures instead of hanging forever

### DIFF
--- a/packages/pdfrx/lib/src/pdfrx_flutter.dart
+++ b/packages/pdfrx/lib/src/pdfrx_flutter.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
@@ -58,7 +57,11 @@ extension PdfImageExt on PdfImage {
   /// while maintaining the aspect ratio.
   ///
   /// The returned [Image] must be disposed of when no longer needed.
-  Future<Image> createImage({int? pixelSizeThreshold}) {
+  ///
+  /// Throws if the engine cannot decode the pixel buffer, which in practice
+  /// means it failed to allocate for it - a large page on a memory-constrained
+  /// device. The returned future never completes with null.
+  Future<Image> createImage({int? pixelSizeThreshold}) async {
     int? targetWidth;
     int? targetHeight;
     if (pixelSizeThreshold != null && (width > pixelSizeThreshold || height > pixelSizeThreshold)) {
@@ -72,17 +75,27 @@ extension PdfImageExt on PdfImage {
       }
     }
 
-    final comp = Completer<Image>();
-    decodeImageFromPixels(
-      pixels,
-      width,
-      height,
-      PixelFormat.bgra8888,
-      (image) => comp.complete(image),
-      targetWidth: targetWidth,
-      targetHeight: targetHeight,
-    );
-    return comp.future;
+    // This is what `decodeImageFromPixels` does internally, driven directly
+    // instead. That function only takes a success callback, so a decode or
+    // allocation failure leaves the caller awaiting a future that never
+    // completes: the page stays blank, the `pixels` buffer is never freed
+    // because the caller's `dispose()` sits after the await, and the error
+    // surfaces as an unhandled zone error with no context. Awaiting the codec
+    // ourselves lets the failure propagate to the caller as an exception.
+    final buffer = await ImmutableBuffer.fromUint8List(pixels);
+    ImageDescriptor? descriptor;
+    try {
+      descriptor = ImageDescriptor.raw(buffer, width: width, height: height, pixelFormat: PixelFormat.bgra8888);
+      final codec = await descriptor.instantiateCodec(targetWidth: targetWidth, targetHeight: targetHeight);
+      try {
+        return (await codec.getNextFrame()).image;
+      } finally {
+        codec.dispose();
+      }
+    } finally {
+      descriptor?.dispose();
+      buffer.dispose();
+    }
   }
 }
 

--- a/packages/pdfrx/lib/src/widgets/pdf_widgets.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_widgets.dart
@@ -436,6 +436,7 @@ class _PdfPageViewState extends State<PdfPageView> {
     }
 
     if (pageSize == _pageSize) return;
+    final previousPageSize = _pageSize;
     _pageSize = pageSize;
 
     _cancellationToken?.cancel();
@@ -449,7 +450,6 @@ class _PdfPageViewState extends State<PdfPageView> {
     if (pageImage == null) return;
     try {
       final newImage = await pageImage.createImage();
-      pageImage.dispose();
       if (!mounted) {
         newImage.dispose();
         return;
@@ -459,6 +459,11 @@ class _PdfPageViewState extends State<PdfPageView> {
       setState(() {});
     } catch (e) {
       developer.log('Error creating image: $e');
+      // Restore the size we came in with, but only if a newer call has not
+      // already claimed `_pageSize`. Otherwise the equality guard above locks
+      // this page out of ever retrying and it stays blank for good.
+      if (_pageSize == pageSize) _pageSize = previousPageSize;
+    } finally {
       pageImage.dispose();
     }
   }

--- a/packages/pdfrx/test/create_image_test.dart
+++ b/packages/pdfrx/test/create_image_test.dart
@@ -1,0 +1,49 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdfrx/pdfrx.dart';
+
+/// Builds an opaque white BGRA8888 buffer of [width] x [height].
+Uint8List _bgra(int width, int height) => Uint8List(width * height * 4)..fillRange(0, width * height * 4, 0xff);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('PdfImageExt.createImage', () {
+    test('decodes a raw BGRA buffer at its native size', () async {
+      final pdfImage = PdfImage.createFromBgraData(_bgra(4, 3), width: 4, height: 3);
+      final image = await pdfImage.createImage();
+      addTearDown(image.dispose);
+
+      expect(image.width, 4);
+      expect(image.height, 3);
+    });
+
+    test('downscales to pixelSizeThreshold, keeping the aspect ratio', () async {
+      final pdfImage = PdfImage.createFromBgraData(_bgra(40, 20), width: 40, height: 20);
+      final image = await pdfImage.createImage(pixelSizeThreshold: 10);
+      addTearDown(image.dispose);
+
+      expect(image.width, 10);
+      expect(image.height, 5);
+    });
+
+    test('leaves an image untouched when it is already under the threshold', () async {
+      final pdfImage = PdfImage.createFromBgraData(_bgra(4, 3), width: 4, height: 3);
+      final image = await pdfImage.createImage(pixelSizeThreshold: 100);
+      addTearDown(image.dispose);
+
+      expect(image.width, 4);
+      expect(image.height, 3);
+    });
+
+    // Regression test: before the decode path was awaited directly, a failure
+    // completed no future at all, so this test hung until the suite timed out
+    // rather than reporting anything.
+    test('throws instead of hanging when the buffer cannot be decoded', () async {
+      final pdfImage = PdfImage.createFromBgraData(_bgra(4, 3), width: 4000, height: 3000);
+
+      await expectLater(pdfImage.createImage(), throwsA(isA<Object>()));
+    }, timeout: const Timeout(Duration(seconds: 30)));
+  });
+}


### PR DESCRIPTION
Fixes #696.

## The problem

`PdfImageExt.createImage()` creates a `Completer<Image>` and hands `decodeImageFromPixels()` a success-only callback:

```dart
final comp = Completer<Image>();
decodeImageFromPixels(
  pixels, width, height, PixelFormat.bgra8888,
  (image) => comp.complete(image),
  targetWidth: targetWidth, targetHeight: targetHeight,
);
return comp.future;
```

`ImageDecoderCallback` has no error parameter, and `decodeImageFromPixels` chains `.then()` without a `.catchError`. So when the engine fails — in practice `Could not allocate intermediate for pixel conversion`, i.e. a large page on a memory-constrained device — the completer is never completed **at all**. The caller does not get an exception, it gets a future that never returns.

Three consequences:

1. **The `try`/`catch` in `PdfPageView._updateImage()` cannot fire**, because there is nothing to catch. `createImage` isn't `async`, so that `catch` only ever saw a synchronous throw from argument validation.
2. **The pdfium buffer leaks.** `pageImage.dispose()` — which is `malloc.free(_buffer)` — sits after the never-returning `await`. Every failed render leaks a full page bitmap.
3. **The engine's error escapes into the zone** as an unhandled async error with nothing in the stack pointing at pdfrx, which makes it very hard to attribute. This is how I found it: it showed up as an uncatchable crash in our own app's error reporting with no pdfrx frames.

## The fix

Drive the codec directly. This is exactly what `decodeImageFromPixels` does internally (`ImmutableBuffer` → `ImageDescriptor.raw` → `instantiateCodec` → `getNextFrame`), except awaited, so a failure propagates to the caller as an exception. `try`/`finally` releases the buffer, descriptor and codec on both paths; the SDK's version disposes the buffer and descriptor only in its last `.then()`, so both leak if the chain rejects earlier.

Behaviour on success is unchanged: same pixel format, same target size logic, same disposal order as the SDK.

With that fixed, the `catch` in `_updateImage()` becomes reachable, so two things there needed adjusting:

- **`pageImage.dispose()` moved into a `finally`.** It was duplicated across the `try` and the `catch`, and skipped entirely if `createImage()` threw.
- **`_pageSize` is restored on failure.** It is committed *before* the render and guarded by `if (pageSize == _pageSize) return;`, so a page that failed once would never be re-rendered at that size again. Without this, fixing the hang just turns one permanently-blank page into another. It only restores if a newer call hasn't already claimed `_pageSize`, so a superseded render can't stomp a live one.

`PdfViewer`'s two `createImage()` call sites already use `finally`, so they only benefit from the first change.

## Tests

`createImage()` had no test coverage, so I added some: native-size decode, downscaling to `pixelSizeThreshold`, the already-under-threshold no-op, and the regression itself — a `PdfImage` claiming 4000x3000 over a 4x3 buffer. That last one asserts a throw; on `master` it hangs until the suite times out:

```
00:00 +3: throws instead of hanging when the buffer cannot be decoded
Shell: [ERROR:flutter/lib/ui/painting/image_decoder_skia.cc(90)] Could not create image from decompressed bytes.
00:00 +3 -1: throws instead of hanging when the buffer cannot be decoded [E]
  Exception: Codec failed to produce an image, possibly due to invalid image data.

  TimeoutException after 0:00:30.000000: Test timed out after 30 seconds.
```

Note what that shows: the engine *did* report the failure, as `Exception: Codec failed to produce an image, possibly due to invalid image data.` — it just arrived as an unhandled error in the zone rather than at the `await`, which is consequence 3 above. With the fix the same case throws at the call site and the test passes in under a second.

## Checks

`flutter analyze` clean, `dart format` reports no changes, and the new tests pass. Of the pre-existing tests, `pdfium_loading_test.dart` and `pdf_viewer_test.dart` need a real pdfium binary and network access respectively, so I couldn't run them here — happy to adjust if CI flags anything.

No CHANGELOG entry, matching #698. Let me know if you'd prefer one.
