### PR TITLE
Release pdfrx 2.4.8 and pdfrx_engine 0.4.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Add [pdfrx](https://pub.dev/packages/pdfrx) to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  pdfrx: ^2.4.6
+  pdfrx: ^2.4.8
 ```
 
 ### For Pure Dart Applications
@@ -89,7 +89,7 @@ Add [pdfrx_engine](https://pub.dev/packages/pdfrx_engine) to your `pubspec.yaml`
 
 ```yaml
 dependencies:
-  pdfrx_engine: ^0.4.5
+  pdfrx_engine: ^0.4.7
 ```
 
 ## Documentation

--- a/packages/pdfrx/CHANGELOG.md
+++ b/packages/pdfrx/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 2.4.8
+
+- Updated to `pdfrx_engine` 0.4.7.
+- FIXED: `PdfPageView` now disposes the previous page image before replacing it, avoiding image memory growth during scrolling ([#698](https://github.com/espresso3389/pdfrx/pull/698)).
+- FIXED: A failed page image decode now surfaces an error instead of leaving the render future pending forever ([#699](https://github.com/espresso3389/pdfrx/pull/699)).
+- FIXED: Text selection is no longer dropped while pages are still progressively loading ([#695](https://github.com/espresso3389/pdfrx/pull/695)).
+- FIXED: Null-check crash when text loading completes after the document has been unloaded ([#671](https://github.com/espresso3389/pdfrx/pull/671)).
+- FIXED: `encodePdf` on the WASM backend now returns only the bytes actually written.
+
 # 2.4.7
 
 - Updated to `pdfium_flutter` 0.2.3 so iOS/macOS Swift Package Manager support is recognized by Flutter and pub.dev.

--- a/packages/pdfrx/README.md
+++ b/packages/pdfrx/README.md
@@ -60,7 +60,7 @@ Add this to your package's `pubspec.yaml` file and execute `flutter pub get`:
 
 ```yaml
 dependencies:
-  pdfrx: ^2.4.7
+  pdfrx: ^2.4.8
 ```
 
 **Note:** You only need to add `pdfrx` to your dependencies. The `pdfrx_engine` package is automatically included as a dependency of `pdfrx`.

--- a/packages/pdfrx/pubspec.yaml
+++ b/packages/pdfrx/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdfrx
 description: pdfrx is a rich and fast PDF viewer and manipulation plugin built on the top of PDFium. Supports viewing, editing, combining PDFs on Android, iOS, Windows, macOS, Linux, and Web.
-version: 2.4.7
+version: 2.4.8
 homepage: https://github.com/espresso3389/pdfrx
 repository: https://github.com/espresso3389/pdfrx/tree/master/packages/pdfrx
 issue_tracker: https://github.com/espresso3389/pdfrx/issues
@@ -14,7 +14,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  pdfrx_engine: ^0.4.5
+  pdfrx_engine: ^0.4.7
   pdfium_flutter: ^0.2.3
   collection:
   crypto:

--- a/packages/pdfrx_coregraphics/README.md
+++ b/packages/pdfrx_coregraphics/README.md
@@ -14,7 +14,7 @@ Add the package to your Flutter app:
 
 ```yaml
 dependencies:
-  pdfrx: ^2.4.6
+  pdfrx: ^2.4.8
   pdfrx_coregraphics: ^0.2.2
 ```
 

--- a/packages/pdfrx_coregraphics/pubspec.yaml
+++ b/packages/pdfrx_coregraphics/pubspec.yaml
@@ -13,7 +13,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  pdfrx_engine: ^0.4.5
+  pdfrx_engine: ^0.4.7
 
 dev_dependencies:
   flutter_test:

--- a/packages/pdfrx_engine/CHANGELOG.md
+++ b/packages/pdfrx_engine/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.7
+
+- FIXED: Updating `PdfDocument.pages` no longer scales quadratically with the page count on the native backend ([#694](https://github.com/espresso3389/pdfrx/pull/694)).
+
 ## 0.4.6
 
 - FIXED: Windows ARM64 builds no longer fail on nullable PDF file cache access.

--- a/packages/pdfrx_engine/pubspec.yaml
+++ b/packages/pdfrx_engine/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdfrx_engine
 description: pdfrx_engine is a PDF rendering and manipulation API built on top of PDFium, designed to be used with the pdfrx plugin. Supports viewing, editing, and combining PDF documents.
-version: 0.4.6
+version: 0.4.7
 homepage: https://github.com/espresso3389/pdfrx
 repository: https://github.com/espresso3389/pdfrx/tree/master/packages/pdfrx_engine
 issue_tracker: https://github.com/espresso3389/pdfrx/issues


### PR DESCRIPTION
Prepares the changelog and version bumps for everything on master since 2.4.7, so publishing is just the `pub publish` steps.

**pdfrx_engine 0.4.7**
- #694 O(N^2) page list update in `_PdfDocumentPdfium.pages`

**pdfrx 2.4.8**
- #698 `PdfPageView` image leak
- #699 `createImage` decode failures hanging forever
- #695 text selection dropped during progressive load
- #671 null check crash in `_loadTextAsync`
- `encodePdf` byte count on the WASM backend (623dfeb)

Also updates the `pdfrx: ^` / `pdfrx_engine: ^` snippets in the root, pdfrx and pdfrx_coregraphics READMEs and the `pdfrx_engine` constraint in `packages/pdfrx/pubspec.yaml` and `packages/pdfrx_coregraphics/pubspec.yaml`, mirroring d3f9cc7. No code changes.

Publishing order, `pub publish` and tags are yours per `doc/agents/RELEASING.md` - happy to adjust the wording or the version numbers if you'd rather cut this differently.

@espresso3389
