### PR TITLE
perf: measure pages in short worker chunks during progressive loading

### DIFF
--- a/doc/Progressive-Loading.md
+++ b/doc/Progressive-Loading.md
@@ -212,7 +212,7 @@ await document.loadPagesProgressively(
 
 The callback is invoked periodically (every `loadUnitDuration`) as pages are loaded. Return `false` from the callback to stop the loading process early.
 
-Internally, each `loadUnitDuration` slice is sent to the PDFium worker as a series of short measurement tasks rather than one long task. All PDFium calls in a process share that worker, so this keeps page rendering responsive while the rest of the document is being measured: a render requested during progressive loading only waits for the current short task to finish instead of the whole slice. The callback cadence is unaffected; it is still invoked once per `loadUnitDuration`.
+Internally, each `loadUnitDuration` slice is sent to the PDFium worker as a series of short measurement tasks rather than one long task. All PDFium calls in a process share that worker, so this keeps page rendering responsive while the rest of the document is being measured: a render requested during progressive loading waits for the current short task (and anything already queued ahead of it) to finish instead of the whole slice. The callback cadence is unaffected; it is still invoked once per `loadUnitDuration`.
 
 The callback receives the number of pages loaded so far (`loadedPageCount`), the total number of pages, and the optional `data` value passed to [`loadPagesProgressively()`](https://pub.dev/documentation/pdfrx_engine/latest/pdfrx_engine/PdfDocument/loadPagesProgressively.html). `loadedPageCount` is a count of loaded pages, not a page index; it does not depend on the order in which the pages are measured.
 

--- a/doc/Progressive-Loading.md
+++ b/doc/Progressive-Loading.md
@@ -212,6 +212,8 @@ await document.loadPagesProgressively(
 
 The callback is invoked periodically (every `loadUnitDuration`) as pages are loaded. Return `false` from the callback to stop the loading process early.
 
+Internally, each `loadUnitDuration` slice is sent to the PDFium worker as a series of short measurement tasks rather than one long task. All PDFium calls in a process share that worker, so this keeps page rendering responsive while the rest of the document is being measured: a render requested during progressive loading only waits for the current short task to finish instead of the whole slice. The callback cadence is unaffected; it is still invoked once per `loadUnitDuration`.
+
 The callback receives the number of pages loaded so far (`loadedPageCount`), the total number of pages, and the optional `data` value passed to [`loadPagesProgressively()`](https://pub.dev/documentation/pdfrx_engine/latest/pdfrx_engine/PdfDocument/loadPagesProgressively.html). `loadedPageCount` is a count of loaded pages, not a page index; it does not depend on the order in which the pages are measured.
 
 By default, pages are measured from page 1 onward. Pass `startPageNumber` to measure pages in order of their distance from a given page instead (`start`, `start+1`, `start-1`, `start+2`, `start-2`, ...), so that the pages around the one being displayed become available first. Pages that are already loaded are skipped, and all pages are loaded when the call completes without being cancelled. [`PdfViewer`](https://pub.dev/documentation/pdfrx/latest/pdfrx/PdfViewer-class.html) does this automatically using its initial page:

--- a/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
+++ b/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
@@ -1124,18 +1124,34 @@ class _PdfDocumentPdfium extends PdfDocument {
     for (;;) {
       if (isDisposed) return;
 
-      final pageIndicesToLoad = _unloadedPageIndicesOrderedFrom(_pages, startPageNumber);
+      var pageIndicesToLoad = _unloadedPageIndicesOrderedFrom(_pages, startPageNumber);
       if (pageIndicesToLoad.isEmpty) {
         _notifyDocumentLoadComplete();
         return;
       }
-      final loaded = await _loadPagesInLimitedTime(
-        pageIndicesToLoad: pageIndicesToLoad,
-        pagesToPreserve: _pages,
-        timeout: loadUnitDuration,
-      );
-      if (isDisposed) return;
-      pages = loaded.pages;
+
+      // Spend the loadUnitDuration budget as a series of short worker tasks rather than one long one. All PDFium
+      // calls share a single worker, so a page render queued while pages are being measured would otherwise wait
+      // for the whole slice; between chunks the worker drains its queue and renders get through.
+      final budget = Stopwatch()..start();
+      ({List<PdfPage> pages, int loadedPageCount}) loaded;
+      for (;;) {
+        final remaining = loadUnitDuration - budget.elapsed;
+        final chunkTimeout = remaining < _measurementChunkDuration ? remaining : _measurementChunkDuration;
+        // A chunk always measures at least one page, so a budget that has already elapsed (Duration.zero or a
+        // shortfall left by the previous chunk) still makes progress.
+        loaded = await _loadPagesInLimitedTime(
+          pageIndicesToLoad: pageIndicesToLoad,
+          pagesToPreserve: _pages,
+          timeout: chunkTimeout.isNegative ? Duration.zero : chunkTimeout,
+        );
+        if (isDisposed) return;
+        pages = loaded.pages;
+        if (budget.elapsed >= loadUnitDuration) break;
+        // Recompute from the current page list so pages measured concurrently (e.g. by reloadPages) are skipped.
+        pageIndicesToLoad = _unloadedPageIndicesOrderedFrom(_pages, startPageNumber);
+        if (pageIndicesToLoad.isEmpty) break;
+      }
 
       if (onPageLoadProgress != null) {
         final result = await onPageLoadProgress(loaded.loadedPageCount, loaded.pages.length, data);
@@ -1149,6 +1165,12 @@ class _PdfDocumentPdfium extends PdfDocument {
       }
     }
   }
+
+  /// Maximum duration of a single page-measurement task sent to the worker by [loadPagesProgressively].
+  ///
+  /// About two pages on a typical desktop: small enough that a render queued behind it waits roughly one page's
+  /// worth of measurement, large enough that the per-task worker round-trip stays negligible.
+  static const _measurementChunkDuration = Duration(milliseconds: 20);
 
   void _notifyDocumentLoadComplete() {
     if (!isDisposed && !_documentLoadCompleteNotified) {
@@ -1218,6 +1240,8 @@ class _PdfDocumentPdfium extends PdfDocument {
           if (params.maxPageCountToLoadAdditionally != null && pages.length >= params.maxPageCountToLoadAdditionally!) {
             break;
           }
+          // The timeout is checked after measuring a page, so every task measures at least one page even when the
+          // timeout is zero or already expired; loadPagesProgressively relies on this to guarantee progress.
           if (t != null && t.elapsedMicroseconds > params.timeoutUs!) {
             break;
           }

--- a/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
+++ b/packages/pdfrx_engine/lib/src/native/pdfrx_pdfium.dart
@@ -1132,29 +1132,41 @@ class _PdfDocumentPdfium extends PdfDocument {
 
       // Spend the loadUnitDuration budget as a series of short worker tasks rather than one long one. All PDFium
       // calls share a single worker, so a page render queued while pages are being measured would otherwise wait
-      // for the whole slice; between chunks the worker drains its queue and renders get through.
+      // for the whole slice; between chunks the worker drains its queue and renders get through. The measured pages
+      // are accumulated locally and published once per budget, so the event cadence is the same as with one task.
       final budget = Stopwatch()..start();
-      ({List<PdfPage> pages, int loadedPageCount}) loaded;
+      final measured = <int, PdfPage>{};
       for (;;) {
         final remaining = loadUnitDuration - budget.elapsed;
         final chunkTimeout = remaining < _measurementChunkDuration ? remaining : _measurementChunkDuration;
+        // Merge with the current page list rather than a snapshot so pages measured concurrently (e.g. by
+        // reloadPages) are neither overwritten nor measured again.
+        final pagesToPreserve = _withMeasuredPages(_pages, measured);
         // A chunk always measures at least one page, so a budget that has already elapsed (Duration.zero or a
         // shortfall left by the previous chunk) still makes progress.
-        loaded = await _loadPagesInLimitedTime(
+        final loaded = await _loadPagesInLimitedTime(
           pageIndicesToLoad: pageIndicesToLoad,
-          pagesToPreserve: _pages,
+          pagesToPreserve: pagesToPreserve,
           timeout: chunkTimeout.isNegative ? Duration.zero : chunkTimeout,
         );
         if (isDisposed) return;
-        pages = loaded.pages;
+        for (var i = 0; i < loaded.pages.length; i++) {
+          final page = loaded.pages[i];
+          if (page.isLoaded && (i >= pagesToPreserve.length || !identical(page, pagesToPreserve[i]))) {
+            measured[i] = page;
+          }
+        }
         if (budget.elapsed >= loadUnitDuration) break;
-        // Recompute from the current page list so pages measured concurrently (e.g. by reloadPages) are skipped.
-        pageIndicesToLoad = _unloadedPageIndicesOrderedFrom(_pages, startPageNumber);
+        pageIndicesToLoad = _unloadedPageIndicesOrderedFrom(_withMeasuredPages(_pages, measured), startPageNumber);
         if (pageIndicesToLoad.isEmpty) break;
       }
 
+      final newPages = _withMeasuredPages(_pages, measured);
+      pages = newPages;
+
       if (onPageLoadProgress != null) {
-        final result = await onPageLoadProgress(loaded.loadedPageCount, loaded.pages.length, data);
+        final loadedPageCount = newPages.where((page) => page.isLoaded).length;
+        final result = await onPageLoadProgress(loadedPageCount, newPages.length, data);
         if (result == false) {
           if (_pages.every((page) => page.isLoaded)) {
             _notifyDocumentLoadComplete();
@@ -1164,6 +1176,17 @@ class _PdfDocumentPdfium extends PdfDocument {
         }
       }
     }
+  }
+
+  /// Returns [pages] with the entries of [measured] (page index to measured page) applied wherever [pages] still
+  /// holds an unloaded placeholder; pages loaded in the meantime by other means are kept.
+  static List<PdfPage> _withMeasuredPages(List<PdfPage> pages, Map<int, PdfPage> measured) {
+    if (measured.isEmpty) return pages;
+    final merged = [...pages];
+    for (final MapEntry(key: index, value: page) in measured.entries) {
+      if (index < merged.length && !merged[index].isLoaded) merged[index] = page;
+    }
+    return merged;
   }
 
   /// Maximum duration of a single page-measurement task sent to the worker by [loadPagesProgressively].

--- a/packages/pdfrx_engine/test/pdf_document_test.dart
+++ b/packages/pdfrx_engine/test/pdf_document_test.dart
@@ -499,33 +499,46 @@ void main() {
     expect(document.pages.every((page) => page.isLoaded), isTrue);
   });
   test('rendering an already loaded page is not blocked behind progressive loading', () async {
-    // A document with enough pages that measuring it takes well over the worker chunk duration.
+    // A document with enough pages that measuring it takes many worker chunks, and a loadUnitDuration longer than the
+    // whole measurement: an implementation that sends each budget to the worker as a single task would then measure
+    // the entire document in one task and the render would wait for all of it.
+    const pageCount = 20000;
     final document = await PdfDocument.openData(
-      buildBlankPdf(20000),
-      sourceName: 'blank20000.pdf',
+      buildBlankPdf(pageCount),
+      sourceName: 'blank$pageCount.pdf',
       useProgressiveLoading: true,
     );
     addTearDown(document.dispose);
-    expect(document.pages.length, 20000);
+    expect(document.pages.length, pageCount);
     expect(document.pages.first.isLoaded, isTrue);
 
     var loadCompleted = false;
-    var loadedPageCountWhenRendered = -1;
-    final loading = document
-        .loadPagesProgressively(loadUnitDuration: const Duration(milliseconds: 250))
-        .then((_) => loadCompleted = true);
+    final loadTimer = Stopwatch()..start();
+    final loading = document.loadPagesProgressively(loadUnitDuration: const Duration(seconds: 5)).then((_) {
+      loadCompleted = true;
+      loadTimer.stop();
+    });
     // Give the first measurement chunk a chance to be queued on the worker before the render.
     await Future<void>.delayed(const Duration(milliseconds: 5));
 
+    final renderTimer = Stopwatch()..start();
     final image = await document.pages.first.render();
+    renderTimer.stop();
     final renderCompletedBeforeLoad = !loadCompleted;
-    loadedPageCountWhenRendered = document.pages.where((page) => page.isLoaded).length;
+    final loadedPageCountWhenRendered = document.pages.where((page) => page.isLoaded).length;
     image?.dispose();
     await loading;
 
     expect(image, isNotNull);
     expect(renderCompletedBeforeLoad, isTrue, reason: 'render must interleave with measurement chunks');
-    expect(loadedPageCountWhenRendered, lessThan(20000));
+    expect(loadedPageCountWhenRendered, lessThan(pageCount));
+    expect(
+      renderTimer.elapsedMilliseconds,
+      lessThan(loadTimer.elapsedMilliseconds ~/ 4),
+      reason:
+          'render (${renderTimer.elapsedMilliseconds} ms) must not wait for most of the measurement '
+          '(${loadTimer.elapsedMilliseconds} ms)',
+    );
     expect(document.pages.every((page) => page.isLoaded), isTrue);
   });
   test('loadLinks reuses raw and compact results', () async {

--- a/packages/pdfrx_engine/test/pdf_document_test.dart
+++ b/packages/pdfrx_engine/test/pdf_document_test.dart
@@ -531,7 +531,8 @@ void main() {
 
     expect(image, isNotNull);
     expect(renderCompletedBeforeLoad, isTrue, reason: 'render must interleave with measurement chunks');
-    expect(loadedPageCountWhenRendered, lessThan(pageCount));
+    // Nothing is published before the first budget ends, so only page 1 is loaded when the render completes.
+    expect(loadedPageCountWhenRendered, equals(1));
     expect(
       renderTimer.elapsedMilliseconds,
       lessThan(loadTimer.elapsedMilliseconds ~/ 4),
@@ -539,6 +540,89 @@ void main() {
           'render (${renderTimer.elapsedMilliseconds} ms) must not wait for most of the measurement '
           '(${loadTimer.elapsedMilliseconds} ms)',
     );
+    expect(document.pages.every((page) => page.isLoaded), isTrue);
+  });
+  test('progressive loading publishes page status once per budget without duplicates', () async {
+    // The default budget spans many ~20 ms worker chunks. Publishing per chunk instead of per budget would emit a
+    // page status event (and relayout the viewer) roughly 40 times a second, so the event count must match the
+    // callback count exactly and no page may be reported twice.
+    const pageCount = 20000;
+    final document = await PdfDocument.openData(
+      buildBlankPdf(pageCount),
+      sourceName: 'blank$pageCount.pdf',
+      useProgressiveLoading: true,
+    );
+    addTearDown(document.dispose);
+    expect(document.pages.length, pageCount);
+    final events = <PdfDocumentEvent>[];
+    final subscription = document.events.listen(events.add);
+    addTearDown(subscription.cancel);
+
+    var callbackCount = 0;
+    await document.loadPagesProgressively(
+      onPageLoadProgress: (_, _, _) {
+        callbackCount++;
+        return true;
+      },
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    final statusEvents = events.whereType<PdfDocumentPageStatusChangedEvent>().toList();
+    expect(callbackCount, greaterThan(0));
+    expect(statusEvents, hasLength(callbackCount), reason: 'each budget publishes exactly once');
+    final reportedPageNumbers = <int>{};
+    var reportedChangeCount = 0;
+    for (final event in statusEvents) {
+      reportedChangeCount += event.changes.length;
+      reportedPageNumbers.addAll(event.changes.keys);
+    }
+    // Page 1 is measured at open time; every other page is reported exactly once.
+    expect(reportedChangeCount, pageCount - 1, reason: 'no page index may appear in more than one event');
+    expect(reportedPageNumbers, hasLength(pageCount - 1));
+    expect(reportedPageNumbers.contains(1), isFalse);
+    expect(document.pages.every((page) => page.isLoaded), isTrue);
+    expect(events.whereType<PdfDocumentLoadCompleteEvent>(), hasLength(1));
+  });
+  test('progressive loading keeps the outward order across chunks within one budget', () async {
+    // One default budget over a large document is split into many worker chunks; the pages measured by the whole
+    // budget must still be the head of the outward sequence from startPageNumber (10000, 10001, 9999, 10002, ...).
+    const pageCount = 20000;
+    const startPageNumber = 10000;
+    final document = await PdfDocument.openData(
+      buildBlankPdf(pageCount),
+      sourceName: 'blank$pageCount.pdf',
+      useProgressiveLoading: true,
+    );
+    addTearDown(document.dispose);
+    expect(document.pages.length, pageCount);
+
+    var callbackCount = 0;
+    await document.loadPagesProgressively(
+      startPageNumber: startPageNumber,
+      onPageLoadProgress: (_, _, _) {
+        callbackCount++;
+        return false;
+      },
+    );
+    expect(callbackCount, 1);
+
+    // Page 1 was loaded at open time and is not part of the outward sequence.
+    final measured = document.pages
+        .where((page) => page.isLoaded && page.pageNumber != 1)
+        .map((page) => page.pageNumber)
+        .toSet();
+    expect(measured, isNotEmpty);
+    expect(measured.length, lessThan(pageCount - 1), reason: 'one budget must not measure the whole document');
+    final expected = <int>{};
+    for (var distance = 0; expected.length < measured.length; distance++) {
+      if (startPageNumber + distance <= pageCount) expected.add(startPageNumber + distance);
+      if (expected.length < measured.length && distance > 0 && startPageNumber - distance >= 2) {
+        expected.add(startPageNumber - distance);
+      }
+    }
+    expect(measured, equals(expected));
+
+    await document.loadPagesProgressively(startPageNumber: startPageNumber);
     expect(document.pages.every((page) => page.isLoaded), isTrue);
   });
   test('loadLinks reuses raw and compact results', () async {

--- a/packages/pdfrx_engine/test/pdf_document_test.dart
+++ b/packages/pdfrx_engine/test/pdf_document_test.dart
@@ -447,6 +447,87 @@ void main() {
     expect(loadedPageNumbers.length, lessThan(40));
     expect(loadedPageNumbers, List.generate(loadedPageNumbers.length, (index) => index + 1));
   });
+  for (final loadUnitDuration in [const Duration(milliseconds: 1), null]) {
+    test('progressive loading loads every page and reports monotonic progress (loadUnitDuration: '
+        '${loadUnitDuration ?? 'default'})', () async {
+      final document = await PdfDocument.openFile(multiPageTestPdfFile.path, useProgressiveLoading: true);
+      addTearDown(document.dispose);
+      final events = <PdfDocumentEvent>[];
+      final subscription = document.events.listen(events.add);
+      addTearDown(subscription.cancel);
+
+      final progress = <(int loadedPageCount, int totalPageCount)>[];
+      bool onProgress(int loadedPageCount, int totalPageCount, void _) {
+        progress.add((loadedPageCount, totalPageCount));
+        return true;
+      }
+
+      if (loadUnitDuration != null) {
+        await document.loadPagesProgressively(onPageLoadProgress: onProgress, loadUnitDuration: loadUnitDuration);
+      } else {
+        await document.loadPagesProgressively(onPageLoadProgress: onProgress);
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      expect(document.pages.every((page) => page.isLoaded), isTrue);
+      expect(document.pages.map((page) => page.pageNumber), List.generate(40, (index) => index + 1));
+      expect(progress, isNotEmpty);
+      expect(progress.map((entry) => entry.$2), everyElement(40));
+      for (var i = 1; i < progress.length; i++) {
+        expect(progress[i].$1, greaterThanOrEqualTo(progress[i - 1].$1), reason: 'loadedPageCount is monotonic');
+      }
+      expect(progress.last.$1, 40);
+      expect(events.whereType<PdfDocumentLoadCompleteEvent>(), hasLength(1));
+    });
+  }
+  test('progressive loading with a tiny loadUnitDuration reports progress more than once', () async {
+    final document = await PdfDocument.openFile(multiPageTestPdfFile.path, useProgressiveLoading: true);
+    addTearDown(document.dispose);
+    var callbackCount = 0;
+
+    await document.loadPagesProgressively(
+      loadUnitDuration: const Duration(milliseconds: 1),
+      onPageLoadProgress: (_, _, _) {
+        callbackCount++;
+        return true;
+      },
+    );
+
+    // Each budget measures at least one page, so a budget far shorter than the whole measurement yields several
+    // callbacks rather than one covering the whole document.
+    expect(callbackCount, greaterThan(1));
+    expect(document.pages.every((page) => page.isLoaded), isTrue);
+  });
+  test('rendering an already loaded page is not blocked behind progressive loading', () async {
+    // A document with enough pages that measuring it takes well over the worker chunk duration.
+    final document = await PdfDocument.openData(
+      buildBlankPdf(20000),
+      sourceName: 'blank20000.pdf',
+      useProgressiveLoading: true,
+    );
+    addTearDown(document.dispose);
+    expect(document.pages.length, 20000);
+    expect(document.pages.first.isLoaded, isTrue);
+
+    var loadCompleted = false;
+    var loadedPageCountWhenRendered = -1;
+    final loading = document
+        .loadPagesProgressively(loadUnitDuration: const Duration(milliseconds: 250))
+        .then((_) => loadCompleted = true);
+    // Give the first measurement chunk a chance to be queued on the worker before the render.
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+
+    final image = await document.pages.first.render();
+    final renderCompletedBeforeLoad = !loadCompleted;
+    loadedPageCountWhenRendered = document.pages.where((page) => page.isLoaded).length;
+    image?.dispose();
+    await loading;
+
+    expect(image, isNotNull);
+    expect(renderCompletedBeforeLoad, isTrue, reason: 'render must interleave with measurement chunks');
+    expect(loadedPageCountWhenRendered, lessThan(20000));
+    expect(document.pages.every((page) => page.isLoaded), isTrue);
+  });
   test('loadLinks reuses raw and compact results', () async {
     final document = await PdfDocument.openFile(testPdfFile.path);
     addTearDown(document.dispose);

--- a/packages/pdfrx_engine/test/utils.dart
+++ b/packages/pdfrx_engine/test/utils.dart
@@ -1,10 +1,36 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:pdfrx_engine/pdfrx_engine.dart';
 import 'package:test/test.dart';
 
 /// Temporary directory for testing.
 final tmpRoot = Directory('${Directory.current.path}/test/.tmp');
+
+/// Builds a minimal, uncompressed PDF with [pageCount] blank pages.
+///
+/// Used to get a document with enough pages that progressive measurement takes a measurable amount of time, without
+/// shipping a large test asset. The page sizes vary slightly so that measured pages differ from the placeholders.
+Uint8List buildBlankPdf(int pageCount) {
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [${List.generate(pageCount, (i) => '${i + 3} 0 R').join(' ')}] /Count $pageCount >>',
+    for (var i = 0; i < pageCount; i++) '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${200 + i % 7} ${300 + i % 5}] >>',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer.write('xref\n0 ${objects.length + 1}\n0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer.write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n$xrefOffset\n%%EOF\n');
+  return Uint8List.fromList(buffer.toString().codeUnits);
+}
 
 /// Test document with all pages.
 Future<void> testDocument(PdfDocument doc) async {


### PR DESCRIPTION
## Summary

`_PdfDocumentPdfium.loadPagesProgressively` sends each `loadUnitDuration` slice (250 ms by default) to the PDFium worker as one `computeWithArena` task that loops `FPDF_LoadPage`/`FPDF_ClosePage` over the unmeasured pages until the slice elapses. All PDFium calls in the process share that single worker, so a `PdfPage.render` of the visible page issued while the rest of the document is being measured sits behind the task and waits for the whole slice. On two scanned volumes (281 and 242 pages, roughly 9-11 ms per page to measure) this showed up as render latency of p50 256 / 227 ms during measurement versus 112 / 79 ms idle, for the first few seconds after opening the document.

This PR keeps the `loadUnitDuration` budget but spends it as a series of short worker tasks (`_measurementChunkDuration`, 20 ms: about two pages on a typical desktop, small enough that a queued render waits roughly one page, large enough that the per-task round trip stays negligible). Each chunk is its own `computeWithArena` call, so between chunks the worker drains its queue and queued renders get through. The pages measured within a budget are accumulated locally and assigned through the `pages` setter once per budget, exactly as before, so the event cadence does not change. Before each chunk the unloaded page list is recomputed on a merged view of the current pages and the pages measured so far in this budget (preserving the `startPageNumber` ordering), and at publish time the measured pages are merged into the current page list rather than a snapshot taken before the first await; a `reloadPages` that completed concurrently is therefore neither overwritten with stale placeholders nor re-measured. `isDisposed` is checked between chunks.

This is complementary to and independent of #708 (priority queue for the worker). With the current FIFO worker, this bounds a render's wait to one chunk plus whatever else was already queued; combined with #708 it bounds the wait to one chunk.

## Behaviour preserved

- Public API unchanged. `onPageLoadProgress` is still invoked once per `loadUnitDuration` budget with the same `(loadedPageCount, totalPageCount, data)` arguments, `PdfDocumentLoadCompleteEvent` semantics are unchanged, and `startPageNumber` ordering is unchanged.
- `_loadPagesInLimitedTime` itself is unchanged apart from a comment; `openFile`'s initial load (`maxPageCountToLoadAdditionally: 1`) is untouched, and `reloadPages` has its own worker task.
- Every chunk still measures at least one page (the timeout is checked after measuring a page), so `Duration.zero` and expired budgets keep making progress exactly as before; the existing `Duration.zero` tests still pass unchanged.
- The page list is still published via the `pages` setter once per `loadUnitDuration` budget, so `PdfDocumentPageStatusChangedEvent` is emitted at the same cadence as before (about 4/s with the default budget) and `PdfViewer` relayouts are not multiplied by the chunking.
- WASM and CoreGraphics backends are not affected (no shared worker there) and are not touched.

## Numbers

Engine-only benchmark: open with `useProgressiveLoading`, measure the target page, then render it at 1200 px width every 100 ms while `loadPagesProgressively(startPageNumber: target)` runs. Two scanned volumes (281 and 242 pages), Windows desktop.

| | 281 pages, before | 281 pages, after | 242 pages, before | 242 pages, after |
| --- | --- | --- | --- | --- |
| Idle render (p50) | 112 ms | 113 ms | 79 ms | 81 ms |
| Render during measurement, p50 / max | 256 / 361 ms | 125 / 179 ms | 227 / 334 ms | 97 / 111 ms |
| Full measurement, idle | 2374 ms | 2433 ms | 2450 ms | 2492 ms |

Render latency during measurement drops to roughly idle plus one chunk. Idle full-measurement time rises by about 2% (one worker round trip per 20 ms chunk, ~130 chunks for these documents).

## Testing

- New tests in `packages/pdfrx_engine/test/pdf_document_test.dart`:
  - `loadPagesProgressively` loads every page of the 40-page asset and reports monotonically non-decreasing `loadedPageCount` ending at `pages.length`, with both a 1 ms and the default `loadUnitDuration`, with a single completion event.
  - A 1 ms `loadUnitDuration` still yields more than one progress callback.
  - Interleaving: on a generated in-memory 20000-page PDF (`buildBlankPdf` in `test/utils.dart`, since the checked-in assets measure in well under one chunk), a `render()` of the already-loaded first page issued while `loadPagesProgressively(loadUnitDuration: 5 s)` runs completes before the load finishes, while pages are still unloaded, and in under a quarter of the load's wall time. The budget is longer than the whole measurement (~500 ms), so the previous implementation runs the entire document as a single worker task and the test fails against it (render 471 ms of a 489 ms load, completing after the load); with chunking the render takes about 20 ms. The test also asserts that only page 1 is loaded when the render completes, since nothing is published before the first budget ends.
  - Once-per-budget publishing: on the same 20000-page document with the default budget, the number of `PdfDocumentPageStatusChangedEvent`s equals the number of `onPageLoadProgress` callbacks (each budget publishes exactly once even though it runs many ~20 ms chunks), every page other than page 1 appears in exactly one event's `changes`, and a single `PdfDocumentLoadCompleteEvent` is emitted. This guards against publishing per chunk, which would relayout the viewer about 40 times a second.
  - Outward order across chunks: with `startPageNumber: 10000` and the callback stopping after the first default budget, the set of loaded pages (excluding page 1) is exactly the head of the outward sequence 10000, 10001, 9999, 10002, 9998, ...; resuming then loads every page. Each of the two new tests runs in about 1 s.
- `dart test` in `packages/pdfrx_engine`: 64 tests, all passed (3 consecutive runs).
- `dart analyze` in `packages/pdfrx_engine` and `flutter analyze` in `packages/pdfrx`: no new issues (the remaining infos pre-exist on master).
- `doc/Progressive-Loading.md` gained a short paragraph describing the chunked measurement, including that with the FIFO worker a render waits for the current chunk plus anything already queued ahead of it.


