### PR TITLE
fix: read PDFium open errors on the worker isolate so bad files stop prompting for passwords

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@
 *.bat   text eol=crlf
 *.plist text eof=lf
 *.patch text eol=lf
+*.pdf   binary

--- a/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
+++ b/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
@@ -576,6 +576,34 @@ class _FontSource {
       (data[offset] << 24) | (data[offset + 1] << 16) | (data[offset + 2] << 8) | data[offset + 3];
 }
 
+/// Result of a PDFium document load attempt executed on the [BackgroundWorker] isolate.
+///
+/// `doc` is the address of the loaded `FPDF_DOCUMENT` (0 on failure) and `error` is the `FPDF_GetLastError` value
+/// captured right after a failed load (0 on success).
+typedef _PdfLoadResult = ({int doc, int error});
+
+/// Maximum number of times [_pdfLoadResult] runs a failing load to obtain a meaningful error code.
+const _maxPdfLoadAttemptsForErrorCode = 3;
+
+/// Runs the PDFium [load] function and captures its outcome as a [_PdfLoadResult].
+///
+/// PDFium keeps the last error in thread-local storage (Win32 `GetLastError` on Windows), so `FPDF_GetLastError`
+/// must be called on the same isolate (OS thread) right after the failed load; reading it from the caller isolate
+/// yields an unrelated value. This function therefore has to run inside the [BackgroundWorker] callback.
+///
+/// Even on the same thread, the Dart VM's FFI transition between the two calls may invoke Win32 APIs (for example
+/// TLS access) that reset the thread's last-error to 0. Since 0 (`FPDF_ERR_SUCCESS`) is never a valid outcome of a
+/// failed load, the load is simply retried a few times until a meaningful code is obtained.
+_PdfLoadResult _pdfLoadResult(pdfium_bindings.FPDF_DOCUMENT Function() load) {
+  for (var attempt = 0; attempt < _maxPdfLoadAttemptsForErrorCode; attempt++) {
+    final doc = load();
+    if (doc != nullptr) return (doc: doc.address, error: pdfium_bindings.FPDF_ERR_SUCCESS);
+    final error = pdfium.FPDF_GetLastError();
+    if (error != pdfium_bindings.FPDF_ERR_SUCCESS) return (doc: 0, error: error);
+  }
+  return (doc: 0, error: pdfium_bindings.FPDF_ERR_UNKNOWN);
+}
+
 class PdfrxEntryFunctionsImpl implements PdfrxEntryFunctions {
   PdfrxEntryFunctionsImpl();
 
@@ -652,10 +680,12 @@ class PdfrxEntryFunctionsImpl implements PdfrxEntryFunctions {
   }) async {
     await _init();
     return _openByFunc(
-      (password) async => BackgroundWorker.computeWithArena((arena, params) {
-        final doc = pdfium.FPDF_LoadDocument(params.filePath.toUtf8(arena), params.password?.toUtf8(arena) ?? nullptr);
-        return doc.address;
-      }, (filePath: filePath, password: password)),
+      (password) async => BackgroundWorker.computeWithArena(
+        (arena, params) => _pdfLoadResult(
+          () => pdfium.FPDF_LoadDocument(params.filePath.toUtf8(arena), params.password?.toUtf8(arena) ?? nullptr),
+        ),
+        (filePath: filePath, password: password),
+      ),
       sourceName: 'file%$filePath',
       passwordProvider: passwordProvider,
       firstAttemptByEmptyPassword: firstAttemptByEmptyPassword,
@@ -715,11 +745,13 @@ class PdfrxEntryFunctionsImpl implements PdfrxEntryFunctions {
         await read(buffer.asTypedList(fileSize), 0, fileSize);
         return await _openByFunc(
           (password) async => BackgroundWorker.computeWithArena(
-            (arena, params) => pdfium.FPDF_LoadMemDocument(
-              Pointer<Void>.fromAddress(params.buffer),
-              params.fileSize,
-              params.password?.toUtf8(arena) ?? nullptr,
-            ).address,
+            (arena, params) => _pdfLoadResult(
+              () => pdfium.FPDF_LoadMemDocument(
+                Pointer<Void>.fromAddress(params.buffer),
+                params.fileSize,
+                params.password?.toUtf8(arena) ?? nullptr,
+              ),
+            ),
             (buffer: buffer.address, fileSize: fileSize, password: password),
           ),
           sourceName: sourceName,
@@ -745,10 +777,12 @@ class PdfrxEntryFunctionsImpl implements PdfrxEntryFunctions {
     try {
       return await _openByFunc(
         (password) async => BackgroundWorker.computeWithArena(
-          (arena, params) => pdfium.FPDF_LoadCustomDocument(
-            Pointer<pdfium_bindings.FPDF_FILEACCESS>.fromAddress(params.fileAccess),
-            params.password?.toUtf8(arena) ?? nullptr,
-          ).address,
+          (arena, params) => _pdfLoadResult(
+            () => pdfium.FPDF_LoadCustomDocument(
+              Pointer<pdfium_bindings.FPDF_FILEACCESS>.fromAddress(params.fileAccess),
+              params.password?.toUtf8(arena) ?? nullptr,
+            ),
+          ),
           (fileAccess: fa.fileAccess, password: password),
         ),
         sourceName: sourceName,
@@ -792,8 +826,12 @@ class PdfrxEntryFunctionsImpl implements PdfrxEntryFunctions {
     entryFunctions: this,
   );
 
+  /// Opens a document by repeatedly calling [openPdfDocument] until it succeeds or a non-password error occurs.
+  ///
+  /// [openPdfDocument] must run the PDFium load function on the [BackgroundWorker] isolate and return the
+  /// [_PdfLoadResult] captured there (see [_pdfLoadResult]); the error code is only meaningful on that isolate.
   static Future<PdfDocument> _openByFunc(
-    FutureOr<int> Function(String? password) openPdfDocument, {
+    FutureOr<_PdfLoadResult> Function(String? password) openPdfDocument, {
     required String sourceName,
     required PdfPasswordProvider? passwordProvider,
     bool firstAttemptByEmptyPassword = true,
@@ -810,21 +848,20 @@ class PdfrxEntryFunctionsImpl implements PdfrxEntryFunctions {
           throw const PdfPasswordException('No password supplied by PasswordProvider.');
         }
       }
-      final doc = await openPdfDocument(password);
-      if (doc != 0) {
+      final result = await openPdfDocument(password);
+      if (result.doc != 0) {
         return _PdfDocumentPdfium.fromPdfDocument(
-          pdfium_bindings.FPDF_DOCUMENT.fromAddress(doc),
+          pdfium_bindings.FPDF_DOCUMENT.fromAddress(result.doc),
           sourceName: sourceName,
           useProgressiveLoading: useProgressiveLoading,
           disposeCallback: disposeCallback,
         );
       }
-      final error = pdfium.FPDF_GetLastError();
-      if (Platform.isWindows || error == pdfium_bindings.FPDF_ERR_PASSWORD) {
-        // FIXME: Windows does not return error code correctly; we have to mimic every error is password error
+      if (result.error == pdfium_bindings.FPDF_ERR_PASSWORD) {
+        // Missing or wrong password; ask the password provider on the next iteration.
         continue;
       }
-      throw PdfException('Failed to load PDF document ${_getPdfiumErrorString()}.', error);
+      throw PdfException('Failed to load PDF document ${_getPdfiumErrorString(result.error)}.', result.error);
     }
   }
 
@@ -892,8 +929,8 @@ class PdfrxEntryFunctionsImpl implements PdfrxEntryFunctions {
     }
   }
 
-  static String _getPdfiumErrorString([int? error]) {
-    error ??= pdfium.FPDF_GetLastError();
+  /// Formats a PDFium error code (a `FPDF_ERR_*` value) for use in exception messages.
+  static String _getPdfiumErrorString(int error) {
     final errStr = _errorMappings[error];
     if (errStr != null) {
       return '($errStr: $error)';

--- a/packages/pdfrx_engine/test/assets/encrypted.pdf
+++ b/packages/pdfrx_engine/test/assets/encrypted.pdf
@@ -1,0 +1,72 @@
+%PDF-1.3
+%‚„œ”
+1 0 obj
+<<
+/Producer <74a2866023a5a03c57703d7a7400f03772ff55408240bd5ff33fc63e6ee2edac>
+/Title <4b708533a0b1e036ef6e1990f3488bc00c4cdadbec261be1efb9c77a3c64b7035902790c25db34d1dcfa04655ef01c76>
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [ 4 0 R ]
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/Resources <<
+>>
+/MediaBox [ 0.0 0.0 200 100 ]
+/Parent 2 0 R
+>>
+endobj
+5 0 obj
+<<
+/V 5
+/R 6
+/Length 256
+/P 4294967292
+/Filter /Standard
+/O <afc16e2a8ba43a1260d0ef487c323188c70c97605a41c440b7573423ae5a831c98f8c225abdfc509cc08edecf0cef2bc>
+/U <7e5321976df68f5070d390554485ddf7e0aa380ef7446a72064733f4748fd6ebe1db0f0f34c9dda9cd15647dc36f5867>
+/CF <<
+/StdCF <<
+/AuthEvent /DocOpen
+/CFM /AESV3
+/Length 32
+>>
+>>
+/StmF /StdCF
+/StrF /StdCF
+/OE <d8e624245cfe4984b38f6493d6c48bf271d0c695a4f899294a96a3b9f7eff259>
+/UE <b4d2e352b129d456486d99ee63b50c009bc913186890aabd928bb17f08edec5c>
+/Perms <0ab30020f090939b32be94cba57f3444>
+>>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000219 00000 n 
+0000000278 00000 n 
+0000000327 00000 n 
+0000000421 00000 n 
+trailer
+<<
+/Size 6
+/Root 3 0 R
+/Info 1 0 R
+/ID [ <6131656461336436326363346430326233653132636562366265653366326234> <6131656461336436326363346430326233653132636562366265653366326234> ]
+/Encrypt 5 0 R
+>>
+startxref
+976
+%%EOF

--- a/packages/pdfrx_engine/test/pdf_document_test.dart
+++ b/packages/pdfrx_engine/test/pdf_document_test.dart
@@ -29,6 +29,120 @@ void main() {
     final data = await testPdfFile.readAsBytes();
     await testDocument(await PdfDocument.openData(data));
   });
+
+  group('open failures report the PDFium error code', () {
+    // PDFium keeps FPDF_GetLastError in thread-local storage; the code must read it on the worker isolate that
+    // performed the load. If it is read on the caller isolate instead, a non-PDF file used to be mistaken for a
+    // password-protected one and the password provider was asked over and over again.
+    late File nonPdfFile;
+
+    setUp(() async {
+      await tmpRoot.create(recursive: true);
+      nonPdfFile = File('${tmpRoot.path}/not_a_pdf.bin');
+      await nonPdfFile.writeAsBytes(List<int>.generate(4096, (i) => (i * 7919 + 13) & 0xff));
+    });
+
+    tearDown(() async {
+      if (await nonPdfFile.exists()) await nonPdfFile.delete();
+    });
+
+    Future<void> expectFormatError(Future<PdfDocument> Function(PdfPasswordProvider provider) open) async {
+      var passwordRequests = 0;
+      Future<String?> passwordProvider() async => ++passwordRequests <= 2 ? 'wrong' : null;
+
+      await expectLater(
+        open(passwordProvider),
+        throwsA(
+          isA<PdfException>()
+              .having((e) => e, 'type', isNot(isA<PdfPasswordException>()))
+              .having((e) => e.errorCode, 'errorCode', 3), // FPDF_ERR_FORMAT
+        ),
+      );
+      expect(passwordRequests, 0, reason: 'a corrupt file must not be mistaken for a password-protected one');
+    }
+
+    test('openFile of a non-PDF file throws PdfException with FPDF_ERR_FORMAT', () async {
+      await expectFormatError((provider) => PdfDocument.openFile(nonPdfFile.path, passwordProvider: provider));
+    });
+
+    test('openData of non-PDF bytes throws PdfException with FPDF_ERR_FORMAT', () async {
+      final data = await nonPdfFile.readAsBytes();
+      await expectFormatError((provider) => PdfDocument.openData(data, passwordProvider: provider));
+    });
+
+    test('openCustom (on-demand) of non-PDF bytes throws PdfException with FPDF_ERR_FORMAT', () async {
+      final data = await nonPdfFile.readAsBytes();
+      await expectFormatError(
+        (provider) => PdfDocument.openCustom(
+          read: (buffer, position, size) {
+            final n = size.clamp(0, data.length - position);
+            buffer.setRange(0, n, data, position);
+            return n;
+          },
+          fileSize: data.length,
+          sourceName: 'custom-non-pdf',
+          passwordProvider: provider,
+          maxSizeToCacheOnMemory: 0,
+        ),
+      );
+    });
+  });
+
+  group('password-protected PDF', () {
+    // test/assets/encrypted.pdf: one blank page, AES-256, user password 'user', owner password 'owner'.
+    final encryptedPdfFile = File('test/assets/encrypted.pdf');
+
+    test('the password provider is consulted and the right password opens the document', () async {
+      var passwordRequests = 0;
+      final doc = await PdfDocument.openFile(
+        encryptedPdfFile.path,
+        passwordProvider: () async {
+          passwordRequests++;
+          return 'user';
+        },
+      );
+      expect(passwordRequests, 1);
+      expect(doc.pages.length, 1);
+      doc.dispose();
+    });
+
+    test('wrong passwords are retried until the provider returns null, then PdfPasswordException', () async {
+      var passwordRequests = 0;
+      await expectLater(
+        PdfDocument.openFile(
+          encryptedPdfFile.path,
+          passwordProvider: () async => ++passwordRequests <= 2 ? 'wrong' : null,
+        ),
+        throwsA(isA<PdfPasswordException>()),
+      );
+      expect(passwordRequests, 3);
+    });
+
+    test('without a password provider it throws PdfPasswordException', () async {
+      await expectLater(PdfDocument.openFile(encryptedPdfFile.path), throwsA(isA<PdfPasswordException>()));
+    });
+
+    test('firstAttemptByEmptyPassword=false asks the provider before the first attempt', () async {
+      var passwordRequests = 0;
+      final doc = await PdfDocument.openFile(
+        encryptedPdfFile.path,
+        firstAttemptByEmptyPassword: false,
+        passwordProvider: () async {
+          passwordRequests++;
+          return 'user';
+        },
+      );
+      expect(passwordRequests, 1);
+      doc.dispose();
+    });
+
+    test('openData of the encrypted file also honors the password', () async {
+      final data = await encryptedPdfFile.readAsBytes();
+      final doc = await PdfDocument.openData(data, passwordProvider: () async => 'user');
+      expect(doc.pages.length, 1);
+      doc.dispose();
+    });
+  });
   test('reloadPages loads a sparse progressive page at its original index', () async {
     final document = await PdfDocument.openFile(testPdfFile.path, useProgressiveLoading: true);
     addTearDown(document.dispose);


### PR DESCRIPTION
## Problem

`_openByFunc` read `FPDF_GetLastError()` on the caller isolate while the failed load ran on the worker isolate. PDFium keeps the last error in thread-local storage, so the value read on the caller isolate was unrelated to the load that had just failed.

The existing `Platform.isWindows` workaround papered over this by treating every open failure as a wrong password. As a result, corrupt or non-PDF files kept re-prompting the `PdfPasswordProvider` instead of failing with a meaningful error.

## Fix

- The worker callback now returns `(doc, error)`, with the error code read in the same callback right after the load, for `FPDF_LoadDocument`, `FPDF_LoadMemDocument`, and `FPDF_LoadCustomDocument`.
- The password provider is only retried on `FPDF_ERR_PASSWORD`.
- Any other failure throws `PdfException` carrying the real PDFium error code and message.
- The Windows special case is removed.

## Windows detail

Even on the worker isolate, the first failing load after initialization read an error code of 0 deterministically, and roughly 1% of subsequent failing loads read 0 sporadically. The FFI transition between the two calls can invoke Win32 APIs that reset the thread's last-error value.

Since 0 (`FPDF_ERR_SUCCESS`) is never a legitimate result of a failed load, the load is retried up to 3 times while the code reads 0. This only happens on the failure path; successful loads are unaffected.

## Tests

8 new engine tests, including:

- An AES-256 encrypted 1.3KB fixture `test/assets/encrypted.pdf` (user password `user`).
- A non-PDF file yields `PdfException` with code 3 (`FPDF_ERR_FORMAT`) and the password provider is never called.
- Wrong password twice followed by `null` from the provider yields `PdfPasswordException`.
- `.gitattributes` marks `*.pdf binary` so `core.autocrlf` cannot corrupt the fixtures.

## Verification

- `dart test` in `packages/pdfrx_engine`: 54 passed.
- `dart analyze`: clean.
- `flutter analyze`: only pre-existing infos.
- Independent 200-iteration probes on Windows: encrypted file 51/51 password exceptions, random bytes 50/50 format errors.
