### PR TITLE
feat: measure pages outward from the initial page during progressive loading

### DIFF
--- a/doc/Progressive-Loading.md
+++ b/doc/Progressive-Loading.md
@@ -200,7 +200,7 @@ final document = await PdfDocument.openFile(
 
 // Load pages progressively with progress callback
 await document.loadPagesProgressively(
-  onPageLoadProgress: (data, loadedPageCount, totalPageCount) {
+  onPageLoadProgress: (loadedPageCount, totalPageCount, data) {
     print('Loaded $loadedPageCount of $totalPageCount pages');
 
     // Return true to continue loading, false to stop
@@ -211,6 +211,15 @@ await document.loadPagesProgressively(
 ```
 
 The callback is invoked periodically (every `loadUnitDuration`) as pages are loaded. Return `false` from the callback to stop the loading process early.
+
+The callback receives the number of pages loaded so far (`loadedPageCount`), the total number of pages, and the optional `data` value passed to [`loadPagesProgressively()`](https://pub.dev/documentation/pdfrx_engine/latest/pdfrx_engine/PdfDocument/loadPagesProgressively.html). `loadedPageCount` is a count of loaded pages, not a page index; it does not depend on the order in which the pages are measured.
+
+By default, pages are measured from page 1 onward. Pass `startPageNumber` to measure pages in order of their distance from a given page instead (`start`, `start+1`, `start-1`, `start+2`, `start-2`, ...), so that the pages around the one being displayed become available first. Pages that are already loaded are skipped, and all pages are loaded when the call completes without being cancelled. [`PdfViewer`](https://pub.dev/documentation/pdfrx/latest/pdfrx/PdfViewer-class.html) does this automatically using its initial page:
+
+```dart
+// Measure pages 300, 301, 299, 302, 298, ... before the rest of the document
+await document.loadPagesProgressively(startPageNumber: 300);
+```
 
 ## Common Pitfalls and Solutions
 
@@ -324,7 +333,7 @@ Future<void> processPdfPages(String filePath) async {
   try {
     // Load pages progressively with progress reporting
     await document.loadPagesProgressively(
-      onPageLoadProgress: (_, loadedCount, totalCount) {
+      onPageLoadProgress: (loadedCount, totalCount, _) {
         final progress = (loadedCount / totalCount * 100).toStringAsFixed(1);
         print('Loading pages: $progress% ($loadedCount/$totalCount)');
         return true; // Continue loading

--- a/packages/pdfrx/assets/pdfium_worker.js
+++ b/packages/pdfrx/assets/pdfium_worker.js
@@ -1502,18 +1502,45 @@ async function _loadPagesInLimitedTimeAsync(
 }
 
 /**
- * @param {{docHandle: number, firstPageIndex: number, loadedPageIndices: number[], loadUnitDuration: number}} params
+ * Loads the pages listed in `pageIndices`, in that order, until `timeoutMs` elapses.
+ * At least one page is loaded per call. Indices outside the document are ignored.
+ * @param {number} docHandle
+ * @param {number[]} pageIndices
+ * @param {number} timeoutMs
+ * @returns {Promise<PdfPage[]>}
+ */
+async function _loadPageIndicesInLimitedTimeAsync(docHandle, pageIndices, timeoutMs) {
+  const pageCount = Pdfium.wasmExports.FPDF_GetPageCount(docHandle);
+  const t = Date.now() + timeoutMs;
+  /** @type {PdfPage[]} */
+  const pages = [];
+  _resetMissingFonts();
+  for (const i of pageIndices) {
+    if (i < 0 || i >= pageCount) {
+      continue;
+    }
+    await _ensurePageAvailable(docHandle, i);
+    pages.push(_loadPageMetadata(docHandle, i));
+    if (Date.now() > t) {
+      break;
+    }
+  }
+  _updateMissingFonts(docHandle);
+  return pages;
+}
+
+/**
+ * `pageIndices`, when present, lists the unloaded pages in the order they should be measured
+ * (e.g. spreading outward from the page being displayed); otherwise pages are measured from
+ * `firstPageIndex` onward, skipping `loadedPageIndices`.
+ * @param {{docHandle: number, firstPageIndex: number, loadedPageIndices: number[], pageIndices?: number[], loadUnitDuration: number}} params
  * @returns {{pages: PdfPage[], missingFonts: FontQueries}}
  */
 async function loadPagesProgressively(params) {
-  const { docHandle, firstPageIndex, loadedPageIndices, loadUnitDuration } = params;
-  const pages = await _loadPagesInLimitedTimeAsync(
-    docHandle,
-    firstPageIndex,
-    loadedPageIndices,
-    null,
-    loadUnitDuration,
-  );
+  const { docHandle, firstPageIndex, loadedPageIndices, pageIndices, loadUnitDuration } = params;
+  const pages = pageIndices
+    ? await _loadPageIndicesInLimitedTimeAsync(docHandle, pageIndices, loadUnitDuration)
+    : await _loadPagesInLimitedTimeAsync(docHandle, firstPageIndex, loadedPageIndices, null, loadUnitDuration);
   return { pages, missingFonts: missingFonts[docHandle] };
 }
 

--- a/packages/pdfrx/lib/src/wasm/pdfrx_wasm.dart
+++ b/packages/pdfrx/lib/src/wasm/pdfrx_wasm.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:js_interop';
+import 'dart:math';
 import 'dart:typed_data';
 import 'dart:ui_web' as ui_web;
 
@@ -461,17 +462,20 @@ class _PdfDocumentWasm extends PdfDocument {
     PdfPageLoadingCallback<T>? onPageLoadProgress,
     T? data,
     Duration loadUnitDuration = const Duration(milliseconds: 250),
+    int? startPageNumber,
   }) async {
     if (isDisposed) return;
     await synchronized(() async {
       for (;;) {
         if (isDisposed) return;
-        final firstPageIndex = pages.indexWhere((page) => !page.isLoaded);
-        if (firstPageIndex < 0) {
+        final pageIndicesToLoad = _unloadedPageIndicesOrderedFrom(pages, startPageNumber);
+        if (pageIndicesToLoad.isEmpty) {
           _notifyDocumentLoadComplete();
           return;
         }
         final newPages = pages.toList(growable: false);
+        // firstPageIndex/loadedPageIndices are kept for workers that predate pageIndices.
+        final firstPageIndex = pageIndicesToLoad.reduce(min);
         final loadedPageIndices = <int>[
           for (var i = firstPageIndex + 1; i < newPages.length; i++)
             if (newPages[i].isLoaded) i,
@@ -482,6 +486,7 @@ class _PdfDocumentWasm extends PdfDocument {
             'docHandle': document['docHandle'],
             'firstPageIndex': firstPageIndex,
             'loadedPageIndices': loadedPageIndices,
+            'pageIndices': pageIndicesToLoad,
             'loadUnitDuration': loadUnitDuration.inMilliseconds,
           },
         );
@@ -493,8 +498,7 @@ class _PdfDocumentWasm extends PdfDocument {
         updateMissingFonts(result['missingFonts']);
         if (pagesLoaded.isEmpty) return;
 
-        final firstUnloadedPageIndex = pages.indexWhere((page) => !page.isLoaded);
-        final pageCountLoaded = firstUnloadedPageIndex < 0 ? pages.length : firstUnloadedPageIndex;
+        final pageCountLoaded = pages.where((page) => page.isLoaded).length;
 
         if (onPageLoadProgress != null) {
           if (!await onPageLoadProgress(pageCountLoaded, pages.length, data)) {
@@ -507,6 +511,26 @@ class _PdfDocumentWasm extends PdfDocument {
         }
       }
     });
+  }
+
+  /// Returns the indices of the unloaded pages in [pages], ordered by distance from [startPageNumber] (1-based).
+  ///
+  /// The order alternates after and before the start page (start, start+1, start-1, start+2, start-2, ...). When
+  /// [startPageNumber] is null (or out of range), the order starts from the first page, i.e. plain page order.
+  static List<int> _unloadedPageIndicesOrderedFrom(List<PdfPage> pages, int? startPageNumber) {
+    final pageCount = pages.length;
+    final startIndex = startPageNumber == null ? 0 : min(max(startPageNumber - 1, 0), max(pageCount - 1, 0));
+    final indices = <int>[];
+    void addIfUnloaded(int index) {
+      if (index >= 0 && index < pageCount && !pages[index].isLoaded) indices.add(index);
+    }
+
+    addIfUnloaded(startIndex);
+    for (var distance = 1; startIndex + distance < pageCount || startIndex - distance >= 0; distance++) {
+      addIfUnloaded(startIndex + distance);
+      addIfUnloaded(startIndex - distance);
+    }
+    return indices;
   }
 
   @override

--- a/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
+++ b/packages/pdfrx/lib/src/widgets/pdf_viewer.dart
@@ -536,15 +536,21 @@ class _PdfViewerState extends State<PdfViewer>
     }
 
     final stopwatch = Stopwatch()..start();
+    // Measure outward from the initial page so its neighbours are ready first instead of waiting for pages 1..N-1.
+    // _initialPageNumber is only known once the first layout has run, hence it is read here and not earlier.
+    final initialPageNumber = _clampInitialPageNumber(document, _initialPageNumber ?? widget.initialPageNumber);
     await document.loadPagesProgressively(
-      onPageLoadProgress: (pageNumber, totalPageCount, document) {
+      onPageLoadProgress: (loadedPageCount, totalPageCount, document) {
         if (document == _document && mounted) {
-          debugPrint('PdfViewer: Loaded page $pageNumber of $totalPageCount in ${stopwatch.elapsedMilliseconds} ms');
+          debugPrint(
+            'PdfViewer: Loaded $loadedPageCount of $totalPageCount pages in ${stopwatch.elapsedMilliseconds} ms',
+          );
           return true;
         }
         return false;
       },
       data: _document,
+      startPageNumber: initialPageNumber,
     );
     if (!mounted || document != _document) return;
     if (document.pages.every((page) => page.isLoaded)) {

--- a/packages/pdfrx/test/pdf_viewer_test.dart
+++ b/packages/pdfrx/test/pdf_viewer_test.dart
@@ -642,6 +642,7 @@ class _TestDocument extends PdfDocument {
   late List<PdfPage> _pages;
   final reloadRequests = <List<int>?>[];
   bool progressiveLoadingStarted = false;
+  int? progressiveLoadingStartPageNumber;
 
   void reportMissingFonts() {
     _events.add(
@@ -684,8 +685,10 @@ class _TestDocument extends PdfDocument {
     PdfPageLoadingCallback<T>? onPageLoadProgress,
     T? data,
     Duration loadUnitDuration = const Duration(milliseconds: 250),
+    int? startPageNumber,
   }) async {
     progressiveLoadingStarted = true;
+    progressiveLoadingStartPageNumber = startPageNumber;
     _loadPages([for (var pageNumber = 1; pageNumber <= _pages.length; pageNumber++) pageNumber]);
     await onPageLoadProgress?.call(_pages.length, _pages.length, data);
     if (emitCompletionOnProgressive) {

--- a/packages/pdfrx/test/pdf_viewer_test.dart
+++ b/packages/pdfrx/test/pdf_viewer_test.dart
@@ -383,6 +383,34 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
   });
 
+  testWidgets('progressive loading starts from the initial page', (tester) async {
+    final document = _TestDocument(9);
+    addTearDown(document.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PdfViewer(
+          PdfDocumentRefDirect(document, autoDispose: false),
+          initialPageNumber: 8,
+          params: const PdfViewerParams(
+            behaviorControlParams: PdfViewerBehaviorControlParams(trailingPageLoadingDelay: Duration.zero),
+          ),
+        ),
+      ),
+    );
+    for (var i = 0; i < 20 && !document.progressiveLoadingStarted; i++) {
+      await tester.pump(const Duration(milliseconds: 10));
+      await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+
+    expect(document.progressiveLoadingStarted, isTrue);
+    expect(document.progressiveLoadingStartPageNumber, 8);
+    expect(tester.takeException(), isNull);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 100));
+  });
+
   testWidgets('progressive loading continues when priority loading fails', (tester) async {
     final document = _TestDocument(3, reloadError: UnimplementedError());
     addTearDown(document.dispose);

--- a/packages/pdfrx_coregraphics/lib/pdfrx_coregraphics.dart
+++ b/packages/pdfrx_coregraphics/lib/pdfrx_coregraphics.dart
@@ -448,8 +448,9 @@ class _CoreGraphicsPdfDocument extends PdfDocument {
     PdfPageLoadingCallback<T>? onPageLoadProgress,
     T? data,
     Duration loadUnitDuration = const Duration(milliseconds: 250),
+    int? startPageNumber,
   }) async {
-    // CoreGraphics loads all pages immediately; nothing to do.
+    // CoreGraphics loads all pages immediately; nothing to do, so startPageNumber has no effect here.
   }
 
   @override

--- a/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
+++ b/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
@@ -1081,22 +1081,18 @@ class _PdfDocumentPdfium extends PdfDocument {
     PdfPageLoadingCallback<T>? onPageLoadProgress,
     T? data,
     Duration loadUnitDuration = const Duration(milliseconds: 250),
+    int? startPageNumber,
   }) async {
     for (;;) {
       if (isDisposed) return;
 
-      final firstUnloadedPageIndex = _pages.indexWhere((page) => !page.isLoaded);
-      if (firstUnloadedPageIndex == -1) {
+      final pageIndicesToLoad = _unloadedPageIndicesOrderedFrom(_pages, startPageNumber);
+      if (pageIndicesToLoad.isEmpty) {
         _notifyDocumentLoadComplete();
         return;
       }
-      final loadedPageIndicesToSkip = <int>[
-        for (var i = firstUnloadedPageIndex + 1; i < _pages.length; i++)
-          if (_pages[i].isLoaded) i,
-      ];
       final loaded = await _loadPagesInLimitedTime(
-        pagesLoadedCountSoFar: firstUnloadedPageIndex,
-        loadedPageIndicesToSkip: loadedPageIndicesToSkip,
+        pageIndicesToLoad: pageIndicesToLoad,
         pagesToPreserve: _pages,
         timeout: loadUnitDuration,
       );
@@ -1104,7 +1100,7 @@ class _PdfDocumentPdfium extends PdfDocument {
       pages = loaded.pages;
 
       if (onPageLoadProgress != null) {
-        final result = await onPageLoadProgress(loaded.pageCountLoadedTotal, loaded.pages.length, data);
+        final result = await onPageLoadProgress(loaded.loadedPageCount, loaded.pages.length, data);
         if (result == false) {
           if (_pages.every((page) => page.isLoaded)) {
             _notifyDocumentLoadComplete();
@@ -1123,10 +1119,36 @@ class _PdfDocumentPdfium extends PdfDocument {
     }
   }
 
+  /// Returns the indices of the unloaded pages in [pages], ordered by distance from [startPageNumber] (1-based).
+  ///
+  /// The order alternates after and before the start page (start, start+1, start-1, start+2, start-2, ...). When
+  /// [startPageNumber] is null (or out of range), the order starts from the first page, i.e. plain page order.
+  static List<int> _unloadedPageIndicesOrderedFrom(List<PdfPage> pages, int? startPageNumber) {
+    final pageCount = pages.length;
+    final startIndex = startPageNumber == null ? 0 : min(max(startPageNumber - 1, 0), max(pageCount - 1, 0));
+    final indices = <int>[];
+    void addIfUnloaded(int index) {
+      if (index >= 0 && index < pageCount && !pages[index].isLoaded) indices.add(index);
+    }
+
+    addIfUnloaded(startIndex);
+    for (var distance = 1; startIndex + distance < pageCount || startIndex - distance >= 0; distance++) {
+      addIfUnloaded(startIndex + distance);
+      addIfUnloaded(startIndex - distance);
+    }
+    return indices;
+  }
+
   /// Loads pages in the document in a time-limited manner.
-  Future<({List<PdfPage> pages, int pageCountLoadedTotal})> _loadPagesInLimitedTime({
-    int pagesLoadedCountSoFar = 0,
-    List<int> loadedPageIndicesToSkip = const [],
+  ///
+  /// [pageIndicesToLoad] lists the page indices to measure, in the order they should be measured. When null, all
+  /// pages of the document are measured in page order (used when the page count is not known yet). Indices outside
+  /// the document are ignored. The measurement stops early when [maxPageCountToLoadAdditionally] pages are measured
+  /// or when [timeout] elapses; at least one page is measured per call.
+  ///
+  /// The returned `loadedPageCount` is the number of loaded pages in the resulting page list.
+  Future<({List<PdfPage> pages, int loadedPageCount})> _loadPagesInLimitedTime({
+    List<int>? pageIndicesToLoad,
     List<PdfPage> pagesToPreserve = const [],
     int? maxPageCountToLoadAdditionally,
     Duration? timeout,
@@ -1135,11 +1157,11 @@ class _PdfDocumentPdfium extends PdfDocument {
       (arena, params) {
         final doc = pdfium_bindings.FPDF_DOCUMENT.fromAddress(params.docAddress);
         final pageCount = pdfium.FPDF_GetPageCount(doc);
-        final loadedPageIndicesToSkip = params.loadedPageIndicesToSkip.toSet();
+        final indices = params.pageIndicesToLoad ?? Iterable<int>.generate(pageCount);
         final t = params.timeoutUs != null ? (Stopwatch()..start()) : null;
         final pages = <({int pageIndex, double width, double height, int rotation, double bbLeft, double bbBottom})>[];
-        for (var i = params.pagesCountLoadedSoFar; i < pageCount; i++) {
-          if (loadedPageIndicesToSkip.contains(i)) continue;
+        for (final i in indices) {
+          if (i < 0 || i >= pageCount) continue;
           final page = pdfium.FPDF_LoadPage(doc, i);
           try {
             final rect = arena<pdfium_bindings.FS_RECTF>();
@@ -1166,8 +1188,7 @@ class _PdfDocumentPdfium extends PdfDocument {
       },
       (
         docAddress: document.address,
-        pagesCountLoadedSoFar: pagesLoadedCountSoFar,
-        loadedPageIndicesToSkip: loadedPageIndicesToSkip,
+        pageIndicesToLoad: pageIndicesToLoad,
         maxPageCountToLoadAdditionally: maxPageCountToLoadAdditionally,
         timeoutUs: timeout?.inMicroseconds,
       ),
@@ -1192,9 +1213,8 @@ class _PdfDocumentPdfium extends PdfDocument {
       }
     }
     _resizePagesWithPlaceholders(pages, results.totalPageCount);
-    final firstUnloadedPageIndex = pages.indexWhere((page) => !page.isLoaded);
-    final pageCountLoadedTotal = firstUnloadedPageIndex < 0 ? pages.length : firstUnloadedPageIndex;
-    return (pages: pages, pageCountLoadedTotal: pageCountLoadedTotal);
+    final loadedPageCount = pages.where((page) => page.isLoaded).length;
+    return (pages: pages, loadedPageCount: loadedPageCount);
   }
 
   /// Resizes [pages], using unloaded placeholders when the document grows.

--- a/packages/pdfrx_engine/lib/src/pdf_document.dart
+++ b/packages/pdfrx_engine/lib/src/pdf_document.dart
@@ -222,11 +222,19 @@ abstract class PdfDocument {
   /// When [onPageLoadProgress] is called, it should return true to continue loading process or false to stop loading.
   /// [data] is an optional data that can be used to pass additional information to the callback.
   ///
+  /// [startPageNumber] is the 1-based page number to start measuring from. Pages are measured in order of their
+  /// distance from [startPageNumber], alternating after and before it (start, start+1, start-1, start+2, start-2, ...),
+  /// so that the pages around the one being displayed become available first. Pages that are already loaded are
+  /// skipped. When null (the default), pages are measured from the first page onward. Regardless of the order, all
+  /// pages are loaded when the function completes without being cancelled, and [PdfDocumentLoadCompleteEvent] is
+  /// emitted once.
+  ///
   /// It's always safe to call this function even if the pages are already loaded.
   Future<void> loadPagesProgressively<T>({
     PdfPageLoadingCallback<T>? onPageLoadProgress,
     T? data,
     Duration loadUnitDuration = const Duration(milliseconds: 250),
+    int? startPageNumber,
   });
 
   /// Pages.
@@ -322,7 +330,16 @@ abstract class PdfDocument {
 
 typedef PdfFontLoadResultCallback = FutureOr<void> Function(PdfFontLoadResult result);
 
-typedef PdfPageLoadingCallback<T> = FutureOr<bool> Function(int currentPageNumber, int totalPageCount, T? data);
+/// Callback function to notify progressive page loading progress; see [PdfDocument.loadPagesProgressively].
+///
+/// [loadedPageCount] is the number of pages whose real dimensions are loaded so far, including pages loaded by other
+/// means (e.g. [PdfDocument.reloadPages]). Because pages are not necessarily measured in page order, it is a count,
+/// not the number of the last loaded page.
+/// [totalPageCount] is the total number of pages in the document.
+/// [data] is the optional data passed to [PdfDocument.loadPagesProgressively].
+///
+/// Return true to continue loading or false to stop.
+typedef PdfPageLoadingCallback<T> = FutureOr<bool> Function(int loadedPageCount, int totalPageCount, T? data);
 
 /// Callback function to notify download progress.
 ///

--- a/packages/pdfrx_engine/test/pdf_document_test.dart
+++ b/packages/pdfrx_engine/test/pdf_document_test.dart
@@ -10,6 +10,7 @@ import 'package:test/test.dart';
 import 'utils.dart';
 
 final testPdfFile = File('../pdfrx/example/viewer/assets/hello.pdf');
+final multiPageTestPdfFile = File('../pdfrx/test/assets/multipage40.pdf');
 
 void main() {
   setUp(() => pdfrxInitialize(tmpPath: tmpRoot.path));
@@ -262,6 +263,71 @@ void main() {
 
     expect(document.pages.every((page) => page.isLoaded), isTrue);
     await expectLater(completionEvent.timeout(const Duration(seconds: 1)), completes);
+  });
+  test('progressive loading measures pages outward from startPageNumber', () async {
+    final document = await PdfDocument.openFile(multiPageTestPdfFile.path, useProgressiveLoading: true);
+    addTearDown(document.dispose);
+    expect(document.pages.length, 40);
+    // Only the first page is loaded when the document is opened progressively.
+    expect(document.pages.map((page) => page.isLoaded).where((loaded) => loaded), hasLength(1));
+    final events = <PdfDocumentEvent>[];
+    final subscription = document.events.listen(events.add);
+    addTearDown(subscription.cancel);
+
+    // Stop after the first slice to inspect what was measured first.
+    final progress = <(int loadedPageCount, int totalPageCount)>[];
+    await document.loadPagesProgressively(
+      startPageNumber: 20,
+      loadUnitDuration: Duration.zero,
+      onPageLoadProgress: (loadedPageCount, totalPageCount, _) {
+        progress.add((loadedPageCount, totalPageCount));
+        return false;
+      },
+    );
+
+    expect(progress, hasLength(1));
+    expect(progress.single.$2, 40);
+    final loadedPageNumbers = document.pages.where((page) => page.isLoaded).map((page) => page.pageNumber).toList();
+    expect(progress.single.$1, loadedPageNumbers.length);
+    // Page 1 was loaded at open time; everything else measured so far must be the head of the outward sequence
+    // 20, 21, 19, 22, 18, ... rather than 2, 3, 4, ...
+    final measured = loadedPageNumbers.where((pageNumber) => pageNumber != 1).toList();
+    expect(measured, isNotEmpty);
+    expect(measured.length, lessThan(39), reason: 'a zero-length slice must not measure the whole document');
+    final expectedOrder = <int>[
+      20,
+      for (var distance = 1; distance < 40; distance++) ...[
+        if (20 + distance <= 40) 20 + distance,
+        if (20 - distance >= 2) 20 - distance,
+      ],
+    ];
+    expect(measured, unorderedEquals(expectedOrder.take(measured.length)));
+    expect(document.pages[19].isLoaded, isTrue);
+    expect(document.pages[1].isLoaded, isFalse);
+
+    // Resuming (from any start page) still ends with every page loaded and a single completion event.
+    await document.loadPagesProgressively(startPageNumber: 20, loadUnitDuration: Duration.zero);
+    await document.loadPagesProgressively(startPageNumber: 20);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(document.pages.every((page) => page.isLoaded), isTrue);
+    expect(document.pages.map((page) => page.pageNumber), List.generate(40, (index) => index + 1));
+    expect(events.whereType<PdfDocumentLoadCompleteEvent>(), hasLength(1));
+  });
+  test('progressive loading without startPageNumber still measures from the first page', () async {
+    final document = await PdfDocument.openFile(multiPageTestPdfFile.path, useProgressiveLoading: true);
+    addTearDown(document.dispose);
+
+    await document.loadPagesProgressively(
+      startPageNumber: null,
+      loadUnitDuration: Duration.zero,
+      onPageLoadProgress: (_, _, _) => false,
+    );
+
+    final loadedPageNumbers = document.pages.where((page) => page.isLoaded).map((page) => page.pageNumber).toList();
+    expect(loadedPageNumbers.length, greaterThan(1));
+    expect(loadedPageNumbers.length, lessThan(40));
+    expect(loadedPageNumbers, List.generate(loadedPageNumbers.length, (index) => index + 1));
   });
   test('loadLinks reuses raw and compact results', () async {
     final document = await PdfDocument.openFile(testPdfFile.path);


### PR DESCRIPTION
## Summary

A `PdfViewer` opened at page 300 of a progressively loaded document had to wait for pages 1..299 to be measured before the pages around 300 became available: `PdfDocument.loadPagesProgressively` always measured pages in ascending order from page 1.

This PR adds an optional `startPageNumber` parameter to `loadPagesProgressively`. When it is set, pages are measured outward from that page (`start`, `start+1`, `start-1`, `start+2`, `start-2`, ...) so the neighbours of the displayed page are ready first. Already loaded pages are skipped. `PdfViewer` passes its clamped initial page (explicit `initialPageNumber`, or the calculated one once known) as the start page.

The end state is unchanged: every page is loaded when the call completes without being cancelled, and `PdfDocumentLoadCompleteEvent` is emitted exactly once. `startPageNumber: null` (the default) keeps the previous behaviour of loading from page 1.

`doc/Progressive-Loading.md` documents the new parameter and fixes the `onPageLoadProgress` examples, which listed the callback parameters in the wrong order.

## Backends

- PDFium (native): honours the outward order.
- WASM: honours the outward order; the worker still accepts the old parameters, so an outdated worker script keeps working with the new engine.
- CoreGraphics (iOS/macOS): no-op, because that backend loads all pages at open time and has nothing left to measure.

## Breaking notes for the release

- Third-party `PdfDocument` implementations must add the new named parameter `int? startPageNumber` to their `loadPagesProgressively` override.
- `PdfPageLoadingCallback`'s first argument is now the count of loaded pages rather than the index of the first unloaded page, matching its documented name (`loadedPageCount`). Code that used it as a page index needs to be adjusted; code that used it as a progress counter is unaffected.

## Testing

- `packages/pdfrx_engine`: `dart test` — 48 passed, including 2 new tests for the outward measuring order and the unchanged end state.
- `packages/pdfrx`: `flutter test` with `PDFIUM_PATH` set — all tests passed, including a new widget test asserting that `PdfViewer` forwards its initial page as `startPageNumber`.
- WASM worker: `node --test` passed.
- `flutter analyze` / `dart analyze`: clean apart from pre-existing infos.
