### PR TITLE
fix: render real-size partial images at the document-to-pixel scale

### DIFF
--- a/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
@@ -1703,7 +1703,12 @@ class _PdfViewerState extends State<PdfViewer>
 
       final pageScale = scale * max(rect.width / page.width, rect.height / page.height);
       if (!enableLowResolutionPagePreview || pageScale > previewScaleLimit) {
-        _requestRealSizePartialImage(cache, page, pageScale, targetRect);
+        // `scale` (not `pageScale`) converts document units to physical pixels.
+        // `pageScale` additionally carries the layout-to-page-size ratio, which
+        // `_createRealSizePartialImage` would apply a second time via
+        // `pageRect.width * scale` -- under-rendering a custom `layoutPages`
+        // that does not lay pages out at their natural size.
+        _requestRealSizePartialImage(cache, page, scale, targetRect);
       }
 
       if ((!enableLowResolutionPagePreview || pageScale > previewScaleLimit) && partial != null) {


### PR DESCRIPTION
### Problem

A custom `layoutPages` that does not lay pages out at their natural point size gets a permanently blurry page when the user zooms in — the high-resolution partial render never reaches the resolution the viewer is actually displaying, and zooming further does not help.

### Cause

In `_paintPagesCustom`:

```dart
final pageScale = scale * max(rect.width / page.width, rect.height / page.height);
if (!enableLowResolutionPagePreview || pageScale > previewScaleLimit) {
  _requestRealSizePartialImage(cache, page, pageScale, targetRect);
}
```

`scale` is `_currentZoom * devicePixelRatio` — the document-units-to-physical-pixels factor. `pageScale` multiplies it by the layout ratio `r = pageRect.size / page.size`, which is the right quantity for the `previewScaleLimit` comparison, because `previewScaleLimit` is a page-points-to-pixels density (the preview is rendered as `page.width * previewScaleLimit`).

But `_createRealSizePartialImage` then uses the value it receives as a document-to-pixel factor again:

```dart
final width = (inPageRect.width * scale).toInt();   // inPageRect is in document units
fullWidth: pageRect.width * scale                   // pageRect is in document units
```

So `r` is counted twice:

```
needed:   pageRect.width * zoom * dpr
rendered: pageRect.width * (zoom * dpr * r)
```

With the built-in layouts `r == 1`, so the two are equal and nothing is wrong — which is why this only shows up with a custom `layoutPages`. With `r = 0.5` (a two-page book-style spread laid out at half size, which is how I hit this) the partial image is rendered at half the required resolution and is upscaled 2x on screen. The error is proportional, so it never improves with more zoom.

### Fix

Pass `scale` rather than `pageScale` to `_requestRealSizePartialImage`. The threshold comparison keeps using `pageScale`, which is correct there.

This is a no-op for every layout with `r == 1`, i.e. all built-in layouts.

### Testing

To be explicit about what I have and have not checked: the analysis above is derived from reading the code, and I have not yet run a visual before/after in a built app. What I can state is that the change is provably a no-op wherever `r == 1` (`pageScale` and `scale` are equal there by definition), which covers every built-in layout, so the risk to existing users is nil.

Happy to add a regression test if you can point me at where you would want it — the value is computed inside a private paint method, so I did not see an obvious seam in `packages/pdfrx/test`.
