### PR TITLE
feat(pdfium_dart): load PDFium on HarmonyOS (OHOS) via bare-name dlopen

### DIFF
--- a/packages/pdfium_dart/README.md
+++ b/packages/pdfium_dart/README.md
@@ -108,5 +108,8 @@ The bindings are generated from PDFium headers using the `ffigen` configuration 
 | Linux    | x64, ARM64, ARM, x86 | ✅ |
 | Android  | ARM64, ARMv7, x86, x86_64 | ✅ |
 | macOS    | x64, ARM64  | ✅      |
+| HarmonyOS (OHOS) | ARM64 | ✅ (bring your own `libpdfium.so`) |
 
 **Note:** For Flutter applications, use [pdfium_flutter](https://pub.dev/packages/pdfium_flutter) unless you specifically need the lower-level Dart bindings directly. `pdfium_flutter` includes the Flutter deployment layer for all native platforms except Web.
+
+**HarmonyOS note:** the build hook does not download PDFium for OHOS targets. Bundle a `libpdfium.so` under the HAP's `libs/<abi>/` directory; the loader resolves it via a bare-name `dlopen` from the app's native library directory at runtime.

--- a/packages/pdfium_dart/lib/src/pdfium_loader.dart
+++ b/packages/pdfium_dart/lib/src/pdfium_loader.dart
@@ -75,6 +75,11 @@ DynamicLibrary _getModule({String? modulePath}) {
 /// Gets the default PDFium library file name based on the platform.
 String _getModuleFileName() {
   if (Platform.isAndroid) return 'libpdfium.so';
+  // HarmonyOS (OH Flutter): same bare-name dlopen as Android; the library is
+  // resolved from the app's native library directory when bundled under the
+  // HAP's libs/<abi>/ directory. Detected by OS name because dart:io exposes
+  // no dedicated Platform.isOhos on standard Dart SDKs.
+  if (Platform.operatingSystem == 'ohos') return 'libpdfium.so';
   if (Platform.isWindows) return 'pdfium.dll';
   if (Platform.isLinux) {
     // For Flutter on Linux, the PDFium library is bundled in the app's shared library directory.


### PR DESCRIPTION
## Summary

Adds HarmonyOS (OpenHarmony Flutter) support to `getPdfium()`'s platform resolution in `pdfium_dart`.

## What it does

`_getModuleFileName()` now returns `libpdfium.so` when `Platform.operatingSystem == 'ohos'`, mirroring the Android bare-name `dlopen` strategy. On OH Flutter the loader resolves the library from the app's native library directory, so apps bundle `libpdfium.so` under the HAP's `libs/<abi>/` directory (documented in the README platform table).

## Compatibility

- Detection uses the `Platform.operatingSystem` string, since standard Dart SDKs expose no `Platform.isOhos`; the check is a no-op on every platform this package currently supports, so there is no behavior change elsewhere.
- The build hook is untouched: it does not target OHOS, and no native asset is produced there — hence the bring-your-own-library note.

## Verification

Verified in a real HarmonyOS NEXT HAP build (OH Flutter 3.44.x canary / API 24): with `libpdfium.so` (ARM64, musl) placed in `entry/libs/arm64-v8a/`, the HAP packages the library and `getPdfium()` resolves it at runtime.