### PR TITLE
feat: run page renders ahead of background work on the PDFium worker

### DIFF
--- a/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
+++ b/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
@@ -1324,6 +1324,7 @@ class _PdfDocumentPdfium extends PdfDocument {
         return (pages: pages, invalidPageNumber: invalidPageNumber);
       },
       (docAddress: document.address, pageNumbersToReload: pageNumbersToReload, currentPageCount: _pages.length),
+      priority: BackgroundWorkerPriority.high,
     );
     if (results.invalidPageNumber != null) {
       throw ArgumentError.value(
@@ -1764,6 +1765,7 @@ class _PdfPagePdfium extends PdfPage with PdfPageLinkCache {
             formInfo: document.formInfo.address,
             cancelFlag: cancelFlag.address,
           ),
+          priority: BackgroundWorkerPriority.high,
         );
       });
 

--- a/packages/pdfrx_engine/lib/src/native/worker.dart
+++ b/packages/pdfrx_engine/lib/src/native/worker.dart
@@ -10,6 +10,20 @@ import '../pdfrx.dart';
 
 typedef PdfrxComputeCallback<M, R> = FutureOr<R> Function(M message);
 
+/// Scheduling priority of a [BackgroundWorker.compute] call.
+///
+/// All PDFium work in the process funnels through a single worker isolate, so a long run of background work
+/// (text extraction, outline parsing, document loading, ...) can delay latency-sensitive work such as rendering the
+/// pages currently on screen. The worker keeps one queue per priority and always picks a pending [high] item before
+/// any [normal] one; items of the same priority run in FIFO order.
+enum BackgroundWorkerPriority {
+  /// Latency-sensitive work (page rendering, on-demand measurement of visible pages).
+  high,
+
+  /// Everything else. This is the default.
+  normal,
+}
+
 /// Background worker based on Dart [Isolate].
 class BackgroundWorker {
   BackgroundWorker._(this.debugName);
@@ -30,10 +44,14 @@ class BackgroundWorker {
       _sendPort = await receivePort.first as SendPort;
 
       // propagate the pdfium module path to the worker
-      await _compute((params) {
-        Pdfrx.pdfiumModulePath = params.modulePath;
-        Pdfrx.pdfiumNativeBindings = params.bindings;
-      }, (modulePath: Pdfrx.pdfiumModulePath, bindings: Pdfrx.pdfiumNativeBindings));
+      await _compute(
+        (params) {
+          Pdfrx.pdfiumModulePath = params.modulePath;
+          Pdfrx.pdfiumNativeBindings = params.bindings;
+        },
+        (modulePath: Pdfrx.pdfiumModulePath, bindings: Pdfrx.pdfiumNativeBindings),
+        BackgroundWorkerPriority.normal,
+      );
     });
     return _sendPort!;
   }
@@ -54,22 +72,34 @@ class BackgroundWorker {
     _isolate = null;
   }
 
+  /// Maximum number of consecutive [BackgroundWorkerPriority.high] items the scheduler runs while a
+  /// [BackgroundWorkerPriority.normal] item is waiting, before it lets one normal item through.
+  ///
+  /// High-priority work (rendering, page measurement) is expected to be short-lived and bursty, so this is only a
+  /// safety net that keeps a viewer that renders continuously (e.g. during a long animated scroll) from starving
+  /// background work forever.
+  static const _maxConsecutiveHighItems = 8;
+
   /// Entry point for the worker isolate.
   static void _workerEntry(SendPort sendPort) {
     final receivePort = ReceivePort();
     sendPort.send(receivePort.sendPort);
     late StreamSubscription? sub;
+    final scheduler = _WorkerScheduler();
     final suspendingQueue = Queue<_ComputeParams>();
     var suspendingLevel = 0;
     sub = receivePort.listen((message) {
       if (message is _SuspendRequest) {
         suspendingLevel++;
+        // Everything that was sent before the suspend request must have run by the time the requester gets the
+        // acknowledgement; otherwise the caller could touch PDFium while queued work is still pending.
+        scheduler.drainAll();
         message.execute();
       } else if (message is _ResumeRequest) {
         if (suspendingLevel > 0) {
           suspendingLevel--;
           while (suspendingQueue.isNotEmpty) {
-            suspendingQueue.removeFirst().execute();
+            scheduler.enqueue(suspendingQueue.removeFirst());
           }
         }
         message.execute();
@@ -77,10 +107,11 @@ class BackgroundWorker {
         if (suspendingLevel > 0) {
           suspendingQueue.add(message);
         } else {
-          message.execute();
+          scheduler.enqueue(message);
         }
       } else if (message is _StopRequest) {
         developer.log('Stopping worker isolate.');
+        scheduler.drainAll();
         message.execute();
         sub?.cancel();
         sub = null;
@@ -108,8 +139,8 @@ class BackgroundWorker {
   /// a [Future<R>].
   /// Inside [callback], you can only use passed message and create new objects.
   /// You cannot access any variables from the outer scope, otherwise, it will throw an error.
-  Future<R> _compute<M, R>(PdfrxComputeCallback<M, R> callback, M message) async {
-    final result = await _sendComputeParams((sendPort) => _ExecuteParams(sendPort, callback, message));
+  Future<R> _compute<M, R>(PdfrxComputeCallback<M, R> callback, M message, BackgroundWorkerPriority priority) async {
+    final result = await _sendComputeParams((sendPort) => _ExecuteParams(sendPort, callback, message, priority));
     if (result is _ComputeError) {
       // The original error/stack trace object may itself be unsendable (arbitrary user exception types can hold
       // non-sendable fields), so only their string forms cross the isolate boundary; reconstruct a generic
@@ -128,8 +159,14 @@ class BackgroundWorker {
   /// a [Future<R>].
   /// Inside [callback], you can only use passed message and create new objects.
   /// You cannot access any variables from the outer scope, otherwise, it will throw an error.
-  static Future<R> compute<M, R>(PdfrxComputeCallback<M, R> callback, M message) async =>
-      await _instance._compute(callback, message);
+  ///
+  /// [priority] controls where the call is placed in the worker's queue; see [BackgroundWorkerPriority]. Calls of the
+  /// same priority run in FIFO order.
+  static Future<R> compute<M, R>(
+    PdfrxComputeCallback<M, R> callback,
+    M message, {
+    BackgroundWorkerPriority priority = BackgroundWorkerPriority.normal,
+  }) async => await _instance._compute(callback, message, priority);
 
   /// Suspends the worker isolate during the execution of [action].
   static Future<T> suspendDuringAction<T>(FutureOr<T> Function() action) async {
@@ -150,8 +187,13 @@ class BackgroundWorker {
   ///
   /// [Arena] is provided as the first argument to [callback] for temporary memory allocation; the memory block
   /// allocated using the [Arena] within the [callback] will be automatically released after the [callback] execution.
-  static Future<R> computeWithArena<M, R>(R Function(Arena arena, M message) callback, M message) =>
-      compute((message) => using((arena) => callback(arena, message)), message);
+  ///
+  /// [priority] controls where the call is placed in the worker's queue; see [BackgroundWorkerPriority].
+  static Future<R> computeWithArena<M, R>(
+    R Function(Arena arena, M message) callback,
+    M message, {
+    BackgroundWorkerPriority priority = BackgroundWorkerPriority.normal,
+  }) => compute((message) => using((arena) => callback(arena, message)), message, priority: priority);
 
   /// Stop the background worker isolate.
   ///
@@ -160,15 +202,73 @@ class BackgroundWorker {
   static Future<void> stop() => _instance._stop();
 }
 
+/// Priority scheduler that runs inside the worker isolate.
+///
+/// Incoming [_ComputeParams] are not executed on arrival; they are queued per priority and drained one item per
+/// event-loop turn. Yielding to the event loop between items is what lets a [BackgroundWorkerPriority.high] message
+/// that arrives while normal work is queued be picked up before the remaining normal items. Because every callback is
+/// started synchronously in [_ComputeParams.execute] (asynchronous callbacks continue on their own), draining one
+/// item per turn does not change the relative execution order of items of the same priority, so a worker that only
+/// ever receives normal-priority work behaves exactly like a plain FIFO.
+class _WorkerScheduler {
+  final _high = Queue<_ComputeParams>();
+  final _normal = Queue<_ComputeParams>();
+  var _consecutiveHigh = 0;
+  var _drainScheduled = false;
+
+  bool get isEmpty => _high.isEmpty && _normal.isEmpty;
+
+  void enqueue(_ComputeParams params) {
+    (params.priority == BackgroundWorkerPriority.high ? _high : _normal).add(params);
+    _scheduleDrain();
+  }
+
+  /// Runs every queued item now, in priority order, without yielding to the event loop.
+  ///
+  /// Used before acknowledging suspend/stop requests so that they keep their "all earlier work has run" guarantee.
+  void drainAll() {
+    while (!isEmpty) {
+      _next().execute();
+    }
+  }
+
+  void _scheduleDrain() {
+    if (_drainScheduled) return;
+    _drainScheduled = true;
+    // Timer.run (not scheduleMicrotask): a microtask would run before any pending port message is delivered, so a
+    // high-priority message that is already sitting in the isolate's message queue could not overtake queued work.
+    Timer.run(_drainOne);
+  }
+
+  void _drainOne() {
+    _drainScheduled = false;
+    if (isEmpty) return;
+    _next().execute();
+    if (!isEmpty) _scheduleDrain();
+  }
+
+  /// Picks the next item to run: a high-priority item if any, unless normal work has been waiting behind
+  /// [BackgroundWorker._maxConsecutiveHighItems] high items in a row.
+  _ComputeParams _next() {
+    if (_high.isNotEmpty && (_normal.isEmpty || _consecutiveHigh < BackgroundWorker._maxConsecutiveHighItems)) {
+      _consecutiveHigh++;
+      return _high.removeFirst();
+    }
+    _consecutiveHigh = 0;
+    return _normal.removeFirst();
+  }
+}
+
 class _ComputeParams {
-  _ComputeParams(this.sendPort);
+  _ComputeParams(this.sendPort, [this.priority = BackgroundWorkerPriority.normal]);
   final SendPort sendPort;
+  final BackgroundWorkerPriority priority;
 
   void execute() => sendPort.send(null);
 }
 
 class _ExecuteParams<M, R> extends _ComputeParams {
-  _ExecuteParams(super.sendPort, this.callback, this.message);
+  _ExecuteParams(super.sendPort, this.callback, this.message, super.priority);
   final PdfrxComputeCallback<M, R> callback;
   final M message;
 

--- a/packages/pdfrx_engine/lib/src/native/worker.dart
+++ b/packages/pdfrx_engine/lib/src/native/worker.dart
@@ -72,14 +72,6 @@ class BackgroundWorker {
     _isolate = null;
   }
 
-  /// Maximum number of consecutive [BackgroundWorkerPriority.high] items the scheduler runs while a
-  /// [BackgroundWorkerPriority.normal] item is waiting, before it lets one normal item through.
-  ///
-  /// High-priority work (rendering, page measurement) is expected to be short-lived and bursty, so this is only a
-  /// safety net that keeps a viewer that renders continuously (e.g. during a long animated scroll) from starving
-  /// background work forever.
-  static const _maxConsecutiveHighItems = 8;
-
   /// Entry point for the worker isolate.
   static void _workerEntry(SendPort sendPort) {
     final receivePort = ReceivePort();
@@ -169,6 +161,10 @@ class BackgroundWorker {
   }) async => await _instance._compute(callback, message, priority);
 
   /// Suspends the worker isolate during the execution of [action].
+  ///
+  /// Work queued before the suspend request has run by the time [action] starts. This holds for synchronous
+  /// callbacks (all PDFium callbacks in the engine are synchronous); an asynchronous callback only counts as "run" up
+  /// to its first `await`.
   static Future<T> suspendDuringAction<T>(FutureOr<T> Function() action) async {
     await _instance._sendComputeParams((sendPort) => _SuspendRequest._(sendPort));
     try {
@@ -210,10 +206,20 @@ class BackgroundWorker {
 /// started synchronously in [_ComputeParams.execute] (asynchronous callbacks continue on their own), draining one
 /// item per turn does not change the relative execution order of items of the same priority, so a worker that only
 /// ever receives normal-priority work behaves exactly like a plain FIFO.
+///
+/// Ordering invariant: an item never runs before an item of equal-or-higher priority that was enqueued earlier. A
+/// high item may overtake earlier normal items; a normal item never overtakes an earlier high item. Callers rely on
+/// the second half: `PdfDocument.dispose()` marks the document disposed synchronously and then queues
+/// `FPDF_CloseDocument` at normal priority, so renders that passed the disposed check and are already queued as high
+/// items must run before the close does, or they would touch a freed `FPDF_DOCUMENT`. For that reason there is
+/// deliberately no starvation guard that lets normal work through while high work is pending.
+///
+/// High work cannot starve normal work in practice: high priority is only used for rendering and measuring the pages
+/// that are currently visible, so a burst of it is bounded by the visible page set and background work simply waits
+/// for the burst to end, which is the intent.
 class _WorkerScheduler {
   final _high = Queue<_ComputeParams>();
   final _normal = Queue<_ComputeParams>();
-  var _consecutiveHigh = 0;
   var _drainScheduled = false;
 
   bool get isEmpty => _high.isEmpty && _normal.isEmpty;
@@ -226,6 +232,8 @@ class _WorkerScheduler {
   /// Runs every queued item now, in priority order, without yielding to the event loop.
   ///
   /// Used before acknowledging suspend/stop requests so that they keep their "all earlier work has run" guarantee.
+  /// That guarantee holds for synchronous callbacks (all PDFium callbacks in the engine are synchronous); an
+  /// asynchronous callback has only run up to its first `await` when this returns.
   void drainAll() {
     while (!isEmpty) {
       _next().execute();
@@ -243,20 +251,16 @@ class _WorkerScheduler {
   void _drainOne() {
     _drainScheduled = false;
     if (isEmpty) return;
-    _next().execute();
-    if (!isEmpty) _scheduleDrain();
+    try {
+      _next().execute();
+    } finally {
+      // Re-arm even if execute() threw synchronously; otherwise the remaining items would never be drained.
+      if (!isEmpty) _scheduleDrain();
+    }
   }
 
-  /// Picks the next item to run: a high-priority item if any, unless normal work has been waiting behind
-  /// [BackgroundWorker._maxConsecutiveHighItems] high items in a row.
-  _ComputeParams _next() {
-    if (_high.isNotEmpty && (_normal.isEmpty || _consecutiveHigh < BackgroundWorker._maxConsecutiveHighItems)) {
-      _consecutiveHigh++;
-      return _high.removeFirst();
-    }
-    _consecutiveHigh = 0;
-    return _normal.removeFirst();
-  }
+  /// Picks the next item to run: the oldest high-priority item if there is one, otherwise the oldest normal item.
+  _ComputeParams _next() => _high.isNotEmpty ? _high.removeFirst() : _normal.removeFirst();
 }
 
 class _ComputeParams {

--- a/packages/pdfrx_engine/test/background_worker_test.dart
+++ b/packages/pdfrx_engine/test/background_worker_test.dart
@@ -1,6 +1,14 @@
 import 'package:pdfrx_engine/src/native/worker.dart';
 import 'package:test/test.dart';
 
+/// Burns roughly `ms` milliseconds of CPU synchronously inside the worker, so the worker cannot pick up other
+/// messages while the callback runs (as with real PDFium FFI calls). Returns `id` so completion order can be recorded.
+int busyWait(({int id, int ms}) message) {
+  final sw = Stopwatch()..start();
+  while (sw.elapsedMilliseconds < message.ms) {}
+  return message.id;
+}
+
 void main() {
   group('BackgroundWorker.compute', () {
     test('still supports a synchronous callback (regression)', () async {
@@ -52,6 +60,107 @@ void main() {
         }, 'async'),
         throwsA(isA<Exception>().having((e) => e.toString(), 'toString', contains('boom: async'))),
       );
+    });
+  });
+
+  group('BackgroundWorker priority scheduling', () {
+    setUp(() async {
+      // Make sure the worker isolate is already up so that all messages of a test reach it back-to-back.
+      await BackgroundWorker.compute((message) => message, 0);
+    });
+
+    test('a high-priority compute overtakes normal computes that are still queued', () async {
+      final completionOrder = <int>[];
+      Future<void> track(Future<int> f) => f.then(completionOrder.add);
+
+      final futures = <Future<void>>[
+        for (var id = 1; id <= 3; id++) track(BackgroundWorker.compute(busyWait, (id: id, ms: 30))),
+        track(BackgroundWorker.compute(busyWait, (id: 100, ms: 1), priority: BackgroundWorkerPriority.high)),
+      ];
+      await Future.wait(futures);
+
+      expect(completionOrder, hasLength(4));
+      final highIndex = completionOrder.indexOf(100);
+      expect(highIndex, lessThan(completionOrder.indexOf(2)), reason: 'high must run before the 2nd normal item');
+      expect(highIndex, lessThan(completionOrder.indexOf(3)), reason: 'high must run before the 3rd normal item');
+      // Normal items keep their relative FIFO order.
+      expect(completionOrder.where((id) => id != 100), [1, 2, 3]);
+    });
+
+    test('default-priority computes complete in FIFO order', () async {
+      final completionOrder = <int>[];
+      await Future.wait([
+        for (var id = 1; id <= 6; id++)
+          BackgroundWorker.compute(busyWait, (id: id, ms: id.isOdd ? 10 : 1)).then(completionOrder.add),
+      ]);
+      expect(completionOrder, [1, 2, 3, 4, 5, 6]);
+    });
+
+    test('computeWithArena accepts a priority', () async {
+      final result = await BackgroundWorker.computeWithArena(
+        (arena, message) => message * 2,
+        21,
+        priority: BackgroundWorkerPriority.high,
+      );
+      expect(result, 42);
+    });
+
+    test('errors propagate for both priorities', () async {
+      for (final priority in BackgroundWorkerPriority.values) {
+        await expectLater(
+          BackgroundWorker.compute(
+            (message) {
+              throw StateError('boom: $message');
+            },
+            priority.name,
+            priority: priority,
+          ),
+          throwsA(isA<Exception>().having((e) => e.toString(), 'toString', contains('boom: ${priority.name}'))),
+          reason: 'sync throw with $priority',
+        );
+        await expectLater(
+          BackgroundWorker.compute(
+            (message) async {
+              await Future.delayed(const Duration(milliseconds: 5));
+              throw StateError('boom: $message');
+            },
+            priority.name,
+            priority: priority,
+          ),
+          throwsA(isA<Exception>().having((e) => e.toString(), 'toString', contains('boom: ${priority.name}'))),
+          reason: 'async throw with $priority',
+        );
+      }
+    });
+
+    test('suspendDuringAction buffers both priorities until resume', () async {
+      final completionOrder = <int>[];
+      late Future<void> normal;
+      late Future<void> high;
+      await BackgroundWorker.suspendDuringAction(() async {
+        normal = BackgroundWorker.compute(busyWait, (id: 1, ms: 1)).then(completionOrder.add);
+        high = BackgroundWorker.compute(busyWait, (
+          id: 2,
+          ms: 1,
+        ), priority: BackgroundWorkerPriority.high).then(completionOrder.add);
+        // Give the worker ample time; nothing may run while suspended.
+        await Future.delayed(const Duration(milliseconds: 100));
+        expect(completionOrder, isEmpty, reason: 'no compute may run while the worker is suspended');
+      });
+      await Future.wait([normal, high]);
+      // After resume, the buffered items are re-queued by priority: the high one goes first.
+      expect(completionOrder, [2, 1]);
+    });
+
+    test('suspend waits for already-queued work before acknowledging', () async {
+      final completionOrder = <int>[];
+      final queued = [
+        for (var id = 1; id <= 3; id++) BackgroundWorker.compute(busyWait, (id: id, ms: 20)).then(completionOrder.add),
+      ];
+      await BackgroundWorker.suspendDuringAction(() async {
+        await Future.wait(queued);
+        expect(completionOrder, [1, 2, 3], reason: 'everything sent before the suspend must have run');
+      });
     });
   });
 }

--- a/packages/pdfrx_engine/test/background_worker_test.dart
+++ b/packages/pdfrx_engine/test/background_worker_test.dart
@@ -96,6 +96,26 @@ void main() {
       expect(completionOrder, [1, 2, 3, 4, 5, 6]);
     });
 
+    test('a normal compute never overtakes high computes that were queued earlier (regression)', () async {
+      // Models PdfDocument.dispose(): renders (high) that are already queued must run before the
+      // FPDF_CloseDocument call (normal) that dispose() sends afterwards, or they would use a freed document.
+      final completionOrder = <int>[];
+      Future<void> track(Future<int> f) => f.then(completionOrder.add);
+
+      final highs = [
+        for (var id = 1; id <= 12; id++)
+          track(
+            BackgroundWorker.compute(busyWait, (id: id, ms: 10 + id % 3 * 5), priority: BackgroundWorkerPriority.high),
+          ),
+      ];
+      // Let all high requests reach the worker's mailbox before the normal one is sent.
+      await Future<void>.delayed(Duration.zero);
+      final normal = track(BackgroundWorker.compute(busyWait, (id: 999, ms: 1)));
+      await Future.wait([...highs, normal]);
+
+      expect(completionOrder, [for (var id = 1; id <= 12; id++) id, 999]);
+    });
+
     test('computeWithArena accepts a priority', () async {
       final result = await BackgroundWorker.computeWithArena(
         (arena, message) => message * 2,


### PR DESCRIPTION
## Summary

All PDFium work in the process funnels through a single worker isolate (`BackgroundWorker`). An app that extracts text, parses outlines or otherwise indexes a document in the background while a viewer is open makes the renders of the visible pages queue behind that work, which shows up as pages staying blank or blurry while the background job runs.

This adds an internal two-level priority to `BackgroundWorker.compute` / `computeWithArena` (`BackgroundWorkerPriority.high` / `.normal`). `PdfPage.render` and `PdfDocument.reloadPages` use `high`; everything else keeps the default `normal`. Callers that never pass a priority see exactly the same FIFO behaviour as before.

## Ordering guarantee

An item never runs before an item of equal-or-higher priority that was enqueued earlier:

- a `high` item may overtake `normal` items enqueued before it;
- a `normal` item never overtakes a `high` item enqueued before it;
- items of the same priority run in FIFO order.

The second point matters for `PdfDocument.dispose()`: it marks the document disposed synchronously and then queues `FPDF_CloseDocument` at `normal` priority, so renders that already passed the disposed check and are queued as `high` items are guaranteed to run before the close and never touch a freed `FPDF_DOCUMENT`. For that reason there is deliberately no starvation guard that lets normal work through while high work is pending. High priority is only used for rendering and measuring the pages that are currently visible, so a burst of it is bounded by the visible page set and background work simply waits for the burst to end.

## Scheduling detail

- Incoming compute requests are queued per priority in the worker isolate instead of being executed on arrival, and drained one item per event-loop turn via `Timer.run`. Yielding between items is what lets a `high` message that is already sitting in the isolate's mailbox be picked up before the remaining `normal` items. A microtask would not yield, so port messages would not be seen until the queue was empty.
- Every callback is started synchronously inside its turn, so the relative order of same-priority items is unchanged and a worker that only receives `normal` work behaves like the previous plain FIFO.
- `suspendDuringAction` and `stop` drain all queued work synchronously before acknowledging, so their "everything sent earlier has run" guarantee is preserved (for synchronous callbacks, which is what every PDFium callback in the engine is; this is now documented on both).
- The drain is re-armed in a `finally` so a synchronous throw in an item cannot leave the remaining items stuck in the queue.

## Real-app verification

Verified in a Flutter desktop app (Windows) that keeps a viewer open while it pre-parses the outlines of ~40 scanned volumes and extracts text for indexing in the background: the app ran on this branch with no errors, and visible pages rendered while the background work was running.

Engine-level numbers on two scanned volumes (281 and 242 pages, ~21 MB and ~38 MB), rendering the open page at 1200 px width every 100 ms while `loadPagesProgressively` measures the rest of the document, this branch vs. `master` (2.6.1):

| | idle render | render during measurement, p50 | render during measurement, max |
|---|---|---|---|
| 281-page volume, master | 112 ms | 256 ms | 361 ms |
| 281-page volume, this PR | 130 ms | 256 ms | 263 ms |
| 242-page volume, master | 79 ms | 227 ms | 334 ms |
| 242-page volume, this PR | 79 ms | 225 ms | 233 ms |

The p50 is unchanged, as expected: a measurement slice that is already executing cannot be interrupted, and the default slice is 250 ms. The tail is what this PR fixes: on `master` a render could also land behind other queued work, on this branch it waits for at most the currently executing item. Shortening the measurement slices so a render can slot in between pages is a separate, complementary change.

## Testing

- `dart test` in `packages/pdfrx_engine`: 65 passed, including 7 scheduler tests in `background_worker_test.dart` (high overtakes queued normal, FIFO for default calls, `computeWithArena` priority, error propagation for both priorities, suspend/resume buffering and ordering, and a regression test that queues 12 high computes followed by one normal compute and asserts the normal one completes last).
- `dart analyze` in `packages/pdfrx_engine`: only the two pre-existing `prefer_initializing_formals` infos in `pdfrx_pdfium.dart` (present on `master`).
- `flutter analyze` in `packages/pdfrx`: only the pre-existing infos.


